### PR TITLE
Added Support to overwrite build info with same build number

### DIFF
--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -129,7 +129,6 @@ func (bpc *BuildPublishCommand) Run() error {
 		}
 		bpc.buildConfiguration.SetBuildNumber(buildInfo.Number)
 	}
-	// Delete buildinfo when
 	if bpc.config.Overwrite {
 		err := servicesManager.DeleteBuildInfo(buildInfo, bpc.buildConfiguration.GetProject())
 		if err != nil {

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -131,7 +131,7 @@ func (bpc *BuildPublishCommand) Run() error {
 	}
 	if bpc.config.Overwrite {
 		project := bpc.buildConfiguration.GetProject()
-		buildRuns, found, err := servicesManager.GetBuildRuns(services.BuildInfoParams{BuildName: buildName, BuildNumber: buildNumber, ProjectKey: project})
+		buildRuns, found, err := servicesManager.GetBuildRuns(services.BuildInfoParams{BuildName: buildName, ProjectKey: project})
 		if err != nil {
 			return err
 		}
@@ -180,6 +180,8 @@ func (bpc *BuildPublishCommand) Run() error {
 	return logJsonOutput(buildLink)
 }
 
+// calculateBuildNumberFrequency since the build number is not unique, we need to calculate the frequency of each build number
+// in order to delete the correct number of builds and then publish the new build.
 func calculateBuildNumberFrequency(runs *buildinfo.BuildRuns) map[string]int {
 	frequency := make(map[string]int)
 	for _, run := range runs.BuildsNumbers {

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -129,6 +129,13 @@ func (bpc *BuildPublishCommand) Run() error {
 		}
 		bpc.buildConfiguration.SetBuildNumber(buildInfo.Number)
 	}
+	// Delete buildinfo when
+	if bpc.config.Overwrite {
+		err := servicesManager.DeleteBuildInfo(buildInfo, bpc.buildConfiguration.GetProject())
+		if err != nil {
+			return err
+		}
+	}
 	summary, err := servicesManager.PublishBuildInfo(buildInfo, bpc.buildConfiguration.GetProject())
 	if bpc.IsDetailedSummary() {
 		bpc.SetSummary(summary)

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -136,7 +136,7 @@ func (bpc *BuildPublishCommand) Run() error {
 			return err
 		}
 		if found {
-			buildNumbersFrequency := calculateBuildNumberFrequency(buildRuns)
+			buildNumbersFrequency := CalculateBuildNumberFrequency(buildRuns)
 			err = servicesManager.DeleteBuildInfo(buildInfo, project, buildNumbersFrequency[buildNumber])
 			if err != nil {
 				return err
@@ -180,9 +180,9 @@ func (bpc *BuildPublishCommand) Run() error {
 	return logJsonOutput(buildLink)
 }
 
-// calculateBuildNumberFrequency since the build number is not unique, we need to calculate the frequency of each build number
+// CalculateBuildNumberFrequency since the build number is not unique, we need to calculate the frequency of each build number
 // in order to delete the correct number of builds and then publish the new build.
-func calculateBuildNumberFrequency(runs *buildinfo.BuildRuns) map[string]int {
+func CalculateBuildNumberFrequency(runs *buildinfo.BuildRuns) map[string]int {
 	frequency := make(map[string]int)
 	for _, run := range runs.BuildsNumbers {
 		buildNumber := strings.TrimPrefix(run.Uri, "/")

--- a/artifactory/commands/buildinfo/publish_test.go
+++ b/artifactory/commands/buildinfo/publish_test.go
@@ -1,6 +1,7 @@
 package buildinfo
 
 import (
+	buildinfo "github.com/jfrog/build-info-go/entities"
 	"strconv"
 	"testing"
 	"time"
@@ -52,5 +53,53 @@ func TestPrintBuildInfoLink(t *testing.T) {
 		buildPubComService, err := buildPubConf.getBuildInfoUiUrl(linkTypes[i].majorVersion, linkTypes[i].buildTime)
 		assert.NoError(t, err)
 		assert.Equal(t, buildPubComService, linkTypes[i].expected)
+	}
+}
+
+func TestCalculateBuildNumberFrequency(t *testing.T) {
+	tests := []struct {
+		name     string
+		runs     *buildinfo.BuildRuns
+		expected map[string]int
+	}{
+		{
+			name: "Single build number",
+			runs: &buildinfo.BuildRuns{
+				BuildsNumbers: []buildinfo.BuildRun{{Uri: "/1"}},
+			},
+			expected: map[string]int{"1": 1},
+		},
+		{
+			name: "Single build number with special characters",
+			runs: &buildinfo.BuildRuns{
+				BuildsNumbers: []buildinfo.BuildRun{{Uri: "/1-"}},
+			},
+			expected: map[string]int{"1-": 1},
+		},
+		{
+			name: "Multiple build numbers",
+			runs: &buildinfo.BuildRuns{
+				BuildsNumbers: []buildinfo.BuildRun{
+					{Uri: "/1"},
+					{Uri: "/2"},
+					{Uri: "/1"},
+				},
+			},
+			expected: map[string]int{"1": 2, "2": 1},
+		},
+		{
+			name: "No build numbers",
+			runs: &buildinfo.BuildRuns{
+				BuildsNumbers: []buildinfo.BuildRun{},
+			},
+			expected: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateBuildNumberFrequency(tt.runs)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/artifactory/commands/buildinfo/publish_test.go
+++ b/artifactory/commands/buildinfo/publish_test.go
@@ -98,7 +98,7 @@ func TestCalculateBuildNumberFrequency(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calculateBuildNumberFrequency(tt.runs)
+			result := CalculateBuildNumberFrequency(tt.runs)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a
 
-replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4
+replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240811150357-12a9330a2d67
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a
 
-replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b
+replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240811150357-12a9330a2d67
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/tools v0.29.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
@@ -123,9 +122,9 @@ require (
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.56.9-0.20241127142944-b39d0cc8f1c1
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.31.1-0.20241211104546-3e12a85de116
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250130104846-27e495de291e
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250126110945-81abbdde452f
+replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240811150357-12a9330a2d67
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.56.9-0.20241127142944-b39d0cc8f1c1
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.31.1-0.20241211104546-3e12a85de116
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6
 
 replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22
 

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af
 
-replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250219065446-e17342f27e44
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240811150357-12a9330a2d67
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.mod
+++ b/go.mod
@@ -122,9 +122,9 @@ require (
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.56.9-0.20241127142944-b39d0cc8f1c1
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/oshratZairi/jfrog-cli-core/v2 v2.31.1-0.20241211104546-3e12a85de116
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af
 
-replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22
+replace github.com/jfrog/jfrog-client-go => github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240811150357-12a9330a2d67
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/apache/camel-k/v2 v2.5.0 h1:voFPrxhuaedKn68RerS+QkXYXyZ+5tBfVaAc7QYOg
 github.com/apache/camel-k/v2 v2.5.0/go.mod h1:vLrJAJAp9EGxY54cUR7VHzIF70JHfFzk4OOaYRfLr44=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e h1:MyGZd73U2FeI6IZJbrm1C6edz2vmKU4bQPcZjOjBwco=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -116,6 +114,8 @@ github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af h1:XnyhhyARP1YCzYGdhk8ovpyZV+hSchiTGVTuejrZXsI=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250219065446-e17342f27e44 h1:Q2S65q8vk4Yb0B95XGCkcJJCUmJoKsDO5w/A1l6guJ8=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250219065446-e17342f27e44/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a h1:IHOUPqe3kJE1U6wYMlzMqFuB47d30PQZieh48vSXK+s=
 github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b h1:C91cQrktZquPV+cWMemkakADaG1uzgueodqUTDeTvqA=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22 h1:srjPEBWZZlqeDlgRsUxSETJT7o0nX7xbJOXVuY7sUBQ=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/apache/camel-k/v2 v2.5.0 h1:voFPrxhuaedKn68RerS+QkXYXyZ+5tBfVaAc7QYOg
 github.com/apache/camel-k/v2 v2.5.0/go.mod h1:vLrJAJAp9EGxY54cUR7VHzIF70JHfFzk4OOaYRfLr44=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a h1:IHOUPqe3kJE1U6wYMlzMqFuB47d30PQZieh48vSXK+s=
-github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
+github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6 h1:tgbOgq5HW67fMclrFK28I1OIQcFpt9lp3KXkznvOU0k=
+github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6/go.mod h1:GjXMU6Za1M0Knbdn5UHmTe8qmmFiGeRsFDfRNxfS6H8=
 github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22 h1:srjPEBWZZlqeDlgRsUxSETJT7o0nX7xbJOXVuY7sUBQ=
 github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,8 @@ github.com/apache/camel-k/v2 v2.5.0 h1:voFPrxhuaedKn68RerS+QkXYXyZ+5tBfVaAc7QYOg
 github.com/apache/camel-k/v2 v2.5.0/go.mod h1:vLrJAJAp9EGxY54cUR7VHzIF70JHfFzk4OOaYRfLr44=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6 h1:tgbOgq5HW67fMclrFK28I1OIQcFpt9lp3KXkznvOU0k=
-github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250211181507-70a8e2e0ffa6/go.mod h1:GjXMU6Za1M0Knbdn5UHmTe8qmmFiGeRsFDfRNxfS6H8=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22 h1:srjPEBWZZlqeDlgRsUxSETJT7o0nX7xbJOXVuY7sUBQ=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211180958-fdd57acc1c22/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e h1:MyGZd73U2FeI6IZJbrm1C6edz2vmKU4bQPcZjOjBwco=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250213094046-10d3186a130e/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -116,6 +114,8 @@ github.com/jfrog/build-info-go v1.10.9 h1:mdJ+wlLw2ReFsqC7rifJVlRYLEqYk38uXDYAOZ
 github.com/jfrog/build-info-go v1.10.9/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af h1:XnyhhyARP1YCzYGdhk8ovpyZV+hSchiTGVTuejrZXsI=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a h1:IHOUPqe3kJE1U6wYMlzMqFuB47d30PQZieh48vSXK+s=
 github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4 h1:CWFDHgOEjo//D1EnIWcs1a697+riOAg0c2kY0Kn871Y=
-github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b h1:C91cQrktZquPV+cWMemkakADaG1uzgueodqUTDeTvqA=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211125302-8824d0e90b1b/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,10 @@ github.com/apache/camel-k/v2 v2.5.0 h1:voFPrxhuaedKn68RerS+QkXYXyZ+5tBfVaAc7QYOg
 github.com/apache/camel-k/v2 v2.5.0/go.mod h1:vLrJAJAp9EGxY54cUR7VHzIF70JHfFzk4OOaYRfLr44=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a h1:IHOUPqe3kJE1U6wYMlzMqFuB47d30PQZieh48vSXK+s=
+github.com/bhanurp/jfrog-cli-core/v2 v2.31.1-0.20250205145350-284c79cce51a/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4 h1:CWFDHgOEjo//D1EnIWcs1a697+riOAg0c2kY0Kn871Y=
+github.com/bhanurp/jfrog-client-go v1.28.1-0.20250211102524-8399843549b4/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -112,10 +116,6 @@ github.com/jfrog/build-info-go v1.10.9 h1:mdJ+wlLw2ReFsqC7rifJVlRYLEqYk38uXDYAOZ
 github.com/jfrog/build-info-go v1.10.9/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.58.0 h1:tPjwJdWNv9PTz1ma5TjrMd9Uu0btcQg8eBCpc5h/rn4=
-github.com/jfrog/jfrog-cli-core/v2 v2.58.0/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
-github.com/jfrog/jfrog-client-go v1.50.0 h1:t7v/zpLkPomHR6ZjVbPQ1WPQJd9IFKESK9Tt6phZz3k=
-github.com/jfrog/jfrog-client-go v1.50.0/go.mod h1:xHxwKBjPSUBd/FyCWgusfHmSWKUZTkfOZkTmntC2F5Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
- Fetches build info available with given name
- If found proceeds with deletion by calculating build number frequency
- Invokes build publish after deletion causing overwrite.
- artifacts involved wont be deleted
- build info deletion happens based on build number not on build name
-----
## Depends On
- https://github.com/jfrog/jfrog-client-go/pull/1083