### PR TITLE
RTECO-255 - Handled aggregate condition correctly

### DIFF
--- a/artifactory/commands/buildinfo/addgit.go
+++ b/artifactory/commands/buildinfo/addgit.go
@@ -163,6 +163,10 @@ func (config *BuildAddGitCommand) collectBuildIssues() ([]buildinfo.AffectedIssu
 	}
 
 	var foundIssues []buildinfo.AffectedIssue
+	if !config.issuesConfig.Aggregate {
+		return foundIssues, nil
+	}
+
 	logRegExp, err := createLogRegExpHandler(config.issuesConfig, &foundIssues)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What: Added the condition to not include the previous build affected issue when aggregate option is false. This was a bug due to which previous build version affected issues were added to the current build affected issue irrespective of the aggregate field value.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-artifactory#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-artifactory/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
