### PR TITLE
RTDEV-53813 - Support .json file in manifest when creating release bundle

### DIFF
--- a/evidence/create_release_bundle.go
+++ b/evidence/create_release_bundle.go
@@ -2,6 +2,7 @@ package evidence
 
 import (
 	"fmt"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory"
@@ -14,6 +15,11 @@ type createEvidenceReleaseBundle struct {
 	releaseBundle        string
 	releaseBundleVersion string
 }
+
+const (
+	releaseBundleEvdManifestName       = "release-bundle.json"
+	releaseBundleEvdManifestNameLegacy = "release-bundle.json.evd"
+)
 
 func NewCreateEvidenceReleaseBundle(serverDetails *coreConfig.ServerDetails, predicateFilePath, predicateType, markdownFilePath, key, keyId, project, releaseBundle,
 	releaseBundleVersion string) Command {
@@ -64,9 +70,14 @@ func (c *createEvidenceReleaseBundle) Run() error {
 
 func (c *createEvidenceReleaseBundle) buildReleaseBundleSubjectPath(artifactoryClient artifactory.ArtifactoryServicesManager) (string, string, error) {
 	repoKey := buildRepoKey(c.project)
-	manifestPath := buildManifestPath(repoKey, c.releaseBundle, c.releaseBundleVersion)
-
-	manifestChecksum, err := c.getFileChecksum(manifestPath, artifactoryClient)
+	manifestPath, manifestChecksum, err := c.buildReleaseBundleSubjectPathWithManifestName(artifactoryClient, releaseBundleEvdManifestName, repoKey)
+	if err == nil {
+		return manifestPath, manifestChecksum, nil
+	}
+	log.Info(fmt.Sprintf("Failed to get manifest name %s in %s", releaseBundleEvdManifestName, manifestPath), err)
+	log.Info(fmt.Sprintf("Attempt to get manifest name %s", releaseBundleEvdManifestNameLegacy))
+	// fallback to legacy name
+	manifestPath, manifestChecksum, err = c.buildReleaseBundleSubjectPathWithManifestName(artifactoryClient, releaseBundleEvdManifestNameLegacy, repoKey)
 	if err != nil {
 		return "", "", err
 	}
@@ -74,13 +85,21 @@ func (c *createEvidenceReleaseBundle) buildReleaseBundleSubjectPath(artifactoryC
 	return manifestPath, manifestChecksum, nil
 }
 
+func (c *createEvidenceReleaseBundle) buildReleaseBundleSubjectPathWithManifestName(artifactoryClient artifactory.ArtifactoryServicesManager, manifestName, repoKey string) (string, string, error) {
+	manifestPath := buildManifestPath(repoKey, c.releaseBundle, c.releaseBundleVersion, manifestName)
+	manifestChecksum, err := c.getFileChecksum(manifestPath, artifactoryClient)
+
+	return manifestPath, manifestChecksum, err
+}
+
 func buildRepoKey(project string) string {
 	if project == "" || project == "default" {
 		return "release-bundles-v2"
 	}
+
 	return fmt.Sprintf("%s-release-bundles-v2", project)
 }
 
-func buildManifestPath(repoKey, name, version string) string {
-	return fmt.Sprintf("%s/%s/%s/release-bundle.json.evd", repoKey, name, version)
+func buildManifestPath(repoKey, name, version, manifestName string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", repoKey, name, version, manifestName)
 }


### PR DESCRIPTION

- [v] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [v] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [v] This pull request is on the dev branch.
- [v] I used gofmt for formatting the code before submitting the pull request.
-----

Support .json file in manifest when creating release bundle if there is no .json file in release bundle fall back to .json.evd file