### PR TITLE
fix plural form of evidence word. It should be evidence instead of evidences

### DIFF
--- a/evidence/cli/command.go
+++ b/evidence/cli/command.go
@@ -10,5 +10,5 @@ import (
 type EvidenceCommands interface {
 	CreateEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
 	GetEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
-	VerifyEvidences(ctx *components.Context, serverDetails *config.ServerDetails) error
+	VerifyEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
 }

--- a/evidence/cli/command_build.go
+++ b/evidence/cli/command_build.go
@@ -47,13 +47,13 @@ func (ebc *evidenceBuildCommand) GetEvidence(ctx *components.Context, serverDeta
 	return errorutils.CheckErrorf("Get evidence is not supported with builds")
 }
 
-func (ebc *evidenceBuildCommand) VerifyEvidences(ctx *components.Context, serverDetails *config.ServerDetails) error {
+func (ebc *evidenceBuildCommand) VerifyEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
 	err := ebc.validateEvidenceBuildContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	verifyCmd := verify.NewVerifyEvidencesBuild(
+	verifyCmd := verify.NewVerifyEvidenceBuild(
 		serverDetails,
 		ebc.ctx.GetStringFlagValue(project),
 		ebc.ctx.GetStringFlagValue(buildName),

--- a/evidence/cli/command_cli.go
+++ b/evidence/cli/command_cli.go
@@ -40,12 +40,12 @@ func GetCommands() []components.Command {
 			Action:      getEvidence,
 		},
 		{
-			Name:        "verify-evidences",
+			Name:        "verify-evidence",
 			Aliases:     []string{"verify"},
 			Flags:       GetCommandFlags(VerifyEvidence),
 			Description: verify.GetDescription(),
 			Arguments:   verify.GetArguments(),
-			Action:      verifyEvidences,
+			Action:      verifyEvidence,
 		},
 	}
 }
@@ -123,7 +123,7 @@ func validateGetEvidenceCommonContext(ctx *components.Context) error {
 	return nil
 }
 
-func verifyEvidences(ctx *components.Context) error {
+func verifyEvidence(ctx *components.Context) error {
 	// validate common context
 	serverDetails, err := evidenceDetailsByFlags(ctx)
 	if err != nil {
@@ -144,7 +144,7 @@ func verifyEvidences(ctx *components.Context) error {
 		packageName:     NewEvidencePackageCommand,
 	}
 	if commandFunc, exists := evidenceCommands[subjectType[0]]; exists {
-		err = commandFunc(ctx, execFunc).VerifyEvidences(ctx, serverDetails)
+		err = commandFunc(ctx, execFunc).VerifyEvidence(ctx, serverDetails)
 		if err != nil {
 			if err.Error() != "" {
 				return fmt.Errorf("evidence verification failed: %w", err)

--- a/evidence/cli/command_cli_test.go
+++ b/evidence/cli/command_cli_test.go
@@ -340,7 +340,7 @@ func TestVerifyEvidence_Context(t *testing.T) {
 			// Replace execFunc with the mockExec function
 			defer func() { execFunc = exec }() // Restore original execFunc after test
 
-			err := verifyEvidences(context)
+			err := verifyEvidence(context)
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/evidence/cli/command_custom.go
+++ b/evidence/cli/command_custom.go
@@ -53,7 +53,7 @@ func (ecc *evidenceCustomCommand) GetEvidence(_ *components.Context, serverDetai
 	return ecc.execute(getCmd)
 }
 
-func (ecc *evidenceCustomCommand) VerifyEvidences(_ *components.Context, serverDetails *config.ServerDetails) error {
+func (ecc *evidenceCustomCommand) VerifyEvidence(_ *components.Context, serverDetails *config.ServerDetails) error {
 	verifyCmd := verify.NewVerifyEvidenceCustom(
 		serverDetails,
 		ecc.ctx.GetStringFlagValue(subjectRepoPath),

--- a/evidence/cli/command_github.go
+++ b/evidence/cli/command_github.go
@@ -47,8 +47,8 @@ func (ebc *evidenceGitHubCommand) CreateEvidence(ctx *components.Context, server
 	return ebc.execute(createCmd)
 }
 
-func (ebc *evidenceGitHubCommand) VerifyEvidences(_ *components.Context, _ *config.ServerDetails) error {
-	return errorutils.CheckErrorf("Verify evidences is not supported with github")
+func (ebc *evidenceGitHubCommand) VerifyEvidence(_ *components.Context, _ *config.ServerDetails) error {
+	return errorutils.CheckErrorf("Verify evidence is not supported with github")
 
 }
 

--- a/evidence/cli/command_package.go
+++ b/evidence/cli/command_package.go
@@ -47,7 +47,7 @@ func (epc *evidencePackageCommand) GetEvidence(ctx *components.Context, serverDe
 	return errorutils.CheckErrorf("Get evidence is not supported with packages")
 }
 
-func (epc *evidencePackageCommand) VerifyEvidences(ctx *components.Context, serverDetails *config.ServerDetails) error {
+func (epc *evidencePackageCommand) VerifyEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
 	err := epc.validateEvidencePackageContext(ctx)
 	if err != nil {
 		return err

--- a/evidence/cli/command_release_bundle.go
+++ b/evidence/cli/command_release_bundle.go
@@ -64,7 +64,7 @@ func (erc *evidenceReleaseBundleCommand) GetEvidence(ctx *components.Context, se
 	return erc.execute(getCmd)
 }
 
-func (erc *evidenceReleaseBundleCommand) VerifyEvidences(ctx *components.Context, serverDetails *config.ServerDetails) error {
+func (erc *evidenceReleaseBundleCommand) VerifyEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
 	err := erc.validateEvidenceReleaseBundleContext(ctx)
 	if err != nil {
 		return err

--- a/evidence/cli/flags.go
+++ b/evidence/cli/flags.go
@@ -9,7 +9,7 @@ const (
 	// Evidence commands keys
 	CreateEvidence = "create-evidence"
 	GetEvidence    = "get-evidence"
-	VerifyEvidence = "verify-evidences"
+	VerifyEvidence = "verify-evidence"
 )
 
 const (

--- a/evidence/get/get_release_bundle.go
+++ b/evidence/get/get_release_bundle.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-// A graphql query to get evidence for a release bundle including evidences on artifacts and builds inside the release bundle.
+// A graphql query to get evidence for a release bundle including evidence on artifacts and builds inside the release bundle.
 // Artifacts in release bundle will be given from the first artifact YXJ0aWZhY3Q6MA== which is base64 of artifact:0
 const getReleaseBundleEvidenceWithoutPredicateGraphqlQuery = "{\"query\":\"{ releaseBundleVersion { getVersion(repositoryKey: \\\"%s\\\", name: \\\"%s\\\", version: \\\"%s\\\") { evidenceConnection { edges { node { predicateSlug predicateType downloadPath verified signingKey { alias } createdBy createdAt } } } artifactsConnection(first: %s, after: \\\"YXJ0aWZhY3Q6MA==\\\", where: { hasEvidence: true }) { totalCount edges { node { sourceRepositoryPath packageType evidenceConnection(first: 0) { totalCount edges { node { createdBy createdAt downloadPath predicateSlug verified signingKey { alias }} } } } } } fromBuilds { name number startedAt evidenceConnection { edges { node { predicateSlug predicateType downloadPath verified signingKey { alias } createdBy createdAt } } } } } } }\"}"
 
@@ -63,12 +63,12 @@ func (g *getEvidenceReleaseBundle) Run() error {
 		return err
 	}
 
-	evidences, err := g.getEvidence(onemodelClient)
+	evidenceRecords, err := g.getEvidence(onemodelClient)
 	if err != nil {
 		return err
 	}
 
-	err = g.exportEvidenceToFile(evidences, g.outputFileName, g.format)
+	err = g.exportEvidenceToFile(evidenceRecords, g.outputFileName, g.format)
 	if err != nil {
 		return err
 	}

--- a/evidence/verify/verify_base.go
+++ b/evidence/verify/verify_base.go
@@ -120,7 +120,7 @@ func printText(result *model.VerificationResponse) error {
 	fmt.Printf("Subject sha256:        %s\n", result.Subject.Sha256)
 	fmt.Printf("Subject:               %s\n", result.Subject.Path)
 	evidenceNumber := len(*result.EvidenceVerifications)
-	fmt.Printf("Loaded %d evidence items\n", evidenceNumber)
+	fmt.Printf("Loaded %d evidence\n", evidenceNumber)
 	successfulVerifications := 0
 	for _, v := range *result.EvidenceVerifications {
 		if v.VerificationResult.Sha256VerificationStatus == model.Success && v.VerificationResult.SignaturesVerificationStatus == model.Success {
@@ -128,7 +128,7 @@ func printText(result *model.VerificationResponse) error {
 		}
 	}
 	fmt.Println()
-	verificationStatusMessage := fmt.Sprintf("Verification passed for %d out of %d evidence items", successfulVerifications, evidenceNumber)
+	verificationStatusMessage := fmt.Sprintf("Verification passed for %d out of %d evidence", successfulVerifications, evidenceNumber)
 	switch {
 	case successfulVerifications == 0:
 		fmt.Println(color.Red.Render(verificationStatusMessage))
@@ -148,7 +148,7 @@ func printText(result *model.VerificationResponse) error {
 }
 
 func printVerificationResult(verification *model.EvidenceVerification, index int) {
-	fmt.Printf("- Evidence: %d\n", index+1)
+	fmt.Printf("- Evidence %d:\n", index+1)
 	fmt.Printf("    - Predicate type:                 %s\n", verification.PredicateType)
 	fmt.Printf("    - Evidence subject sha256:        %s\n", verification.SubjectChecksum)
 	if verification.VerificationResult.KeySource != "" {

--- a/evidence/verify/verify_base.go
+++ b/evidence/verify/verify_base.go
@@ -40,8 +40,8 @@ func (v *verifyEvidenceBase) printVerifyResult(result *model.VerificationRespons
 	return printText(result)
 }
 
-// verifyEvidences runs the verification process for the given evidence metadata and subject sha256.
-func (v *verifyEvidenceBase) verifyEvidences(client *artifactory.ArtifactoryServicesManager, evidenceMetadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
+// verifyEvidence runs the verification process for the given evidence metadata and subject sha256.
+func (v *verifyEvidenceBase) verifyEvidence(client *artifactory.ArtifactoryServicesManager, evidenceMetadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
 	if v.verifier == nil {
 		v.verifier = NewEvidenceVerifier(v.keys, v.useArtifactoryKeys, client)
 	}
@@ -87,12 +87,12 @@ func (v *verifyEvidenceBase) queryEvidenceMetadata(repo string, path string, nam
 		}
 		return nil, fmt.Errorf("error querying evidence from One-Model service: %w", err)
 	}
-	evidences := model.ResponseSearchEvidence{}
-	err = json.Unmarshal(response, &evidences)
+	evidence := model.ResponseSearchEvidence{}
+	err = json.Unmarshal(response, &evidence)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal evidence metadata: %w", err)
 	}
-	edges := evidences.Data.Evidence.SearchEvidence.Edges
+	edges := evidence.Data.Evidence.SearchEvidence.Edges
 	if len(edges) == 0 {
 		return nil, fmt.Errorf("no evidence found for the given subject")
 	}
@@ -120,13 +120,7 @@ func printText(result *model.VerificationResponse) error {
 	fmt.Printf("Subject sha256:        %s\n", result.Subject.Sha256)
 	fmt.Printf("Subject:               %s\n", result.Subject.Path)
 	evidenceNumber := len(*result.EvidenceVerifications)
-	var evidenceText string
-	if evidenceNumber == 1 {
-		evidenceText = "evidence"
-	} else {
-		evidenceText = "evidences"
-	}
-	fmt.Printf("Loaded %d %s\n", evidenceNumber, evidenceText)
+	fmt.Printf("Loaded %d evidence items\n", evidenceNumber)
 	successfulVerifications := 0
 	for _, v := range *result.EvidenceVerifications {
 		if v.VerificationResult.Sha256VerificationStatus == model.Success && v.VerificationResult.SignaturesVerificationStatus == model.Success {
@@ -134,7 +128,7 @@ func printText(result *model.VerificationResponse) error {
 		}
 	}
 	fmt.Println()
-	verificationStatusMessage := fmt.Sprintf("Verification passed for %d out of %d %s", successfulVerifications, evidenceNumber, evidenceText)
+	verificationStatusMessage := fmt.Sprintf("Verification passed for %d out of %d evidence items", successfulVerifications, evidenceNumber)
 	switch {
 	case successfulVerifications == 0:
 		fmt.Println(color.Red.Render(verificationStatusMessage))

--- a/evidence/verify/verify_base_test.go
+++ b/evidence/verify/verify_base_test.go
@@ -308,6 +308,42 @@ func TestPrintText_Success(t *testing.T) {
 	assert.Contains(t, out, "Verification passed for 1 out of 1 evidence")
 }
 
+func TestPrintText_severalEvidence_Success(t *testing.T) {
+	resp := &model.VerificationResponse{
+		Subject: model.Subject{
+			Sha256: "test-checksum",
+			Path:   "test-file.txt",
+		},
+		OverallVerificationStatus: model.Success,
+		EvidenceVerifications: &[]model.EvidenceVerification{{
+			PredicateType: "test-type",
+			CreatedBy:     "test-user",
+			CreatedAt:     "2024-01-01T00:00:00Z",
+			VerificationResult: model.EvidenceVerificationResult{
+				SignaturesVerificationStatus: model.Success,
+				Sha256VerificationStatus:     model.Success,
+			},
+		}, {
+			PredicateType: "test-type-2",
+			CreatedBy:     "test-user-2",
+			CreatedAt:     "2024-01-02T00:00:00Z",
+			VerificationResult: model.EvidenceVerificationResult{
+				SignaturesVerificationStatus: model.Success,
+				Sha256VerificationStatus:     model.Success,
+			},
+		}},
+	}
+
+	out := captureOutput(func() {
+		err := printText(resp)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "Subject sha256:        test-checksum")
+	assert.Contains(t, out, "Subject:               test-file.txt")
+	assert.Contains(t, out, "Loaded 2 evidence")
+	assert.Contains(t, out, "Verification passed for 2 out of 2 evidence")
+}
+
 func TestPrintText_NilResponse(t *testing.T) {
 	err := printText(nil)
 	assert.Error(t, err)

--- a/evidence/verify/verify_build.go
+++ b/evidence/verify/verify_build.go
@@ -19,8 +19,8 @@ type verifyEvidenceBuild struct {
 	buildNumber string
 }
 
-// NewVerifyEvidencesBuild creates a new command for verifying evidence for a build.
-func NewVerifyEvidencesBuild(serverDetails *config.ServerDetails, project, buildName, buildNumber, format string, keys []string, useArtifactoryKeys bool) evidence.Command {
+// NewVerifyEvidenceBuild creates a new command for verifying evidence for a build.
+func NewVerifyEvidenceBuild(serverDetails *config.ServerDetails, project, buildName, buildNumber, format string, keys []string, useArtifactoryKeys bool) evidence.Command {
 	return &verifyEvidenceBuild{
 		verifyEvidenceBase: verifyEvidenceBase{
 			serverDetails:      serverDetails,
@@ -59,7 +59,7 @@ func (v *verifyEvidenceBuild) Run() error {
 	}
 
 	subjectPath := fmt.Sprintf("%s/%s/%s", repoKey, v.buildName, subjectFileName)
-	return v.verifyEvidences(client, metadata, buildInfoSha256, subjectPath)
+	return v.verifyEvidence(client, metadata, buildInfoSha256, subjectPath)
 }
 
 // ServerDetails returns the server details for the command.

--- a/evidence/verify/verify_build_test.go
+++ b/evidence/verify/verify_build_test.go
@@ -55,13 +55,13 @@ func (m *MockOneModelManagerBuild) GraphqlQuery(_ []byte) ([]byte, error) {
 	return m.GraphqlResponse, nil
 }
 
-// MockVerifyEvidenceBaseBuild for testing verifyEvidences method
+// MockVerifyEvidenceBaseBuild for testing verifyEvidence method
 type MockVerifyEvidenceBaseBuild struct {
 	mock.Mock
 	verifyEvidenceBase
 }
 
-func (m *MockVerifyEvidenceBaseBuild) verifyEvidences(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
+func (m *MockVerifyEvidenceBaseBuild) verifyEvidence(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
 	args := m.Called(client, metadata, sha256, subjectPath)
 	return args.Error(0)
 }
@@ -84,7 +84,7 @@ func (m *MockVerifier) Verify(subjectSha256 string, evidenceMetadata *[]model.Se
 	return resp, args.Error(1)
 }
 
-func TestNewVerifyEvidencesBuild(t *testing.T) {
+func TestNewVerifyEvidenceBuild(t *testing.T) {
 	serverDetails := &config.ServerDetails{}
 	project := "test-project"
 	buildName := "test-build"
@@ -92,7 +92,7 @@ func TestNewVerifyEvidencesBuild(t *testing.T) {
 	format := "json"
 	keys := []string{"key1", "key2"}
 
-	cmd := NewVerifyEvidencesBuild(serverDetails, project, buildName, buildNumber, format, keys, true)
+	cmd := NewVerifyEvidenceBuild(serverDetails, project, buildName, buildNumber, format, keys, true)
 	verifyCmd, ok := cmd.(*verifyEvidenceBuild)
 	assert.True(t, ok)
 
@@ -211,7 +211,7 @@ func TestVerifyEvidenceBuild_Run_QueryEvidenceMetadataError(t *testing.T) {
 	assert.Contains(t, err.Error(), "graphql query failed")
 }
 
-func TestVerifyEvidenceBuild_Run_VerifyEvidencesError(t *testing.T) {
+func TestVerifyEvidenceBuild_Run_VerifyEvidenceError(t *testing.T) {
 	// Mock AQL response with build info file
 	aqlResult := `{"results":[{"sha256":"test-sha256","name":"1-1234567890.json"}]}`
 
@@ -236,10 +236,10 @@ func TestVerifyEvidenceBuild_Run_VerifyEvidencesError(t *testing.T) {
 		oneModelClient: mockOneModel,
 	}
 	mockBase.verifyEvidenceBase = *base
-	mockBase.On("verifyEvidences", mock.Anything, mock.Anything, "test-sha256", mock.Anything).Return(errors.New("verification failed"))
+	mockBase.On("verifyEvidence", mock.Anything, mock.Anything, "test-sha256", mock.Anything).Return(errors.New("verification failed"))
 
 	// Test direct method call
-	err := mockBase.verifyEvidences(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256", "/test/path")
+	err := mockBase.verifyEvidence(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256", "/test/path")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "verification failed")
 	mockBase.AssertExpectations(t)

--- a/evidence/verify/verify_custom.go
+++ b/evidence/verify/verify_custom.go
@@ -54,7 +54,7 @@ func (v *verifyEvidenceCustom) Run() error {
 		return err
 	}
 	subjectSha256 := result.Results[0].Sha256
-	return v.verifyEvidences(client, metadata, subjectSha256, v.subjectRepoPath)
+	return v.verifyEvidence(client, metadata, subjectSha256, v.subjectRepoPath)
 }
 
 func extractSubjectRepoPathName(v *verifyEvidenceCustom) (string, string, string, error) {

--- a/evidence/verify/verify_custom_test.go
+++ b/evidence/verify/verify_custom_test.go
@@ -40,13 +40,13 @@ func (m *MockOneModelManagerCustom) GraphqlQuery(_ []byte) ([]byte, error) {
 	return m.GraphqlResponse, nil
 }
 
-// MockVerifyEvidenceBaseCustom for testing verifyEvidences method
+// MockVerifyEvidenceBaseCustom for testing verifyEvidence method
 type MockVerifyEvidenceBaseCustom struct {
 	mock.Mock
 	verifyEvidenceBase
 }
 
-func (m *MockVerifyEvidenceBaseCustom) verifyEvidences(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
+func (m *MockVerifyEvidenceBaseCustom) verifyEvidence(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256, subjectPath string) error {
 	args := m.Called(client, metadata, sha256, subjectPath)
 	return args.Error(0)
 }
@@ -68,7 +68,7 @@ func (m *MockVerifierCustom) Verify(subjectSha256 string, evidenceMetadata *[]mo
 	return resp, args.Error(1)
 }
 
-func TestNewVerifyEvidencesCustom(t *testing.T) {
+func TestNewVerifyEvidenceCustom(t *testing.T) {
 	serverDetails := &config.ServerDetails{}
 	subjectRepoPath := "test-repo/path/to/subject.txt"
 	format := "json"
@@ -185,7 +185,7 @@ func TestVerifyEvidenceCustom_Run_QueryEvidenceMetadataError(t *testing.T) {
 	assert.Contains(t, err.Error(), "graphql query failed")
 }
 
-func TestVerifyEvidenceCustom_Run_VerifyEvidencesError(t *testing.T) {
+func TestVerifyEvidenceCustom_Run_VerifyEvidenceError(t *testing.T) {
 	// Mock AQL response with subject file
 	aqlResult := `{"results":[{"sha256":"test-sha256","name":"subject.txt","repo":"test-repo","path":"path/to"}]}`
 
@@ -210,10 +210,10 @@ func TestVerifyEvidenceCustom_Run_VerifyEvidencesError(t *testing.T) {
 		oneModelClient: mockOneModel,
 	}
 	mockBase.verifyEvidenceBase = *base
-	mockBase.On("verifyEvidences", mock.Anything, mock.Anything, "test-sha256", mock.Anything).Return(errors.New("verification failed"))
+	mockBase.On("verifyEvidence", mock.Anything, mock.Anything, "test-sha256", mock.Anything).Return(errors.New("verification failed"))
 
 	// Test direct method call
-	err := mockBase.verifyEvidences(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256", "test-path")
+	err := mockBase.verifyEvidence(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256", "test-path")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "verification failed")
 	mockBase.AssertExpectations(t)

--- a/evidence/verify/verify_package.go
+++ b/evidence/verify/verify_package.go
@@ -86,5 +86,5 @@ func (c *verifyEvidencePackage) Run() error {
 		return err
 	}
 	subjectPath := fmt.Sprintf("%s/%s/%s", c.packageService.GetPackageRepoName(), path, fileName)
-	return c.verifyEvidences(artifactoryClient, metadata, packageSha256, subjectPath)
+	return c.verifyEvidence(artifactoryClient, metadata, packageSha256, subjectPath)
 }

--- a/evidence/verify/verify_package_test.go
+++ b/evidence/verify/verify_package_test.go
@@ -65,13 +65,13 @@ func (m *MockOneModelManagerPackage) GraphqlQuery(_ []byte) ([]byte, error) {
 	return m.GraphqlResponse, nil
 }
 
-// MockVerifyEvidenceBasePackage for testing verifyEvidences method
+// MockVerifyEvidenceBasePackage for testing verifyEvidence method
 type MockVerifyEvidenceBasePackage struct {
 	mock.Mock
 	verifyEvidenceBase
 }
 
-func (m *MockVerifyEvidenceBasePackage) verifyEvidences(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256 string) error {
+func (m *MockVerifyEvidenceBasePackage) verifyEvidence(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256 string) error {
 	args := m.Called(client, metadata, sha256)
 	return args.Error(0)
 }
@@ -273,7 +273,7 @@ func TestVerifyEvidencePackage_Run_QueryEvidenceMetadataError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error querying evidence from One-Model service: graphql query failed")
 }
 
-func TestVerifyEvidencePackage_Run_VerifyEvidencesError(t *testing.T) {
+func TestVerifyEvidencePackage_Run_VerifyEvidenceError(t *testing.T) {
 	// Mock AQL response with package file
 	aqlResult := `{"results":[{"sha256":"test-sha256","name":"test-package-1.0.0.jar"}]}`
 
@@ -302,10 +302,10 @@ func TestVerifyEvidencePackage_Run_VerifyEvidencesError(t *testing.T) {
 		oneModelClient: mockOneModel,
 	}
 	mockBase.verifyEvidenceBase = *base
-	mockBase.On("verifyEvidences", mock.Anything, mock.Anything, "test-sha256").Return(errors.New("verification failed"))
+	mockBase.On("verifyEvidence", mock.Anything, mock.Anything, "test-sha256").Return(errors.New("verification failed"))
 
 	// Test direct method call
-	err := mockBase.verifyEvidences(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
+	err := mockBase.verifyEvidence(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "verification failed")
 	mockBase.AssertExpectations(t)

--- a/evidence/verify/verify_release_bundle.go
+++ b/evidence/verify/verify_release_bundle.go
@@ -67,5 +67,5 @@ func (c *verifyEvidenceReleaseBundle) Run() error {
 	}
 	subjectPath := fmt.Sprintf("%s/%s/%s", repoKey, path, "release-bundle.json.evd")
 	releaseBundleSha256 := result.Results[0].Sha256
-	return c.verifyEvidences(artifactoryClient, metadata, releaseBundleSha256, subjectPath)
+	return c.verifyEvidence(artifactoryClient, metadata, releaseBundleSha256, subjectPath)
 }

--- a/evidence/verify/verify_release_bundle_test.go
+++ b/evidence/verify/verify_release_bundle_test.go
@@ -47,7 +47,7 @@ type MockVerifyEvidenceBaseReleaseBundle struct {
 	verifyEvidenceBase
 }
 
-func (m *MockVerifyEvidenceBaseReleaseBundle) verifyEvidences(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256 string) error {
+func (m *MockVerifyEvidenceBaseReleaseBundle) verifyEvidence(client *artifactory.ArtifactoryServicesManager, metadata *[]model.SearchEvidenceEdge, sha256 string) error {
 	args := m.Called(client, metadata, sha256)
 	return args.Error(0)
 }
@@ -363,7 +363,7 @@ func TestVerifyEvidenceReleaseBundle_Run_QueryEvidenceMetadataError(t *testing.T
 	assert.Contains(t, err.Error(), "graphql query failed")
 }
 
-func TestVerifyEvidenceReleaseBundle_Run_VerifyEvidencesError(t *testing.T) {
+func TestVerifyEvidenceReleaseBundle_Run_VerifyEvidenceError(t *testing.T) {
 	// Mock AQL response with release bundle manifest
 	aqlResult := `{"results":[{"sha256":"test-sha256","name":"release-bundle.json.evd"}]}`
 
@@ -388,10 +388,10 @@ func TestVerifyEvidenceReleaseBundle_Run_VerifyEvidencesError(t *testing.T) {
 		oneModelClient: mockOneModel,
 	}
 	mockBase.verifyEvidenceBase = *base
-	mockBase.On("verifyEvidences", mock.Anything, mock.Anything, "test-sha256").Return(errors.New("verification failed"))
+	mockBase.On("verifyEvidence", mock.Anything, mock.Anything, "test-sha256").Return(errors.New("verification failed"))
 
 	// Test direct method call
-	err := mockBase.verifyEvidences(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
+	err := mockBase.verifyEvidence(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "verification failed")
 	mockBase.AssertExpectations(t)
@@ -460,10 +460,10 @@ func TestVerifyEvidenceReleaseBundle_ProjectBuildRepoKey(t *testing.T) {
 				oneModelClient: mockOneModel,
 			}
 			mockBase.verifyEvidenceBase = *base
-			mockBase.On("verifyEvidences", mock.Anything, mock.Anything, "test-sha256").Return(nil)
+			mockBase.On("verifyEvidence", mock.Anything, mock.Anything, "test-sha256").Return(nil)
 
 			// Test direct method call
-			err := mockBase.verifyEvidences(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
+			err := mockBase.verifyEvidence(nil, &[]model.SearchEvidenceEdge{{}}, "test-sha256")
 			assert.NoError(t, err)
 			mockBase.AssertExpectations(t)
 		})


### PR DESCRIPTION

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
**Description**

This pull request addresses an issue with the usage of the term "evidence" within the codebase. The word "evidences" is incorrect as "evidence" is an uncountable noun and does not take a plural form.
