### PR TITLE
Allow Build Publish with `overwrite` Flag When Build Number is New

### DIFF
--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -137,9 +137,11 @@ func (bpc *BuildPublishCommand) Run() error {
 		}
 		if found {
 			buildNumbersFrequency := CalculateBuildNumberFrequency(buildRuns)
-			err = servicesManager.DeleteBuildInfo(buildInfo, project, buildNumbersFrequency[buildNumber])
-			if err != nil {
-				return err
+			if frequency, ok := buildNumbersFrequency[buildNumber]; ok {
+				err = servicesManager.DeleteBuildInfo(buildInfo, project, frequency)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
## **Fix: Allow Build Publish with `overwrite` Flag When Build Number is New**

### **Issue**
When attempting to publish a build with the `overwrite` flag, the process fails if the `buildName` already exists in Artifactory but the `buildNumber` is new. The failure occurs due to a missing build number in Artifactory.

### **Current Behavior**
- Publishing fails with an error stating that the build number is not available.

### **Solution**
- Ensure that the build info is pushed even if the specified `buildNumber` is not yet available in Artifactory.
