### PR TITLE
align verify response with evd get command

### DIFF
--- a/evidence/cli/command_cli.go
+++ b/evidence/cli/command_cli.go
@@ -282,12 +282,6 @@ func setBuildValue(ctx *components.Context, flag, envVar string) bool {
 func validateKeys(ctx *components.Context) error {
 	signingKeyValue, _ := jfrogArtClient.GetEnvVariable(coreUtils.SigningKey)
 	providedKeys := ctx.GetStringsArrFlagValue(publicKeys)
-	if signingKeyValue == "" {
-		if len(providedKeys) == 0 && !ctx.GetBoolFlagValue(useArtifactoryKeys) {
-			return errorutils.CheckErrorf("JFROG_CLI_SIGNING_KEY env variable or --%s flag or --%s must be provided when verifying evidence", publicKeys, useArtifactoryKeys)
-		}
-		return nil
-	}
 	if len(providedKeys) > 0 {
 		joinedKeys := strings.Join(append(providedKeys, signingKeyValue), ";")
 		ctx.SetStringFlagValue(publicKeys, joinedKeys)

--- a/evidence/cli/docs/verify/help.go
+++ b/evidence/cli/docs/verify/help.go
@@ -4,8 +4,7 @@ import "github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 
 func GetDescription() string {
 	return `Verify all evidence associated with the specified subject. Provide the subject's path and relevant keys.
-	Keys can be supplied using the --keys flag, the JFROG_CLI_SIGNING_KEY environment variable, or retrieved from Artifactory using the --use-artifactory-keys option.
-	The command exits with code 0 if verification succeeds, and code 1 if it fails.`
+	Keys can be supplied using the --keys flag, the JFROG_CLI_SIGNING_KEY environment variable, or retrieved from Artifactory using the --use-artifactory-keys option.`
 }
 
 func GetArguments() []components.Argument {

--- a/evidence/model/verify.go
+++ b/evidence/model/verify.go
@@ -2,26 +2,34 @@ package model
 
 import "github.com/jfrog/jfrog-cli-artifactory/evidence/dsse"
 
+const SchemaVersion = "1.0.0"
+
 type VerificationResponse struct {
-	SubjectPath               string                  `json:"subjectPath"`
-	SubjectChecksum           string                  `json:"subjectDigest"`
+	// Update the schemaVersion value when this structure is updated.
+	SchemaVersion             string                  `json:"schemaVersion"`
+	Subject                   Subject                 `json:"subject"`
 	EvidenceVerifications     *[]EvidenceVerification `json:"evidenceVerifications"`
 	OverallVerificationStatus VerificationStatus      `json:"overallVerificationStatus"`
 }
 
+type Subject struct {
+	Path   string `json:"path"`
+	Sha256 string `json:"sha256"`
+}
+
 type EvidenceVerification struct {
 	DsseEnvelope       dsse.Envelope              `json:"dsseEnvelope"`
-	EvidencePath       string                     `json:"evidencePath"`
-	SubjectChecksum    string                     `json:"evidenceSubjectDigest"`
+	DownloadPath       string                     `json:"downloadPath"`
+	SubjectChecksum    string                     `json:"evidenceSubjectSha256"`
 	PredicateType      string                     `json:"predicateType"`
 	CreatedBy          string                     `json:"createdBy"`
-	Time               string                     `json:"time"`
+	CreatedAt          string                     `json:"createdAt"`
 	VerificationResult EvidenceVerificationResult `json:"verificationResult"`
 }
 
 type EvidenceVerificationResult struct {
-	ChecksumVerificationStatus   VerificationStatus `json:"digestVerificationStatus"`
-	SignaturesVerificationStatus VerificationStatus `json:"signaturesVerified"`
+	Sha256VerificationStatus     VerificationStatus `json:"sha256VerificationStatus"`
+	SignaturesVerificationStatus VerificationStatus `json:"signaturesVerificationStatus"`
 	KeySource                    string             `json:"keySource,omitempty"`
 	KeyFingerprint               string             `json:"keyFingerprint,omitempty"`
 }

--- a/evidence/model/verify.go
+++ b/evidence/model/verify.go
@@ -2,7 +2,7 @@ package model
 
 import "github.com/jfrog/jfrog-cli-artifactory/evidence/dsse"
 
-const SchemaVersion = "1.0.0"
+const SchemaVersion = "1.0"
 
 type VerificationResponse struct {
 	// Update the schemaVersion value when this structure is updated.

--- a/evidence/verify/evidence_verifier.go
+++ b/evidence/verify/evidence_verifier.go
@@ -42,8 +42,11 @@ func (v *evidenceVerifier) Verify(subjectSha256 string, evidenceMetadata *[]mode
 		return nil, fmt.Errorf("no evidence metadata provided")
 	}
 	result := &model.VerificationResponse{
-		SubjectPath:               subjectPath,
-		SubjectChecksum:           subjectSha256,
+		SchemaVersion: model.SchemaVersion,
+		Subject: model.Subject{
+			Path:   subjectPath,
+			Sha256: subjectSha256,
+		},
 		OverallVerificationStatus: model.Success,
 	}
 	results := make([]model.EvidenceVerification, 0, len(*evidenceMetadata))
@@ -54,7 +57,7 @@ func (v *evidenceVerifier) Verify(subjectSha256 string, evidenceMetadata *[]mode
 			return nil, err
 		}
 		results = append(results, *verification)
-		if verification.VerificationResult.SignaturesVerificationStatus == model.Failed || verification.VerificationResult.ChecksumVerificationStatus == model.Failed {
+		if verification.VerificationResult.SignaturesVerificationStatus == model.Failed || verification.VerificationResult.Sha256VerificationStatus == model.Failed {
 			result.OverallVerificationStatus = model.Failed
 		}
 	}
@@ -80,13 +83,13 @@ func (v *evidenceVerifier) verifyEvidence(evidence *model.SearchEvidenceEdge, su
 	}
 	result := &model.EvidenceVerification{
 		DsseEnvelope:    envelope,
-		EvidencePath:    evidence.Node.DownloadPath,
+		DownloadPath:    evidence.Node.DownloadPath,
 		SubjectChecksum: evidenceChecksum,
 		PredicateType:   evidence.Node.PredicateType,
 		CreatedBy:       evidence.Node.CreatedBy,
-		Time:            evidence.Node.CreatedAt,
+		CreatedAt:       evidence.Node.CreatedAt, // change to CreatedAt
 		VerificationResult: model.EvidenceVerificationResult{
-			ChecksumVerificationStatus:   checksumStatus,
+			Sha256VerificationStatus:     checksumStatus,
 			SignaturesVerificationStatus: model.Failed,
 		},
 	}

--- a/evidence/verify/evidence_verifier_test.go
+++ b/evidence/verify/evidence_verifier_test.go
@@ -147,7 +147,7 @@ func TestVerifier_Verify_InvalidEvidenceMetadata(t *testing.T) {
 	assert.Equal(t, model.VerificationStatus(model.Failed), result.OverallVerificationStatus)
 	assert.Len(t, *result.EvidenceVerifications, 1)
 	// The checksum verification should fail due to mismatch
-	assert.Equal(t, model.VerificationStatus(model.Failed), (*result.EvidenceVerifications)[0].VerificationResult.ChecksumVerificationStatus)
+	assert.Equal(t, model.VerificationStatus(model.Failed), (*result.EvidenceVerifications)[0].VerificationResult.Sha256VerificationStatus)
 }
 
 // Test readEnvelopeFromRemote function directly (tests envelope reading without triggering remote key fetching)
@@ -384,8 +384,8 @@ func TestVerifier_Verify_Success(t *testing.T) {
 	// Assertions
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, "/test/subject/path", result.SubjectPath)
-	assert.Equal(t, "test-sha256", result.SubjectChecksum)
+	assert.Equal(t, "/test/subject/path", result.Subject.Path)
+	assert.Equal(t, "test-sha256", result.Subject.Sha256)
 	assert.Equal(t, model.VerificationStatus(model.Success), result.OverallVerificationStatus)
 
 	// Check evidence verifications
@@ -393,12 +393,12 @@ func TestVerifier_Verify_Success(t *testing.T) {
 	assert.Len(t, *result.EvidenceVerifications, 1)
 
 	evidence := (*result.EvidenceVerifications)[0]
-	assert.Equal(t, "/evidence/path", evidence.EvidencePath)
+	assert.Equal(t, "/evidence/path", evidence.DownloadPath)
 	assert.Equal(t, "test-sha256", evidence.SubjectChecksum)
 	assert.Equal(t, "test-predicate", evidence.PredicateType)
 	assert.Equal(t, "test-user", evidence.CreatedBy)
-	assert.Equal(t, "2023-01-01T00:00:00Z", evidence.Time)
-	assert.Equal(t, model.VerificationStatus(model.Success), evidence.VerificationResult.ChecksumVerificationStatus)
+	assert.Equal(t, "2023-01-01T00:00:00Z", evidence.CreatedAt)
+	assert.Equal(t, model.VerificationStatus(model.Success), evidence.VerificationResult.Sha256VerificationStatus)
 	assert.Equal(t, model.VerificationStatus(model.Success), evidence.VerificationResult.SignaturesVerificationStatus)
 	assert.Equal(t, localKeySource, evidence.VerificationResult.KeySource)
 
@@ -451,8 +451,8 @@ func TestVerifier_Verify_VerificationFailed(t *testing.T) {
 	// Assertions - should succeed but with failed verification status
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, "/test/subject/path", result.SubjectPath)
-	assert.Equal(t, "test-sha256", result.SubjectChecksum)
+	assert.Equal(t, "/test/subject/path", result.Subject.Path)
+	assert.Equal(t, "test-sha256", result.Subject.Sha256)
 	assert.Equal(t, model.VerificationStatus(model.Failed), result.OverallVerificationStatus)
 
 	// Check evidence verifications
@@ -460,9 +460,9 @@ func TestVerifier_Verify_VerificationFailed(t *testing.T) {
 	assert.Len(t, *result.EvidenceVerifications, 1)
 
 	evidence := (*result.EvidenceVerifications)[0]
-	assert.Equal(t, "/evidence/path", evidence.EvidencePath)
+	assert.Equal(t, "/evidence/path", evidence.DownloadPath)
 	assert.Equal(t, "test-sha256", evidence.SubjectChecksum)
-	assert.Equal(t, model.VerificationStatus(model.Success), evidence.VerificationResult.ChecksumVerificationStatus)
+	assert.Equal(t, model.VerificationStatus(model.Success), evidence.VerificationResult.Sha256VerificationStatus)
 	assert.Equal(t, model.VerificationStatus(model.Failed), evidence.VerificationResult.SignaturesVerificationStatus)
 
 	// Verify mock was called

--- a/evidence/verify/evidence_verifier_test.go
+++ b/evidence/verify/evidence_verifier_test.go
@@ -288,7 +288,7 @@ func TestVerifyEnvelop_NilInputs(t *testing.T) {
 
 	assert.False(t, success)
 	// When inputs are nil, verifyEnvelope doesn't set the status (returns early)
-	assert.Equal(t, model.VerificationStatus(""), result.VerificationResult.SignaturesVerificationStatus)
+	assert.Equal(t, model.VerificationStatus("failed"), result.VerificationResult.SignaturesVerificationStatus)
 }
 
 // Test verifyEnvelope with empty verifiers

--- a/evidence/verify/verify_base.go
+++ b/evidence/verify/verify_base.go
@@ -117,8 +117,8 @@ func printText(result *model.VerificationResponse) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Subject digest sha256: %s\n", result.SubjectChecksum)
-	fmt.Printf("Subject:               %s\n", result.SubjectPath)
+	fmt.Printf("Subject sha256:        %s\n", result.Subject.Sha256)
+	fmt.Printf("Subject:               %s\n", result.Subject.Path)
 	evidenceNumber := len(*result.EvidenceVerifications)
 	var evidenceText string
 	if evidenceNumber == 1 {
@@ -129,7 +129,7 @@ func printText(result *model.VerificationResponse) error {
 	fmt.Printf("Loaded %d %s\n", evidenceNumber, evidenceText)
 	successfulVerifications := 0
 	for _, v := range *result.EvidenceVerifications {
-		if v.VerificationResult.ChecksumVerificationStatus == model.Success && v.VerificationResult.SignaturesVerificationStatus == model.Success {
+		if v.VerificationResult.Sha256VerificationStatus == model.Success && v.VerificationResult.SignaturesVerificationStatus == model.Success {
 			successfulVerifications++
 		}
 	}
@@ -156,12 +156,12 @@ func printText(result *model.VerificationResponse) error {
 func printVerificationResult(verification *model.EvidenceVerification, index int) {
 	fmt.Printf("- Evidence: %d\n", index+1)
 	fmt.Printf("    - Predicate type:                 %s\n", verification.PredicateType)
-	fmt.Printf("    - Evidence subject digest sha256: %s\n", verification.SubjectChecksum)
+	fmt.Printf("    - Evidence subject sha256:        %s\n", verification.SubjectChecksum)
 	if verification.VerificationResult.KeySource != "" {
 		fmt.Printf("    - Key source:                     %s\n", verification.VerificationResult.KeySource)
 		fmt.Printf("    - Key fingerprint:                %s\n", verification.VerificationResult.KeyFingerprint)
 	}
-	fmt.Printf("    - Digest verification status:     %s\n", getColoredStatus(verification.VerificationResult.ChecksumVerificationStatus))
+	fmt.Printf("    - Sha256 verification status:     %s\n", getColoredStatus(verification.VerificationResult.Sha256VerificationStatus))
 	fmt.Printf("    - Signatures verification status: %s\n", getColoredStatus(verification.VerificationResult.SignaturesVerificationStatus))
 }
 

--- a/evidence/verify/verify_base_test.go
+++ b/evidence/verify/verify_base_test.go
@@ -80,7 +80,9 @@ func captureOutput(f func()) string {
 func TestVerifyEvidenceBase_PrintVerifyResult_JSON(t *testing.T) {
 	v := &verifyEvidenceBase{format: "json"}
 	resp := &model.VerificationResponse{
-		SubjectChecksum:           "test-checksum",
+		Subject: model.Subject{
+			Sha256: "test-checksum",
+		},
 		OverallVerificationStatus: model.Success,
 	}
 
@@ -93,15 +95,17 @@ func TestVerifyEvidenceBase_PrintVerifyResult_JSON(t *testing.T) {
 func TestVerifyEvidenceBase_PrintVerifyResult_Failed(t *testing.T) {
 	v := &verifyEvidenceBase{format: "full"}
 	resp := &model.VerificationResponse{
-		SubjectChecksum:           "test-checksum",
+		Subject: model.Subject{
+			Sha256: "test-checksum",
+		},
 		OverallVerificationStatus: model.Failed,
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			SubjectChecksum: "test-checksum",
 			PredicateType:   "test-type",
 			CreatedBy:       "test-user",
-			Time:            "2024-01-01T00:00:00Z",
+			CreatedAt:       "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
-				ChecksumVerificationStatus:   model.Failed,
+				Sha256VerificationStatus:     model.Failed,
 				SignaturesVerificationStatus: model.Success,
 			},
 		}},
@@ -120,9 +124,9 @@ func TestVerifyEvidenceBase_PrintVerifyResult_Text_Success(t *testing.T) {
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			PredicateType: "test-type",
 			CreatedBy:     "test-user",
-			Time:          "2024-01-01T00:00:00Z",
+			CreatedAt:     "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
-				ChecksumVerificationStatus:   model.Success,
+				Sha256VerificationStatus:     model.Success,
 				SignaturesVerificationStatus: model.Success,
 			},
 		}},
@@ -140,9 +144,9 @@ func TestVerifyEvidenceBase_PrintVerifyResult_Text_Failed(t *testing.T) {
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			PredicateType: "test-type",
 			CreatedBy:     "test-user",
-			Time:          "2024-01-01T00:00:00Z",
+			CreatedAt:     "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
-				ChecksumVerificationStatus:   model.Failed,
+				Sha256VerificationStatus:     model.Failed,
 				SignaturesVerificationStatus: model.Failed,
 			},
 		}},
@@ -160,9 +164,9 @@ func TestVerifyEvidenceBase_PrintVerifyResult_UnknownFormat(t *testing.T) {
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			PredicateType: "test-type",
 			CreatedBy:     "test-user",
-			Time:          "2024-01-01T00:00:00Z",
+			CreatedAt:     "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
-				ChecksumVerificationStatus:   model.Success,
+				Sha256VerificationStatus:     model.Success,
 				SignaturesVerificationStatus: model.Success,
 			},
 		}},
@@ -289,10 +293,10 @@ func TestPrintText_Success(t *testing.T) {
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			PredicateType: "test-type",
 			CreatedBy:     "test-user",
-			Time:          "2024-01-01T00:00:00Z",
+			CreatedAt:     "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
 				SignaturesVerificationStatus: model.Success,
-				ChecksumVerificationStatus:   model.Success,
+				Sha256VerificationStatus:     model.Success,
 			},
 		}},
 	}
@@ -312,16 +316,18 @@ func TestPrintText_NilResponse(t *testing.T) {
 
 func TestPrintText_WithFullDetails(t *testing.T) {
 	resp := &model.VerificationResponse{
-		SubjectChecksum:           "test-checksum",
-		SubjectPath:               "test/path",
+		Subject: model.Subject{
+			Sha256: "test-checksum",
+			Path:   "test/path",
+		},
 		OverallVerificationStatus: model.Success,
 		EvidenceVerifications: &[]model.EvidenceVerification{{
 			SubjectChecksum: "test-checksum",
 			PredicateType:   "test-type",
 			CreatedBy:       "test-user",
-			Time:            "2024-01-01T00:00:00Z",
+			CreatedAt:       "2024-01-01T00:00:00Z",
 			VerificationResult: model.EvidenceVerificationResult{
-				ChecksumVerificationStatus:   model.Success,
+				Sha256VerificationStatus:     model.Success,
 				SignaturesVerificationStatus: model.Success,
 				KeySource:                    "test-key-source",
 				KeyFingerprint:               "test-fingerprint",
@@ -333,7 +339,7 @@ func TestPrintText_WithFullDetails(t *testing.T) {
 		err := printText(resp)
 		assert.NoError(t, err)
 	})
-	assert.Contains(t, out, "Subject digest sha256: test-checksum")
+	assert.Contains(t, out, "Subject sha256:        test-checksum")
 	assert.Contains(t, out, "Subject:               test/path")
 	assert.Contains(t, out, "Key source:                     test-key-source")
 	assert.Contains(t, out, "Key fingerprint:                test-fingerprint")
@@ -341,7 +347,9 @@ func TestPrintText_WithFullDetails(t *testing.T) {
 
 func TestPrintJson_Success(t *testing.T) {
 	resp := &model.VerificationResponse{
-		SubjectChecksum:           "test-checksum",
+		Subject: model.Subject{
+			Sha256: "test-checksum",
+		},
 		OverallVerificationStatus: model.Success,
 	}
 
@@ -435,7 +443,7 @@ func TestVerifyEvidenceBase_MultipleFormats(t *testing.T) {
 				EvidenceVerifications: &[]model.EvidenceVerification{{
 					PredicateType: "test-type",
 					CreatedBy:     "test-user",
-					Time:          "2024-01-01T00:00:00Z",
+					CreatedAt:     "2024-01-01T00:00:00Z",
 					VerificationResult: model.EvidenceVerificationResult{
 						SignaturesVerificationStatus: model.Success,
 					},

--- a/evidence/verify/verify_build_test.go
+++ b/evidence/verify/verify_build_test.go
@@ -339,8 +339,10 @@ func TestVerifyEvidenceBuild_Run_Success(t *testing.T) {
 
 	// Set up expectations for the mock verifier
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "/test/subject/path",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "/test/subject/path",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Success,
 	}
@@ -394,8 +396,10 @@ func TestVerifyEvidenceBuild_Run_VerificationFailed(t *testing.T) {
 
 	// Set up expectations for the mock verifier to return FAILED status
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "/test/subject/path",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "/test/subject/path",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Failed,
 	}

--- a/evidence/verify/verify_custom_test.go
+++ b/evidence/verify/verify_custom_test.go
@@ -308,8 +308,10 @@ func TestVerifyEvidenceCustom_Run_Success(t *testing.T) {
 	mockVerifier := &MockVerifierCustom{}
 	expectedResponse := &model.VerificationResponse{
 		OverallVerificationStatus: model.Success,
-		SubjectPath:               "test-repo/path/to/subject.txt",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "test-repo/path/to/subject.txt",
+			Sha256: "test-sha256",
+		},
 	}
 
 	// Set up the mock expectations - use mock.Anything for the subjectPath since it gets formatted

--- a/evidence/verify/verify_package_test.go
+++ b/evidence/verify/verify_package_test.go
@@ -351,8 +351,10 @@ func TestVerifyEvidencePackage_Run_Success(t *testing.T) {
 
 	// Set up expectations for the mock verifier
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "maven-local/test-package/1.0.0/test-package-1.0.0.jar",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "maven-local/test-package/1.0.0/test-package-1.0.0.jar",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Success,
 	}
@@ -408,8 +410,10 @@ func TestVerifyEvidencePackage_Run_VerificationFailed(t *testing.T) {
 
 	// Set up expectations for the mock verifier to return FAILED status
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "maven-local/test-package/1.0.0/test-package-1.0.0.jar",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "maven-local/test-package/1.0.0/test-package-1.0.0.jar",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Failed,
 	}

--- a/evidence/verify/verify_release_bundle_test.go
+++ b/evidence/verify/verify_release_bundle_test.go
@@ -128,8 +128,10 @@ func TestVerifyEvidenceReleaseBundle_Run_Success(t *testing.T) {
 
 	// Set up expectations for the mock verifier
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "/test/subject/path",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "/test/subject/path",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Success,
 	}
@@ -183,8 +185,10 @@ func TestVerifyEvidenceReleaseBundle_Run_VerificationFailed(t *testing.T) {
 
 	// Set up expectations for the mock verifier to return FAILED status
 	expectedResponse := &model.VerificationResponse{
-		SubjectPath:               "/test/subject/path",
-		SubjectChecksum:           "test-sha256",
+		Subject: model.Subject{
+			Path:   "/test/subject/path",
+			Sha256: "test-sha256",
+		},
 		EvidenceVerifications:     &[]model.EvidenceVerification{},
 		OverallVerificationStatus: model.Failed,
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
**Description**
This PR refactors the `VerificationResponse` struct in the evidence verification model to align its field naming and structure with the model used by the` jf evd get` command. Specifically, the `SubjectPath` and `SubjectChecksum` fields are now nested within a new `Subject` struct, improving consistency across evidence-related commands.
**Changes**
Refactored `VerificationResponse` to use a nested `Subject` struct (`Path` and `Sha256`).
Updated all affected test files in jfrog-cli-artifactory/evidence to use the new structure.
Fixed test assertions to match updated output where necessary.
