### PR TITLE
Support lifecycle annotate command for release bundle

### DIFF
--- a/cliutils/cmddefs/commands.go
+++ b/cliutils/cmddefs/commands.go
@@ -16,4 +16,5 @@ const (
 	ReleaseBundleDeleteRemote = "release-bundle-delete-remote"
 	ReleaseBundleExport       = "release-bundle-export"
 	ReleaseBundleImport       = "release-bundle-import"
+	ReleaseBundleAnnotate     = "release-bundle-annotate"
 )

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -137,7 +137,7 @@ const (
 
 	// Generic commands flags
 	exclusions              = "exclusions"
-	recursive               = "recursive"
+	Recursive               = "recursive"
 	flat                    = "flat"
 	build                   = "build"
 	excludeArtifacts        = "exclude-artifacts"
@@ -179,7 +179,7 @@ const (
 	// Unique upload flags
 	uploadPrefix      = "upload-"
 	uploadExclusions  = uploadPrefix + exclusions
-	uploadRecursive   = uploadPrefix + recursive
+	uploadRecursive   = uploadPrefix + Recursive
 	uploadFlat        = uploadPrefix + flat
 	uploadRegexp      = uploadPrefix + regexpFlag
 	uploadExplode     = uploadPrefix + explode
@@ -194,7 +194,7 @@ const (
 
 	// Unique download flags
 	downloadPrefix       = "download-"
-	downloadRecursive    = downloadPrefix + recursive
+	downloadRecursive    = downloadPrefix + Recursive
 	downloadFlat         = downloadPrefix + flat
 	downloadExplode      = downloadPrefix + explode
 	downloadProps        = downloadPrefix + props
@@ -207,21 +207,21 @@ const (
 
 	// Unique move flags
 	movePrefix       = "move-"
-	moveRecursive    = movePrefix + recursive
+	moveRecursive    = movePrefix + Recursive
 	moveFlat         = movePrefix + flat
 	moveProps        = movePrefix + props
 	moveExcludeProps = movePrefix + excludeProps
 
 	// Unique copy flags
 	copyPrefix       = "copy-"
-	copyRecursive    = copyPrefix + recursive
+	copyRecursive    = copyPrefix + Recursive
 	copyFlat         = copyPrefix + flat
 	copyProps        = copyPrefix + props
 	copyExcludeProps = copyPrefix + excludeProps
 
 	// Unique delete flags
 	deletePrefix       = "delete-"
-	deleteRecursive    = deletePrefix + recursive
+	deleteRecursive    = deletePrefix + Recursive
 	deleteProps        = deletePrefix + props
 	deleteExcludeProps = deletePrefix + excludeProps
 	deleteQuiet        = deletePrefix + quiet
@@ -229,7 +229,7 @@ const (
 	// Unique search flags
 	searchInclude      = "include"
 	searchPrefix       = "search-"
-	searchRecursive    = searchPrefix + recursive
+	searchRecursive    = searchPrefix + Recursive
 	searchProps        = searchPrefix + props
 	searchExcludeProps = searchPrefix + excludeProps
 	count              = "count"
@@ -237,7 +237,7 @@ const (
 
 	// Unique properties flags
 	propertiesPrefix  = "props-"
-	propsRecursive    = propertiesPrefix + recursive
+	propsRecursive    = propertiesPrefix + Recursive
 	propsProps        = propertiesPrefix + props
 	propsExcludeProps = propertiesPrefix + excludeProps
 
@@ -257,7 +257,7 @@ const (
 	// Unique build-add-dependencies flags
 	badPrefix    = "bad-"
 	badDryRun    = badPrefix + dryRun
-	badRecursive = badPrefix + recursive
+	badRecursive = badPrefix + Recursive
 	badRegexp    = badPrefix + regexpFlag
 	badFromRt    = badPrefix + fromRt
 	badModule    = badPrefix + module
@@ -352,7 +352,7 @@ const (
 	// Unique Terraform flags
 	namespace = "namespace"
 	provider  = "provider"
-	tag       = "tag"
+	Tag       = "tag"
 
 	// Template user flags
 	vars = "vars"
@@ -464,6 +464,10 @@ const (
 	lcIncludeRepos       = lifecyclePrefix + IncludeRepos
 	lcExcludeRepos       = lifecyclePrefix + ExcludeRepos
 	PromotionType        = "promotion-type"
+	lcTag                = lifecyclePrefix + Tag
+	lcProperties         = lifecyclePrefix + Properties
+	DeleteProperty       = "del-prop"
+	lcDeleteProperties   = lifecyclePrefix + DeleteProperty
 )
 
 var commandFlags = map[string][]string{
@@ -512,6 +516,9 @@ var commandFlags = map[string][]string{
 	},
 	cmddefs.ReleaseBundleImport: {
 		user, password, accessToken, serverId, platformUrl,
+	},
+	cmddefs.ReleaseBundleAnnotate: {
+		platformUrl, user, password, accessToken, serverId, lcProject, lcTag, lcProperties, lcDeleteProperties, propsRecursive,
 	},
 	AddConfig: {
 		interactive, EncPassword, configPlatformUrl, configRtUrl, configDistUrl, configXrUrl, configMcUrl, configPlUrl, configUser, configPassword, configAccessToken, sshKeyPath, sshPassphrase, ClientCertPath,
@@ -695,7 +702,7 @@ var commandFlags = map[string][]string{
 		global, serverIdDeploy, repoDeploy,
 	},
 	Terraform: {
-		namespace, provider, tag, exclusions,
+		namespace, provider, Tag, exclusions,
 		BuildName, BuildNumber, module, Project,
 	},
 	Twine: {
@@ -824,7 +831,7 @@ var flagsMap = map[string]components.Flag{
 	sortOrder:               components.NewStringFlag(sortOrder, "[Default: asc] The order by which fields in the 'sort-by' option should be sorted. Accepts 'asc' or 'desc'.", components.SetMandatoryFalse()),
 	limit:                   components.NewStringFlag(limit, "[Optional] The maximum number of items to fetch. Usually used with the 'sort-by' option.", components.SetMandatoryFalse()),
 	offset:                  components.NewStringFlag(offset, "[Optional] The offset from which to fetch items (i.e. how many items should be skipped). Usually used with the 'sort-by' option.", components.SetMandatoryFalse()),
-	downloadRecursive:       components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to include the download of artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
+	downloadRecursive:       components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to include the download of artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	downloadFlat:            components.NewBoolFlag(flat, "[Default: false] Set to true if you do not wish to have the Artifactory repository path structure created locally for your downloaded files.", components.WithBoolDefaultValueFalse()),
 	build:                   components.NewStringFlag(build, "[Optional] If specified, only artifacts of the specified build are matched. The property format is build-name/build-number. If you do not specify the build number, the artifacts are filtered by the latest build number. If the build is assigned to a specific project please provide the project key using the --project flag.", components.SetMandatoryFalse()),
 	includeDeps:             components.NewStringFlag(includeDeps, "[Default: false] If specified, also dependencies of the specified build are matched. Used together with the --build flag.", components.SetMandatoryFalse()),
@@ -846,7 +853,7 @@ var flagsMap = map[string]components.Flag{
 	uploadTargetProps: components.NewStringFlag(targetProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Those properties will be attached to the uploaded artifacts.", components.SetMandatoryFalse()),
 	uploadExclusions:  components.NewStringFlag(exclusions, "[Optional] List of semicolon-separated(;) exclude patterns. Exclude patterns may contain the * and the ? wildcards or a regex pattern, according to the value of the 'regexp' option.", components.SetMandatoryFalse()),
 	deb:               components.NewStringFlag(deb, "[Optional] Used for Debian packages in the form of distribution/component/architecture. If the value for distribution, component or architecture includes a slash, the slash should be escaped with a back-slash.", components.SetMandatoryFalse()),
-	uploadRecursive:   components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to collect artifacts in sub-folders to be uploaded to Artifactory.", components.WithBoolDefaultValueFalse()),
+	uploadRecursive:   components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to collect artifacts in sub-folders to be uploaded to Artifactory.", components.WithBoolDefaultValueFalse()),
 	uploadFlat:        components.NewBoolFlag(flat, "[Default: false] If set to false, files are uploaded according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	uploadRegexp:      components.NewBoolFlag(regexpFlag, "[Default: false] Set to true to use a regular expression instead of wildcards expression to collect files to upload.", components.WithBoolDefaultValueFalse()),
 	uploadExplode:     components.NewBoolFlag(explode, "[Default: false] Set to true to extract an archive after it is deployed to Artifactory.", components.WithBoolDefaultValueFalse()),
@@ -859,25 +866,25 @@ var flagsMap = map[string]components.Flag{
 	chunkSize:         components.NewStringFlag(chunkSize, "[Default: "+strconv.Itoa(UploadChunkSizeMb)+"] The upload chunk size in MiB that can be concurrently uploaded during a multi-part upload. This option, as well as the functionality of multi-part upload, requires Artifactory with S3 or GCP storage.", components.SetMandatoryFalse()),
 
 	// Move specific commands flags
-	moveRecursive:    components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to move artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
+	moveRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to move artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	moveFlat:         components.NewBoolFlag(flat, "[Default: false] If set to false, files are moved according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	moveProps:        components.NewStringFlag(props, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be moved.", components.SetMandatoryFalse()),
 	moveExcludeProps: components.NewStringFlag(excludeProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be moved.", components.SetMandatoryFalse()),
 
 	// Copy specific commands flags
-	copyRecursive:    components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to copy artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
+	copyRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to copy artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	copyFlat:         components.NewBoolFlag(flat, "[Default: false] If set to false, files are copied according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	copyProps:        components.NewStringFlag(props, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be copied.", components.SetMandatoryFalse()),
 	copyExcludeProps: components.NewStringFlag(excludeProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be copied.", components.SetMandatoryFalse()),
 
 	// Delete specific commands flags
-	deleteRecursive:    components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to delete artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
+	deleteRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to delete artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	deleteQuiet:        components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
 	deleteProps:        components.NewStringFlag(props, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be deleted.", components.SetMandatoryFalse()),
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
 
 	// Search specific commands flags
-	searchRecursive:    components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to search artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
+	searchRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to search artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	count:              components.NewBoolFlag(count, "[Optional] Set to true to display only the total of files or folders found.", components.WithBoolDefaultValueFalse()),
 	searchProps:        components.NewStringFlag(props, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be returned.", components.SetMandatoryFalse()),
 	searchExcludeProps: components.NewStringFlag(excludeProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be returned.", components.SetMandatoryFalse()),
@@ -885,7 +892,7 @@ var flagsMap = map[string]components.Flag{
 	searchInclude:      components.NewStringFlag(searchInclude, "[Optional] List of semicolon-separated(;) fields in the form of \"value1;value2;...\". Only the path and the fields that are specified will be returned. The fields must be part of the 'items' AQL domain. For the full supported items list, check %sjfrog-artifactory-documentation/artifactory-query-language.", components.SetMandatoryFalse()),
 
 	// Properties specific commands flags
-	propsRecursive:    components.NewBoolFlag(recursive, "[Default: true] When false, artifacts inside sub-folders in Artifactory will not be affected.", components.WithBoolDefaultValueFalse()),
+	propsRecursive:    components.NewBoolFlag(Recursive, "[Default: true] When false, artifacts inside sub-folders in Artifactory will not be affected.", components.WithBoolDefaultValueFalse()),
 	propsProps:        components.NewStringFlag(props, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties are affected.", components.SetMandatoryFalse()),
 	propsExcludeProps: components.NewStringFlag(excludeProps, "[Optional] List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties are affected.", components.SetMandatoryFalse()),
 
@@ -898,7 +905,7 @@ var flagsMap = map[string]components.Flag{
 	bpOverwrite:       components.NewBoolFlag(Overwrite, "[Default: false] Overwrites all existing occurrences of build infos with the provided name and number. Build artifacts will not be deleted.", components.WithBoolDefaultValueFalse()),
 
 	// Build Add Dependencies specific commands flags
-	badRecursive: components.NewBoolFlag(recursive, "[Default: true] Set to false if you do not wish to collect artifacts in sub-folders to be added to the build info.", components.WithBoolDefaultValueFalse()),
+	badRecursive: components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to collect artifacts in sub-folders to be added to the build info.", components.WithBoolDefaultValueFalse()),
 	badRegexp:    components.NewBoolFlag(regexpFlag, "[Default: false] Set to true to use a regular expression instead of wildcards expression to collect files to be added to the build info."),
 	badDryRun:    components.NewBoolFlag(dryRun, "[Default: false] Set to true to only get a summary of the dependencies that will be added to the build info.", components.WithBoolDefaultValueFalse()),
 	badFromRt:    components.NewBoolFlag(fromRt, "[Default: false] Set true to search the files in Artifactory, rather than on the local file system. The --regexp option is not supported when --from-rt is set to true.", components.WithBoolDefaultValueFalse()),
@@ -989,7 +996,7 @@ var flagsMap = map[string]components.Flag{
 	// Terraform specific commands flags
 	namespace:       components.NewStringFlag(namespace, "[Mandatory] Terraform namespace.", components.SetMandatoryTrue()),
 	provider:        components.NewStringFlag(provider, "[Mandatory] Terraform provider.", components.SetMandatoryTrue()),
-	tag:             components.NewStringFlag(tag, "[Mandatory] Terraform package tag.", components.SetMandatoryTrue()),
+	Tag:             components.NewStringFlag(Tag, "[Mandatory] Terraform package tag.", components.SetMandatoryTrue()),
 	IncludeProjects: components.NewStringFlag(IncludeProjects, "[Optional] List of semicolon-separated(;) JFrog Project keys to include in the transfer. You can use wildcards to specify patterns for the JFrog Project keys.", components.SetMandatoryFalse()),
 	ExcludeProjects: components.NewStringFlag(ExcludeProjects, "[Optional] List of semicolon-separated(;) JFrog Projects to exclude from the transfer. You can use wildcards to specify patterns for the project keys.", components.SetMandatoryFalse()),
 
@@ -1044,9 +1051,12 @@ var flagsMap = map[string]components.Flag{
 	lcDryRun: components.NewBoolFlag(dryRun, "Set to true to only simulate the distribution of the release bundle.", components.WithBoolDefaultValueFalse()),
 	lcIncludeRepos: components.NewStringFlag(IncludeRepos, "List of semicolon-separated(;) repositories to include in the promotion. If this property is left undefined, all repositories (except those specifically excluded) are included in the promotion. "+
 		"If one or more repositories are specifically included, all other repositories are excluded.` `", components.SetMandatoryFalse()),
-	lcExcludeRepos: components.NewStringFlag(ExcludeRepos, "List of semicolon-separated(;) repositories to exclude from the promotion.` `", components.SetMandatoryFalse()),
-	platformUrl:    components.NewStringFlag(url, "JFrog platform URL. (example: https://acme.jfrog.io)` `", components.SetMandatoryFalse()),
-	PromotionType:  components.NewStringFlag(PromotionType, "The promotion type. Can be one of 'copy' or 'move'.", components.WithStrDefaultValue("copy")),
+	lcExcludeRepos:     components.NewStringFlag(ExcludeRepos, "List of semicolon-separated(;) repositories to exclude from the promotion.` `", components.SetMandatoryFalse()),
+	platformUrl:        components.NewStringFlag(url, "JFrog platform URL. (example: https://acme.jfrog.io)` `", components.SetMandatoryFalse()),
+	PromotionType:      components.NewStringFlag(PromotionType, "The promotion type. Can be one of 'copy' or 'move'.", components.WithStrDefaultValue("copy")),
+	lcTag:              components.NewStringFlag(Tag, "Tag to put on Release Bundle version.", components.SetMandatoryFalse()),
+	lcProperties:       components.NewStringFlag(Properties, "Properties to put on the of Manifest Release Bundle version.", components.SetMandatoryFalse()),
+	lcDeleteProperties: components.NewStringFlag(DeleteProperty, "Properties to be deleted on the of Manifest Release Bundle version.", components.SetMandatoryFalse()),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/go.mod
+++ b/go.mod
@@ -132,8 +132,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250429081008-4c70b8d467b9
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250508140039-bfb5e9a50dfe
 
-//replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250406105605-ee90d11546f9
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250508130334-f159cff9b11a
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,10 @@ github.com/jfrog/froggit-go v1.17.0 h1:20Ie787WO27SwB2MOHDvsR6yN7fA5WfRnuAbmUqz1
 github.com/jfrog/froggit-go v1.17.0/go.mod h1:HvDkfFfJwIdsXFdqaB+utvD2cLDRmaC3kF8otYb6Chw=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250429081008-4c70b8d467b9 h1:soybymuMolD5ta/rgiiRpRSBm9BlIbfYvnOcrg1Nkns=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250429081008-4c70b8d467b9/go.mod h1:JbLdMCWL0xVZZ0FY7jd+iTi/gKYqRmRpeLBhAFtldfQ=
-github.com/jfrog/jfrog-client-go v1.52.0 h1:MCmHviUqj3X7iqyOokTkyvV5yBWFwZYDPVXYikl4nf0=
-github.com/jfrog/jfrog-client-go v1.52.0/go.mod h1:uRmT8Q1SJymIzId01v0W1o8mGqrRfrwUF53CgEMsH0U=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250508140039-bfb5e9a50dfe h1:17ZlsX/X4orRHqFoyGnEBHIfKFu49AVvyVoRqk7635E=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250508140039-bfb5e9a50dfe/go.mod h1:8ODu50AZkrP5xXvUGLizFTL1+qJknSShHNGhGl7OtFQ=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250508130334-f159cff9b11a h1:QkebmsUWuurSgp4Lx7k6GtQ0sX3RmJ/d2n+NQ2l2g/E=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250508130334-f159cff9b11a/go.mod h1:uRmT8Q1SJymIzId01v0W1o8mGqrRfrwUF53CgEMsH0U=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=

--- a/lifecycle/cli.go
+++ b/lifecycle/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/distribution"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	lifecycle "github.com/jfrog/jfrog-cli-artifactory/lifecycle/commands"
+	rbAnnotate "github.com/jfrog/jfrog-cli-artifactory/lifecycle/docs/annotate"
 	rbCreate "github.com/jfrog/jfrog-cli-artifactory/lifecycle/docs/create"
 	rbDeleteLocal "github.com/jfrog/jfrog-cli-artifactory/lifecycle/docs/deletelocal"
 	rbDeleteRemote "github.com/jfrog/jfrog-cli-artifactory/lifecycle/docs/deleteremote"
@@ -101,6 +102,15 @@ func GetCommands() []components.Command {
 			Arguments:   rbImport.GetArguments(),
 			Category:    lcCategory,
 			Action:      releaseBundleImport,
+		},
+		{
+			Name:        "release-bundle-annotate",
+			Aliases:     []string{"rba"},
+			Flags:       flagkit.GetCommandFlags(cmddefs.ReleaseBundleAnnotate),
+			Description: rbAnnotate.GetDescription(),
+			Arguments:   rbAnnotate.GetArguments(),
+			Category:    lcCategory,
+			Action:      annotate,
 		},
 	}
 }
@@ -378,6 +388,46 @@ func releaseBundleImport(c *components.Context) error {
 		SetFilepath(c.GetArgumentAt(0))
 
 	return commands.Exec(importCmd)
+}
+
+func annotate(c *components.Context) error {
+	if show, err := pluginsCommon.ShowCmdHelpIfNeeded(c, c.Arguments); show || err != nil {
+		return err
+	}
+
+	if c.GetNumberOfArgs() < 2 {
+		return pluginsCommon.WrongNumberOfArgumentsHandler(c)
+	}
+
+	rtDetails, err := createLifecycleDetailsByFlags(c)
+	if err != nil {
+		return err
+	}
+	annotateCmd := lifecycle.NewReleaseBundleAnnotateCommand()
+
+	project := pluginsCommon.GetProject(c)
+	if project == "" {
+		project = "default"
+	}
+
+	tagExist := c.IsFlagSet(flagkit.Tag)
+	propsExist := c.IsFlagSet(flagkit.Properties)
+	deleteProps := c.IsFlagSet(flagkit.DeleteProperty)
+
+	if !tagExist && !propsExist && !deleteProps {
+		return errors.New("action is not specified. One of tag/properties/del-prop should be specified")
+	}
+
+	annotateCmd.
+		SetServerDetails(rtDetails).
+		SetReleaseBundleProject(project).
+		SetReleaseBundleName(c.GetArgumentAt(0)).
+		SetReleaseBundleVersion(c.GetArgumentAt(1)).
+		SetTag(c.GetStringFlagValue(flagkit.Tag), tagExist).
+		SetProps(c.GetStringFlagValue(flagkit.Properties)).
+		DeleteProps(c.GetStringFlagValue(flagkit.DeleteProperty)).
+		SetRecursive(c.GetBoolFlagValue(flagkit.Recursive), c.IsFlagSet(flagkit.Recursive))
+	return commands.Exec(annotateCmd)
 }
 
 func validateDistributeCommand(c *components.Context) error {

--- a/lifecycle/commands/annotate.go
+++ b/lifecycle/commands/annotate.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/jfrog/gofrog/log"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/lifecycle"
+	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+)
+
+const minSetTagArtifactoryVersion = "7.111.0"
+
+type ReleaseBundleAnnotateCommand struct {
+	releaseBundleCmd
+	tag                       string
+	tagExist                  bool
+	props                     string
+	propsExist                bool
+	deleteProps               string
+	deletePropsExist          bool
+	recursive                 bool
+	validateVersionFunc       func(*config.ServerDetails, string) error
+	getPrerequisitesFunc      func() (*lifecycle.LifecycleServicesManager, services.ReleaseBundleDetails, services.CommonOptionalQueryParams, error)
+	annotateReleaseBundleFunc func(*ReleaseBundleAnnotateCommand, *lifecycle.LifecycleServicesManager,
+		services.ReleaseBundleDetails, services.CommonOptionalQueryParams) error
+}
+
+func NewReleaseBundleAnnotateCommand() *ReleaseBundleAnnotateCommand {
+	cmd := &ReleaseBundleAnnotateCommand{}
+	cmd.annotateReleaseBundleFunc = DefaultAnnotateReleaseBundle
+	cmd.validateVersionFunc = validateFeatureSupportedVersion
+	cmd.getPrerequisitesFunc = func() (*lifecycle.LifecycleServicesManager, services.ReleaseBundleDetails, services.CommonOptionalQueryParams, error) {
+		return DefaultGetPrerequisites(cmd)
+	}
+	return cmd
+}
+
+func DefaultGetPrerequisites(rba *ReleaseBundleAnnotateCommand) (*lifecycle.LifecycleServicesManager, services.ReleaseBundleDetails, services.CommonOptionalQueryParams, error) {
+	return rba.getPrerequisites()
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetRecursive(recursive, flagIsSet bool) *ReleaseBundleAnnotateCommand {
+	if flagIsSet {
+		rba.recursive = recursive
+	} else {
+		rba.recursive = true
+	}
+
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetServerDetails(serverDetails *config.ServerDetails) *ReleaseBundleAnnotateCommand {
+	rba.serverDetails = serverDetails
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetReleaseBundleName(releaseBundleName string) *ReleaseBundleAnnotateCommand {
+	rba.releaseBundleName = releaseBundleName
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetReleaseBundleVersion(releaseBundleVersion string) *ReleaseBundleAnnotateCommand {
+	rba.releaseBundleVersion = releaseBundleVersion
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetReleaseBundleProject(rbProjectKey string) *ReleaseBundleAnnotateCommand {
+	rba.rbProjectKey = rbProjectKey
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetTag(tag string, exist bool) *ReleaseBundleAnnotateCommand {
+	rba.tag = tag
+	rba.tagExist = exist
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) SetProps(props string) *ReleaseBundleAnnotateCommand {
+	rba.props = props
+	rba.propsExist = props != ""
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) DeleteProps(deleteProps string) *ReleaseBundleAnnotateCommand {
+	rba.deleteProps = deleteProps
+	rba.deletePropsExist = deleteProps != ""
+	return rba
+}
+
+func (rba *ReleaseBundleAnnotateCommand) ServerDetails() (*config.ServerDetails, error) {
+	return rba.serverDetails, nil
+}
+
+func (rba *ReleaseBundleAnnotateCommand) CommandName() string {
+	return "rb_annotate"
+}
+
+func (rba *ReleaseBundleAnnotateCommand) Run() error {
+	if err := rba.validateVersionFunc(rba.serverDetails, minSetTagArtifactoryVersion); err != nil {
+		return err
+	}
+
+	servicesManager, rbDetails, queryParams, err := rba.getPrerequisitesFunc()
+	if err != nil {
+		return err
+	}
+
+	err = rba.annotateReleaseBundleFunc(rba, servicesManager, rbDetails, queryParams)
+	if err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("Successfully annotated release bundle: %s/%s", rbDetails.ReleaseBundleName, rbDetails.ReleaseBundleVersion))
+
+	return nil
+}
+
+func DefaultAnnotateReleaseBundle(rba *ReleaseBundleAnnotateCommand, manager *lifecycle.LifecycleServicesManager,
+	details services.ReleaseBundleDetails, params services.CommonOptionalQueryParams) error {
+	return rba.annotateReleaseBundle(manager, details, params, rba)
+}
+
+func (rba *ReleaseBundleAnnotateCommand) annotateReleaseBundle(manager *lifecycle.LifecycleServicesManager,
+	details services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams, rbac *ReleaseBundleAnnotateCommand) error {
+	return manager.AnnotateReleaseBundle(BuildAnnotationOperationParams(rbac, details, queryParams))
+}
+
+func BuildAnnotationOperationParams(rba *ReleaseBundleAnnotateCommand, details services.ReleaseBundleDetails,
+	params services.CommonOptionalQueryParams) services.AnnotateOperationParams {
+	return services.AnnotateOperationParams{
+		RbTag: services.RbAnnotationTag{
+			Tag:   rba.tag,
+			Exist: rba.tagExist,
+		},
+		RbProps: services.RbAnnotationProps{
+			Properties: buildProps(rba.props),
+			Exist:      rba.propsExist,
+		},
+		RbDelProps: services.RbDelProps{
+			Keys:  rba.deleteProps,
+			Exist: rba.deletePropsExist,
+		},
+		RbDetails:   details,
+		QueryParams: params,
+		PropertyParams: services.CommonPropParams{
+			Path: buildManifestPath(params.ProjectKey, details.ReleaseBundleName,
+				details.ReleaseBundleVersion),
+			Recursive: rba.recursive,
+		},
+		ArtifactoryUrl: services.ArtCommonParams{
+			Url: rba.serverDetails.ArtifactoryUrl,
+		},
+	}
+}
+
+func buildProps(properties string) map[string][]string {
+	if properties == "" {
+		return make(map[string][]string)
+	}
+	props, err := utils.ParseProperties(properties)
+	if err != nil {
+		return make(map[string][]string)
+	}
+	return props.ToMap()
+}

--- a/lifecycle/commands/annotate_test.go
+++ b/lifecycle/commands/annotate_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/lifecycle"
+	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReleaseBundleAnnotateCommand_SetServerDetails(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	serverDetails := &config.ServerDetails{
+		ArtifactoryUrl: "https://artifactory.example.com",
+	}
+	cmd.SetServerDetails(serverDetails)
+	result, err := cmd.ServerDetails()
+	assert.NoError(t, err)
+	assert.Equal(t, serverDetails, result)
+}
+
+func TestReleaseBundleAnnotateCommand_SetReleaseBundleName(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.SetReleaseBundleName("example-release-bundle")
+	assert.Equal(t, "example-release-bundle", cmd.releaseBundleName)
+}
+
+func TestReleaseBundleAnnotateCommand_SetReleaseBundleVersion(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.SetReleaseBundleVersion("1.0.0")
+	assert.Equal(t, "1.0.0", cmd.releaseBundleVersion)
+}
+
+func TestReleaseBundleAnnotateCommand_SetReleaseBundleProject(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.SetReleaseBundleProject("example-project")
+	assert.Equal(t, "example-project", cmd.rbProjectKey)
+}
+
+func TestReleaseBundleAnnotateCommand_SetTag(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.SetTag("example-tag", true)
+	assert.Equal(t, "example-tag", cmd.tag)
+	assert.Equal(t, true, cmd.tagExist)
+}
+
+func TestReleaseBundleAnnotateCommand_SetProps(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.SetProps("example-props=prop-value")
+	assert.Equal(t, "example-props=prop-value", cmd.props)
+	assert.Equal(t, true, cmd.propsExist)
+}
+
+func TestBuildAnnotationOperationParams(t *testing.T) {
+	details := services.ReleaseBundleDetails{
+		ReleaseBundleName:    "example-release-bundle",
+		ReleaseBundleVersion: "1.0.0",
+	}
+	params := services.CommonOptionalQueryParams{
+		ProjectKey: "example-project",
+	}
+	cmd := NewReleaseBundleAnnotateCommand()
+	cmd.tag = "example-tag"
+	cmd.serverDetails = &config.ServerDetails{
+		ArtifactoryUrl: "https://artifactory.example.com",
+	}
+
+	result := BuildAnnotationOperationParams(cmd, details, params)
+	assert.Equal(t, "example-tag", result.RbTag.Tag)
+	assert.Equal(t, "example-project-release-bundles-v2/example-release-bundle/1.0.0/release-bundle.json.evd", result.PropertyParams.Path)
+
+}
+
+func TestReleaseBundleAnnotateCommand_Run(t *testing.T) {
+	cmd := NewReleaseBundleAnnotateCommand()
+	serverDetails := &config.ServerDetails{
+		ArtifactoryUrl: "https://artifactory.example.com",
+	}
+	cmd.SetServerDetails(serverDetails)
+	cmd.SetReleaseBundleName("example-release-bundle")
+	cmd.SetReleaseBundleVersion("1.0.0")
+	cmd.SetReleaseBundleProject("example-project")
+	cmd.SetTag("example-tag", true)
+	cmd.SetProps("example-props=prop-value;example-props-2=prop-value-2")
+	cmd.DeleteProps("example-props-2")
+
+	// Mock validateFeatureSupportedVersion function
+	cmd.validateVersionFunc = func(*config.ServerDetails, string) error {
+		return nil
+	}
+
+	// Mock getPrerequisites function
+	cmd.getPrerequisitesFunc = func() (*lifecycle.LifecycleServicesManager, services.ReleaseBundleDetails, services.CommonOptionalQueryParams, error) {
+		testServicesManager := &lifecycle.LifecycleServicesManager{}
+		testReleaseBundleDetails := services.ReleaseBundleDetails{
+			ReleaseBundleName:    "example-release-bundle",
+			ReleaseBundleVersion: "1.0.0",
+		}
+		testQueryParams := services.CommonOptionalQueryParams{
+			ProjectKey: "example-project",
+		}
+		return testServicesManager, testReleaseBundleDetails, testQueryParams, nil
+	}
+
+	// Mock annotateReleaseBundle function
+	cmd.annotateReleaseBundleFunc = func(rba *ReleaseBundleAnnotateCommand, manager *lifecycle.LifecycleServicesManager,
+		details services.ReleaseBundleDetails, params services.CommonOptionalQueryParams) error {
+		return nil
+	}
+
+	err := cmd.Run()
+	assert.NoError(t, err)
+}

--- a/lifecycle/commands/common_test.go
+++ b/lifecycle/commands/common_test.go
@@ -67,3 +67,14 @@ func TestGetPromotionPrerequisites_Success(t *testing.T) {
 	assert.Equal(t, expectedRbDetails, rbDetails, "ReleaseBundleDetails do not match expected values") // Replace _ with appropriate variable.
 	assert.Equal(t, expectedQueryParams, queryParams, "QueryParams do not match expected values")
 }
+
+func TestBuildRepoKey(t *testing.T) {
+	repoKey := buildRepoKey("example-project")
+	assert.Equal(t, "example-project-release-bundles-v2", repoKey)
+
+	repoKey = buildRepoKey("")
+	assert.Equal(t, releaseBundlesV2, repoKey)
+
+	repoKey = buildRepoKey("default")
+	assert.Equal(t, releaseBundlesV2, repoKey)
+}

--- a/lifecycle/docs/annotate/help.go
+++ b/lifecycle/docs/annotate/help.go
@@ -1,0 +1,16 @@
+package annotate
+
+import "github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+
+var Usage = []string{"rba [command options] <release bundle name> <release bundle version>"}
+
+func GetDescription() string {
+	return "Annotate a release bundle"
+}
+
+func GetArguments() []components.Argument {
+	return []components.Argument{
+		{Name: "release bundle name", Description: "Name of the Release Bundle to annotate."},
+		{Name: "release bundle version", Description: "Version of the Release Bundle to annotate."},
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Add support for a new lifecycle command: annotate.
The command has two part: setTag and add/change/delete properties