### PR TITLE
Added validation for repo types in vscode and jetbrains

### DIFF
--- a/artifactory/commands/ide/jetbrains/jetbrains.go
+++ b/artifactory/commands/ide/jetbrains/jetbrains.go
@@ -149,6 +149,10 @@ func (jc *JetbrainsCommand) validateRepository() error {
 	if err := utils.ValidateRepoExists(jc.repoKey, artDetails); err != nil {
 		return fmt.Errorf("repository validation failed: %w", err)
 	}
+	// Validate repository type is 'jetbrains'
+	if err := utils.ValidateRepoType(jc.repoKey, artDetails, "jetbrains"); err != nil {
+		return fmt.Errorf("repository type validation failed: %w", err)
+	}
 
 	log.Info("Repository validation successful")
 	return nil

--- a/artifactory/commands/ide/vscode/vscode.go
+++ b/artifactory/commands/ide/vscode/vscode.go
@@ -107,6 +107,10 @@ func (vc *VscodeCommand) validateRepository() error {
 	if err := utils.ValidateRepoExists(vc.repoKey, artDetails); err != nil {
 		return fmt.Errorf("repository validation failed: %w", err)
 	}
+	// Validate repository type is 'vscode'
+	if err := utils.ValidateRepoType(vc.repoKey, artDetails, "vscode"); err != nil {
+		return fmt.Errorf("repository type validation failed: %w", err)
+	}
 
 	log.Info("Repository validation successful")
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -180,6 +180,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.59.2-0.20250717045550-6e019038f578
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20250724072520-b037614985c5
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250717041744-d3ea4d99f4e7

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20250724072520-b037614985c5 h1:NXMJfuGzIbaSJQW0Q8S7Ase8I73WVrmoEB762JrK488=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20250724072520-b037614985c5/go.mod h1:Itfva9wqPMkUVBuNpKw0Oe4qoPlt0PdXfmWqf7fBebU=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -312,8 +314,6 @@ github.com/jfrog/froggit-go v1.17.0 h1:20Ie787WO27SwB2MOHDvsR6yN7fA5WfRnuAbmUqz1
 github.com/jfrog/froggit-go v1.17.0/go.mod h1:HvDkfFfJwIdsXFdqaB+utvD2cLDRmaC3kF8otYb6Chw=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.59.3 h1:AlFC9l3Cwvx2FzuAP0txxEjZPDjv5bpO7YPTOjHp7HA=
-github.com/jfrog/jfrog-cli-core/v2 v2.59.3/go.mod h1:Itfva9wqPMkUVBuNpKw0Oe4qoPlt0PdXfmWqf7fBebU=
 github.com/jfrog/jfrog-client-go v1.54.3 h1:tIhhDhM7rDMT1lzgeQy4nr6H2ihlqnumhiFybIWlLz0=
 github.com/jfrog/jfrog-client-go v1.54.3/go.mod h1:1v0eih4thdPA4clBo9TuvAMT25sGDr1IQJ81DXQ/lBY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
# Add Repository Type Validation for IDE Integrations (VSCode & JetBrains)

## Overview

This PR enhances the IDE integration commands (`vscode-config` and `jetbrains-config`) by adding validation to ensure that the specified Artifactory repository is not only present, but also of the correct type (`vscode` or `jetbrains`). This prevents misconfiguration and provides clearer error messages to users.

## Changes

- **VSCode & JetBrains Commands:**
  - After checking repository existence, the commands now validate that the repository's `packageType` matches the expected type.
  - If the type does not match, a clear error is returned to the user.
- **Dependency:**  
  - Relies on a new utility function (`ValidateRepoType`) added to `jfrog-cli-core`.

## Related

- Requires the corresponding update in `jfrog-cli-core` for the new utility function.
https://github.com/jfrog/jfrog-cli-core/pull/1421
