### PR TITLE
Add support for non-standard package.json locations in npm tarballs

### DIFF
--- a/artifactory/commands/npm/publish_test.go
+++ b/artifactory/commands/npm/publish_test.go
@@ -23,6 +23,11 @@ func TestReadPackageInfoFromTarball(t *testing.T) {
 			filePath:       filepath.Join("..", "testdata", "npm", "npm-example-0.0.4.tgz"),
 			packageName:    "npm-example",
 			packageVersion: "0.0.4",
+		}, {
+			// Test case for non-standard structure where package.json is in a custom location
+			filePath:       filepath.Join("..", "testdata", "npm", "node-package-1.0.0.tgz"),
+			packageName:    "nonstandard-package",
+			packageVersion: "1.0.0",
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
### Enhance npm publish to support non-standard package.json locations

## **Description**
This PR enhances the JFrog CLI's `npm publish` command to support npm packages where `package.json` is not located at the root of the archive but could be in non-standard locations. Previously, `jfrog npm publish` expected the `package.json` to strictly reside in the `package/` folder, leading to failures with certain npm packages. With this enhancement, the CLI can now locate and use `package.json` files in various subdirectories within the tarball, similar to how `npm publish` handles it.

## **Changes**
* **Modified** `artifactory/commands/npm/publish.go`:
  - Updated `readPackageInfoFromTarball` function to scan and locate `package.json` files across various subdirectory structures within the tarball.
  - Introduced `findBestPackageJson` to determine the location of the `package.json` based on a priority system.
  - Implemented `calculatePackageJsonPriority` to assign priorities to different `package.json` locations, ensuring the most appropriate file is selected.
  - Enhanced logs to inform users if `package.json` is found in a non-standard location.

* **Added**:
  - A new test case in `jfrog-cli-artifactory/artifactory/commands/npm/publish_test.go` to verify the functionality of handling `package.json` located in non-standard directory structures.
  - Test tarball file with `package.json` in a custom location under `testdata/npm`.

## **Testing**
* Manually tested `jfrog npm publish` with various npm packages having different internal structures to confirm proper handling of `package.json` in non-standard locations.
* Verified existing and new test cases to ensure they pass successfully and validate the new functionality.
* Added comprehensive unit tests in `publish_test.go` to systematically verify both standard and non-standard package.json locations.

## **Analyzing npm publish Behavior**
Typically, `npm` publish will look for package.json regardless of its exact location within reasonable conventions. If package.json is located in subdirectories,` npm` publish will manage without throwing exceptions.

