### PR TITLE
Fixed a failure when trying to read if spec flag is set

### DIFF
--- a/distribution/cli/cli.go
+++ b/distribution/cli/cli.go
@@ -128,7 +128,7 @@ func releaseBundleUpdateCmd(c *components.Context) error {
 	}
 	var releaseBundleUpdateSpec *spec.SpecFiles
 	var err error
-	if c.GetBoolFlagValue("spec") {
+	if c.IsFlagSet("spec") {
 		releaseBundleUpdateSpec, err = cliutils.GetSpec(c, true, true)
 	} else {
 		releaseBundleUpdateSpec = createDefaultReleaseBundleSpec(c)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
## Issue
  Fails to read if spec flag is set since instead of using IsFlagSet API getBoolFlagValue is used. Because of this even though right arguments are passed it fails and expects different args for release bundle update.
 
## Fix
  Using IsFlagSet should fix this issue and checks for correct number of arguments