### PR TITLE
add delete evidence cli command which resolves subjectRepoPath and de…

### DIFF
--- a/evidence/cli/command.go
+++ b/evidence/cli/command.go
@@ -11,4 +11,5 @@ type EvidenceCommands interface {
 	CreateEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
 	GetEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
 	VerifyEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
+	DeleteEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error
 }

--- a/evidence/cli/command_build.go
+++ b/evidence/cli/command_build.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/create"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/delete"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/resolver"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/verify"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -63,6 +65,29 @@ func (ebc *evidenceBuildCommand) VerifyEvidence(ctx *components.Context, serverD
 		ebc.ctx.GetBoolFlagValue(useArtifactoryKeys),
 	)
 	return ebc.execute(verifyCmd)
+}
+
+func (ebc *evidenceBuildCommand) DeleteEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
+	err := ebc.validateEvidenceBuildContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	buildResolver, err := resolver.NewBuildPathResolver(
+		ebc.ctx.GetStringFlagValue(project),
+		ebc.ctx.GetStringFlagValue(buildName),
+		ebc.ctx.GetStringFlagValue(buildNumber),
+		serverDetails,
+	)
+	if err != nil {
+		return err
+	}
+	deleteCmd := delete.NewDeleteEvidenceBase(
+		serverDetails,
+		ebc.ctx.GetStringFlagValue(evidenceName),
+		buildResolver,
+	)
+	return ebc.execute(deleteCmd)
 }
 
 func (ebc *evidenceBuildCommand) validateEvidenceBuildContext(ctx *components.Context) error {

--- a/evidence/cli/command_build_test.go
+++ b/evidence/cli/command_build_test.go
@@ -95,7 +95,7 @@ func TestEvidenceBuildCommand_DeleteEvidence(t *testing.T) {
 		return nil
 	}
 	cmd := NewEvidenceBuildCommand(ctx, mockExec)
-	serverDetails := &config.ServerDetails{Url: "http://x"}
+	serverDetails := &config.ServerDetails{Url: "url"}
 
 	err = cmd.DeleteEvidence(ctx, serverDetails)
 	assert.NoError(t, err)

--- a/evidence/cli/command_build_test.go
+++ b/evidence/cli/command_build_test.go
@@ -72,3 +72,32 @@ func TestEvidenceBuildCommand_CreateEvidence_SigstoreBundle(t *testing.T) {
 		})
 	}
 }
+
+func TestEvidenceBuildCommand_DeleteEvidence(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{{Name: "delete"}}
+	set := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(app, set, nil)
+
+	flags := []components.Flag{
+		setDefaultValue(project, "proj"),
+		setDefaultValue(buildName, "bname"),
+		setDefaultValue(buildNumber, "1"),
+		setDefaultValue(evidenceName, "evd"),
+	}
+
+	ctx, err := components.ConvertContext(cliCtx, flags...)
+	assert.NoError(t, err)
+
+	called := false
+	mockExec := func(cmd commands.Command) error {
+		called = true
+		return nil
+	}
+	cmd := NewEvidenceBuildCommand(ctx, mockExec)
+	serverDetails := &config.ServerDetails{Url: "http://x"}
+
+	err = cmd.DeleteEvidence(ctx, serverDetails)
+	assert.NoError(t, err)
+	assert.True(t, called)
+}

--- a/evidence/cli/command_custom.go
+++ b/evidence/cli/command_custom.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/create"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/delete"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/get"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/resolver"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/verify"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -62,4 +64,14 @@ func (ecc *evidenceCustomCommand) VerifyEvidence(_ *components.Context, serverDe
 		ecc.ctx.GetBoolFlagValue(useArtifactoryKeys),
 	)
 	return ecc.execute(verifyCmd)
+}
+
+func (ecc *evidenceCustomCommand) DeleteEvidence(_ *components.Context, serverDetails *config.ServerDetails) error {
+	deleteCmd := delete.NewDeleteEvidenceBase(
+		serverDetails,
+		ecc.ctx.GetStringFlagValue(evidenceName),
+		resolver.NewCustomPathResolver(ecc.ctx.GetStringFlagValue(subjectRepoPath)),
+	)
+
+	return ecc.execute(deleteCmd)
 }

--- a/evidence/cli/command_custom_test.go
+++ b/evidence/cli/command_custom_test.go
@@ -80,3 +80,30 @@ func TestEvidenceCustomCommand_CreateEvidence_SigstoreBundle(t *testing.T) {
 		})
 	}
 }
+
+func TestEvidenceCustomCommand_DeleteEvidence(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{{Name: "delete"}}
+	set := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(app, set, nil)
+
+	flags := []components.Flag{
+		setDefaultValue(subjectRepoPath, "repo/path/artifact"),
+		setDefaultValue(evidenceName, "evd"),
+	}
+
+	ctx, err := components.ConvertContext(cliCtx, flags...)
+	assert.NoError(t, err)
+
+	called := false
+	mockExec := func(cmd commands.Command) error {
+		called = true
+		return nil
+	}
+	cmd := NewEvidenceCustomCommand(ctx, mockExec)
+	serverDetails := &config.ServerDetails{Url: "http://x"}
+
+	err = cmd.DeleteEvidence(ctx, serverDetails)
+	assert.NoError(t, err)
+	assert.True(t, called)
+}

--- a/evidence/cli/command_custom_test.go
+++ b/evidence/cli/command_custom_test.go
@@ -101,7 +101,7 @@ func TestEvidenceCustomCommand_DeleteEvidence(t *testing.T) {
 		return nil
 	}
 	cmd := NewEvidenceCustomCommand(ctx, mockExec)
-	serverDetails := &config.ServerDetails{Url: "http://x"}
+	serverDetails := &config.ServerDetails{Url: "url"}
 
 	err = cmd.DeleteEvidence(ctx, serverDetails)
 	assert.NoError(t, err)

--- a/evidence/cli/command_github.go
+++ b/evidence/cli/command_github.go
@@ -52,6 +52,10 @@ func (ebc *evidenceGitHubCommand) VerifyEvidence(_ *components.Context, _ *confi
 
 }
 
+func (ebc *evidenceGitHubCommand) DeleteEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
+	return errorutils.CheckErrorf("Delete evidence is not supported with github")
+}
+
 func (ebc *evidenceGitHubCommand) validateEvidenceBuildContext(ctx *components.Context) error {
 	if !ctx.IsFlagSet(buildNumber) || assertValueProvided(ctx, buildNumber) != nil {
 		return errorutils.CheckErrorf("--%s is a mandatory field for creating a Release Bundle evidence", buildNumber)

--- a/evidence/cli/command_package.go
+++ b/evidence/cli/command_package.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/create"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/delete"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/resolver"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/verify"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -63,6 +65,31 @@ func (epc *evidencePackageCommand) VerifyEvidence(ctx *components.Context, serve
 		epc.ctx.GetBoolFlagValue(useArtifactoryKeys),
 	)
 	return epc.execute(verifyCmd)
+}
+
+func (epc *evidencePackageCommand) DeleteEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
+	err := epc.validateEvidencePackageContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	pathResolver, err := resolver.NewPackagePathResolver(
+		epc.ctx.GetStringFlagValue(packageName),
+		epc.ctx.GetStringFlagValue(packageVersion),
+		epc.ctx.GetStringFlagValue(packageRepoName),
+		serverDetails,
+	)
+	if err != nil {
+		return err
+	}
+
+	deleteCmd := delete.NewDeleteEvidenceBase(
+		serverDetails,
+		epc.ctx.GetStringFlagValue(evidenceName),
+		pathResolver,
+	)
+
+	return epc.execute(deleteCmd)
 }
 
 func (epc *evidencePackageCommand) validateEvidencePackageContext(ctx *components.Context) error {

--- a/evidence/cli/command_package_test.go
+++ b/evidence/cli/command_package_test.go
@@ -74,3 +74,32 @@ func TestEvidencePackageCommand_CreateEvidence_SigstoreBundle(t *testing.T) {
 		})
 	}
 }
+
+func TestEvidencePackageCommand_DeleteEvidence(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{{Name: "delete"}}
+	set := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(app, set, nil)
+
+	flags := []components.Flag{
+		setDefaultValue(packageName, "pkg"),
+		setDefaultValue(packageVersion, "1.2.3"),
+		setDefaultValue(packageRepoName, "repo"),
+		setDefaultValue(evidenceName, "evd"),
+	}
+
+	ctx, err := components.ConvertContext(cliCtx, flags...)
+	assert.NoError(t, err)
+
+	called := false
+	mockExec := func(cmd commands.Command) error {
+		called = true
+		return nil
+	}
+	cmd := NewEvidencePackageCommand(ctx, mockExec)
+	serverDetails := &config.ServerDetails{Url: "http://x"}
+
+	err = cmd.DeleteEvidence(ctx, serverDetails)
+	assert.NoError(t, err)
+	assert.True(t, called)
+}

--- a/evidence/cli/command_package_test.go
+++ b/evidence/cli/command_package_test.go
@@ -97,7 +97,7 @@ func TestEvidencePackageCommand_DeleteEvidence(t *testing.T) {
 		return nil
 	}
 	cmd := NewEvidencePackageCommand(ctx, mockExec)
-	serverDetails := &config.ServerDetails{Url: "http://x"}
+	serverDetails := &config.ServerDetails{Url: "url"}
 
 	err = cmd.DeleteEvidence(ctx, serverDetails)
 	assert.NoError(t, err)

--- a/evidence/cli/command_release_bundle.go
+++ b/evidence/cli/command_release_bundle.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/commonutils"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/create"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/delete"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/get"
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/resolver"
 	"github.com/jfrog/jfrog-cli-artifactory/evidence/verify"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -80,6 +82,25 @@ func (erc *evidenceReleaseBundleCommand) VerifyEvidence(ctx *components.Context,
 		erc.ctx.GetBoolFlagValue(useArtifactoryKeys),
 	)
 	return erc.execute(verifyCmd)
+}
+
+func (erc *evidenceReleaseBundleCommand) DeleteEvidence(ctx *components.Context, serverDetails *config.ServerDetails) error {
+	err := erc.validateEvidenceReleaseBundleContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	deleteCmd := delete.NewDeleteEvidenceBase(
+		serverDetails,
+		erc.ctx.GetStringFlagValue(evidenceName),
+		resolver.NewReleaseBundlePathResolver(
+			erc.ctx.GetStringFlagValue(project),
+			erc.ctx.GetStringFlagValue(releaseBundle),
+			erc.ctx.GetStringFlagValue(releaseBundleVersion),
+		),
+	)
+
+	return erc.execute(deleteCmd)
 }
 
 func (erc *evidenceReleaseBundleCommand) validateEvidenceReleaseBundleContext(ctx *components.Context) error {

--- a/evidence/cli/command_release_bundle_test.go
+++ b/evidence/cli/command_release_bundle_test.go
@@ -95,7 +95,7 @@ func TestEvidenceReleaseBundleCommand_DeleteEvidence(t *testing.T) {
 		return nil
 	}
 	cmd := NewEvidenceReleaseBundleCommand(ctx, mockExec)
-	serverDetails := &config.ServerDetails{Url: "http://x"}
+	serverDetails := &config.ServerDetails{Url: "url"}
 
 	err = cmd.DeleteEvidence(ctx, serverDetails)
 	assert.NoError(t, err)

--- a/evidence/cli/command_release_bundle_test.go
+++ b/evidence/cli/command_release_bundle_test.go
@@ -72,3 +72,32 @@ func TestEvidenceReleaseBundleCommand_CreateEvidence_SigstoreBundle(t *testing.T
 		})
 	}
 }
+
+func TestEvidenceReleaseBundleCommand_DeleteEvidence(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{{Name: "delete"}}
+	set := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(app, set, nil)
+
+	flags := []components.Flag{
+		setDefaultValue(project, "proj"),
+		setDefaultValue(releaseBundle, "rb"),
+		setDefaultValue(releaseBundleVersion, "1.0.0"),
+		setDefaultValue(evidenceName, "evd"),
+	}
+
+	ctx, err := components.ConvertContext(cliCtx, flags...)
+	assert.NoError(t, err)
+
+	called := false
+	mockExec := func(cmd commands.Command) error {
+		called = true
+		return nil
+	}
+	cmd := NewEvidenceReleaseBundleCommand(ctx, mockExec)
+	serverDetails := &config.ServerDetails{Url: "http://x"}
+
+	err = cmd.DeleteEvidence(ctx, serverDetails)
+	assert.NoError(t, err)
+	assert.True(t, called)
+}

--- a/evidence/cli/docs/delete/help.go
+++ b/evidence/cli/docs/delete/help.go
@@ -1,0 +1,11 @@
+package delete
+
+import "github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+
+func GetDescription() string {
+	return ` Delete evidence associated with a specified subject by evidence name. `
+}
+
+func GetArguments() []components.Argument {
+	return []components.Argument{}
+}

--- a/evidence/cli/flags.go
+++ b/evidence/cli/flags.go
@@ -10,6 +10,7 @@ const (
 	CreateEvidence = "create-evidence"
 	GetEvidence    = "get-evidence"
 	VerifyEvidence = "verify-evidence"
+	DeleteEvidence = "delete-evidence"
 )
 
 const (
@@ -46,6 +47,7 @@ const (
 	useArtifactoryKeys = "use-artifactory-keys"
 	sigstoreBundle     = "sigstore-bundle"
 	artifactsLimit     = "artifacts-limit"
+	evidenceName       = "evidence-name"
 )
 
 // Flag keys mapped to their corresponding components.Flag definition.
@@ -82,6 +84,7 @@ var flagsMap = map[string]components.Flag{
 	sigstoreBundle:     components.NewStringFlag(sigstoreBundle, "Path to a Sigstore bundle file with a pre-signed DSSE envelope. Incompatible with --"+key+", --"+keyAlias+", --"+predicate+", --"+predicateType+" and --"+subjectSha256+".", func(f *components.StringFlag) { f.Mandatory = false }),
 	useArtifactoryKeys: components.NewBoolFlag(useArtifactoryKeys, "Use Artifactory keys for verification. When enabled, the verify command retrieves keys from Artifactory.", components.WithBoolDefaultValueFalse()),
 	artifactsLimit:     components.NewStringFlag(artifactsLimit, "The number of artifacts in a release bundle to be included in the evidences file. The default value is 1000 artifacts", func(f *components.StringFlag) { f.Mandatory = false }),
+	evidenceName:       components.NewStringFlag(evidenceName, "Evidence file name.", func(f *components.StringFlag) { f.Mandatory = true }),
 }
 
 var commandFlags = map[string][]string{
@@ -140,6 +143,22 @@ var commandFlags = map[string][]string{
 		subjectRepoPath,
 		includePredicate,
 		artifactsLimit,
+	},
+	DeleteEvidence: {
+		url,
+		user,
+		accessToken,
+		ServerId,
+		project,
+		releaseBundle,
+		releaseBundleVersion,
+		subjectRepoPath,
+		buildName,
+		buildNumber,
+		packageName,
+		packageVersion,
+		packageRepoName,
+		evidenceName,
 	},
 }
 

--- a/evidence/create/create_github_test.go
+++ b/evidence/create/create_github_test.go
@@ -82,13 +82,13 @@ func TestBuildAndVcsDetailsMock(t *testing.T) {
 	mockBuildVcs := new(MockBuildAndVcsDetails)
 
 	// Define expected return values
-	mockBuildVcs.On("GetLastBuildLink", mock.Anything, mock.Anything).Return("http://mocked-url.com", nil)
+	mockBuildVcs.On("GetLastBuildLink", mock.Anything, mock.Anything).Return("url", nil)
 	mockBuildVcs.On("GetPlainGitLogFromPreviousBuild", mock.Anything, mock.Anything, mock.Anything).Return("mocked git log", nil)
 
 	// Call the method under test
 	url, err := mockBuildVcs.GetLastBuildLink(nil, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "http://mocked-url.com", url)
+	assert.Equal(t, "url", url)
 
 	gitLog, err := mockBuildVcs.GetPlainGitLogFromPreviousBuild(nil, nil, artifactoryUtils.GitLogDetails{})
 	assert.NoError(t, err)

--- a/evidence/delete/delete_base.go
+++ b/evidence/delete/delete_base.go
@@ -1,0 +1,54 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+type deleteEvidenceBase struct {
+	serverDetails *config.ServerDetails
+	evidenceName  string
+	pathResolver  SubjectRepoPathResolver
+}
+
+func NewDeleteEvidenceBase(serverDetails *config.ServerDetails, evidenceName string, resolver SubjectRepoPathResolver) evidence.Command {
+	return &deleteEvidenceBase{
+		serverDetails: serverDetails,
+		evidenceName:  evidenceName,
+		pathResolver:  resolver,
+	}
+}
+
+type SubjectRepoPathResolver interface {
+	ResolveSubjectRepoPath() (string, error)
+}
+
+func (d *deleteEvidenceBase) Run() error {
+	subjectRepoPath, err := d.pathResolver.ResolveSubjectRepoPath()
+	if err != nil {
+		return err
+	}
+	manager, err := utils.CreateEvidenceServiceManager(d.serverDetails, false)
+	if err != nil {
+		return fmt.Errorf("failed to create evidence service manager: %w", err)
+	}
+	log.Debug("Deleting evidence for subject:", subjectRepoPath, "and evidence name:", d.evidenceName)
+	err = manager.DeleteEvidence(subjectRepoPath, d.evidenceName)
+	if err != nil {
+		return fmt.Errorf("failed to delete evidence for subject %s and evidence name %s: %w", subjectRepoPath, d.evidenceName, err)
+	}
+	log.Info("Evidence deleted successfully for subject:", subjectRepoPath, "and evidence name:", d.evidenceName)
+	return nil
+}
+
+func (v *deleteEvidenceBase) ServerDetails() (*config.ServerDetails, error) {
+	return v.serverDetails, nil
+}
+
+func (v *deleteEvidenceBase) CommandName() string {
+	return "delete-evidence"
+}

--- a/evidence/delete/delete_base_test.go
+++ b/evidence/delete/delete_base_test.go
@@ -1,0 +1,40 @@
+package delete
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockResolver struct {
+	path string
+	err  error
+}
+
+func (m *mockResolver) ResolveSubjectRepoPath() (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.path, nil
+}
+
+func TestDeleteEvidenceHandler_CommandName_And_ServerDetails(t *testing.T) {
+	sd := &config.ServerDetails{Url: "http://test.com"}
+	h := NewDeleteEvidenceBase(sd, "evd-name", &mockResolver{path: "repo/path"})
+
+	gotSd, err := h.ServerDetails()
+	assert.NoError(t, err)
+	assert.Equal(t, sd, gotSd)
+	assert.Equal(t, "delete-evidence", h.CommandName())
+}
+
+func TestDeleteEvidenceHandler_Run_PathResolverError(t *testing.T) {
+	sd := &config.ServerDetails{Url: "http://test.com"}
+	h := NewDeleteEvidenceBase(sd, "evd-name", &mockResolver{err: errors.New("resolve failed")})
+
+	err := h.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve failed")
+}

--- a/evidence/resolver/build_path_resolver.go
+++ b/evidence/resolver/build_path_resolver.go
@@ -1,0 +1,47 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/utils"
+	artifactoryUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+)
+
+const aqlBuildQueryTemplate = "items.find({\"repo\":\"%s\",\"path\":\"%s\",\"name\":{\"$match\":\"%s*\"}}).include(\"sha256\",\"name\").sort({\"$desc\":[\"name\"]}).limit(1)"
+
+type BuildPathResolver struct {
+	project           string
+	buildName         string
+	buildNumber       string
+	artifactoryClient artifactory.ArtifactoryServicesManager
+}
+
+func NewBuildPathResolver(project, buildName, buildNumber string, serverDetails *config.ServerDetails) (*BuildPathResolver, error) {
+	client, err := artifactoryUtils.CreateUploadServiceManager(serverDetails, 1, 0, 0, false, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Artifactory client: %w", err)
+	}
+	return &BuildPathResolver{
+		project:           project,
+		buildName:         buildName,
+		buildNumber:       buildNumber,
+		artifactoryClient: client,
+	}, nil
+}
+
+func (b *BuildPathResolver) ResolveSubjectRepoPath() (string, error) {
+	repoKey := utils.BuildBuildInfoRepoKey(b.project)
+	result, err := utils.ExecuteAqlQuery(fmt.Sprintf(aqlBuildQueryTemplate, repoKey, b.buildName, b.buildNumber), &b.artifactoryClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute AQL query: %w", err)
+	}
+	if len(result.Results) == 0 {
+		return "", fmt.Errorf("no build found for the given build name and number")
+	}
+	subjectFileName := result.Results[0].Name
+
+	subjectPath := fmt.Sprintf("%s/%s/%s", repoKey, b.buildName, subjectFileName)
+	return subjectPath, nil
+}

--- a/evidence/resolver/build_path_resolver_test.go
+++ b/evidence/resolver/build_path_resolver_test.go
@@ -22,7 +22,7 @@ func (m *mockArtifactoryServicesManagerAql) Aql(_ string) (io.ReadCloser, error)
 }
 
 func TestBuildPathResolver_Success(t *testing.T) {
-	sd := &config.ServerDetails{Url: "http://x"}
+	sd := &config.ServerDetails{Url: "url"}
 	r, err := NewBuildPathResolver("proj", "bname", "bnum", sd)
 	assert.NoError(t, err)
 
@@ -37,7 +37,7 @@ func TestBuildPathResolver_Success(t *testing.T) {
 }
 
 func TestBuildPathResolver_EmptyResults(t *testing.T) {
-	sd := &config.ServerDetails{Url: "http://x"}
+	sd := &config.ServerDetails{Url: "url"}
 	r, err := NewBuildPathResolver("proj", "bname", "bnum", sd)
 	assert.NoError(t, err)
 

--- a/evidence/resolver/build_path_resolver_test.go
+++ b/evidence/resolver/build_path_resolver_test.go
@@ -1,0 +1,49 @@
+package resolver
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockArtifactoryServicesManagerAql struct {
+	artifactory.EmptyArtifactoryServicesManager
+	rc  io.ReadCloser
+	err error
+}
+
+func (m *mockArtifactoryServicesManagerAql) Aql(_ string) (io.ReadCloser, error) {
+	return m.rc, m.err
+}
+
+func TestBuildPathResolver_Success(t *testing.T) {
+	sd := &config.ServerDetails{Url: "http://x"}
+	r, err := NewBuildPathResolver("proj", "bname", "bnum", sd)
+	assert.NoError(t, err)
+
+	r.artifactoryClient = &mockArtifactoryServicesManagerAql{
+		rc: io.NopCloser(bytes.NewBufferString(`{"results":[{"name":"bnum-123"}]}`)),
+	}
+
+	expected := utils.BuildBuildInfoRepoKey("proj") + "/" + "bname" + "/" + "bnum-123"
+	got, err := r.ResolveSubjectRepoPath()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestBuildPathResolver_EmptyResults(t *testing.T) {
+	sd := &config.ServerDetails{Url: "http://x"}
+	r, err := NewBuildPathResolver("proj", "bname", "bnum", sd)
+	assert.NoError(t, err)
+
+	r.artifactoryClient = &mockArtifactoryServicesManagerAql{
+		rc: io.NopCloser(bytes.NewBufferString(`{"results":[]}`)),
+	}
+	_, err = r.ResolveSubjectRepoPath()
+	assert.Error(t, err)
+}

--- a/evidence/resolver/custom_path_resolver.go
+++ b/evidence/resolver/custom_path_resolver.go
@@ -1,0 +1,20 @@
+package resolver
+
+import "fmt"
+
+type CustomPathResolver struct {
+	SubjectRepoPath string
+}
+
+func NewCustomPathResolver(subjectRepoPath string) *CustomPathResolver {
+	return &CustomPathResolver{
+		SubjectRepoPath: subjectRepoPath,
+	}
+}
+
+func (c *CustomPathResolver) ResolveSubjectRepoPath() (string, error) {
+	if c.SubjectRepoPath == "" {
+		return "", fmt.Errorf("subject repository path is required but not provided")
+	}
+	return c.SubjectRepoPath, nil
+}

--- a/evidence/resolver/custom_path_resolver_test.go
+++ b/evidence/resolver/custom_path_resolver_test.go
@@ -1,0 +1,21 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomPathResolver(t *testing.T) {
+	r := NewCustomPathResolver("repo/path/file")
+	p, err := r.ResolveSubjectRepoPath()
+	assert.NoError(t, err)
+	assert.Equal(t, "repo/path/file", p)
+}
+
+func TestCustomPathResolver_Empty(t *testing.T) {
+	r := NewCustomPathResolver("")
+	_, err := r.ResolveSubjectRepoPath()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}

--- a/evidence/resolver/package_path_resolver.go
+++ b/evidence/resolver/package_path_resolver.go
@@ -1,0 +1,46 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence"
+	cliUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/metadata"
+)
+
+type PackagePathResolver struct {
+	packageService    evidence.PackageService
+	artifactoryClient artifactory.ArtifactoryServicesManager
+	metadataClient    metadata.Manager
+}
+
+func NewPackagePathResolver(packageName, packageVersion, repoName string, serverDetails *config.ServerDetails) (*PackagePathResolver, error) {
+	artifactoryClient, err := cliUtils.CreateUploadServiceManager(serverDetails, 1, 0, 0, false, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Artifactory client: %w", err)
+	}
+	metadataClient, err := cliUtils.CreateMetadataServiceManager(serverDetails, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata service manager: %w", err)
+	}
+	return &PackagePathResolver{
+		packageService:    evidence.NewPackageService(packageName, packageVersion, repoName),
+		artifactoryClient: artifactoryClient,
+		metadataClient:    metadataClient,
+	}, nil
+}
+
+func (p *PackagePathResolver) ResolveSubjectRepoPath() (string, error) {
+	packageType, err := p.packageService.GetPackageType(p.artifactoryClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to get package type: %w", err)
+	}
+
+	leadArtifactPath, err := p.packageService.GetPackageVersionLeadArtifact(packageType, p.metadataClient, p.artifactoryClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to get package version lead artifact: %w", err)
+	}
+	return leadArtifactPath, nil
+}

--- a/evidence/resolver/package_path_resolver_test.go
+++ b/evidence/resolver/package_path_resolver_test.go
@@ -1,0 +1,51 @@
+package resolver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	"github.com/jfrog/jfrog-client-go/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockArtifactoryServicesManagerRepo struct {
+	artifactory.EmptyArtifactoryServicesManager
+	repoType string
+}
+
+func (m *mockArtifactoryServicesManagerRepo) GetRepository(_ string, out interface{}) error {
+	if d, ok := out.(*services.RepositoryDetails); ok {
+		d.PackageType = m.repoType
+	}
+	return nil
+}
+
+func (m *mockArtifactoryServicesManagerRepo) GetPackageLeadFile(_ services.LeadFileParams) ([]byte, error) {
+	return nil, fmt.Errorf("not found")
+}
+
+type mockMetadataManager struct {
+	metadata.Manager
+	body []byte
+	err  error
+}
+
+func (m *mockMetadataManager) GraphqlQuery(_ []byte) ([]byte, error) { return m.body, m.err }
+
+func TestPackagePathResolver(t *testing.T) {
+	sd := &config.ServerDetails{Url: "http://x"}
+	r, err := NewPackagePathResolver("pkg", "1.0.0", "repo", sd)
+	assert.NoError(t, err)
+
+	r.artifactoryClient = &mockArtifactoryServicesManagerRepo{repoType: "nuget"}
+	r.metadataClient = &mockMetadataManager{body: []byte(`{"data":{"versions":{"edges":[{"node":{"repos":[{"name":"repo","leadFilePath":"pkg/1.0.0/pkg-1.0.0.nupkg"}]}}]}}}`)}
+	r.packageService = evidence.NewPackageService("pkg", "1.0.0", "repo")
+
+	got, err := r.ResolveSubjectRepoPath()
+	assert.NoError(t, err)
+	assert.Equal(t, "repo/pkg/1.0.0/pkg-1.0.0.nupkg", got)
+}

--- a/evidence/resolver/package_path_resolver_test.go
+++ b/evidence/resolver/package_path_resolver_test.go
@@ -37,7 +37,7 @@ type mockMetadataManager struct {
 func (m *mockMetadataManager) GraphqlQuery(_ []byte) ([]byte, error) { return m.body, m.err }
 
 func TestPackagePathResolver(t *testing.T) {
-	sd := &config.ServerDetails{Url: "http://x"}
+	sd := &config.ServerDetails{Url: "url"}
 	r, err := NewPackagePathResolver("pkg", "1.0.0", "repo", sd)
 	assert.NoError(t, err)
 

--- a/evidence/resolver/release_bundle_path_resolver.go
+++ b/evidence/resolver/release_bundle_path_resolver.go
@@ -1,0 +1,31 @@
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/jfrog/jfrog-cli-artifactory/evidence/utils"
+)
+
+type ReleaseBundlePathResolver struct {
+	project              string
+	releaseBundle        string
+	releaseBundleVersion string
+}
+
+func NewReleaseBundlePathResolver(project, releaseBundle, releaseBundleVersion string) *ReleaseBundlePathResolver {
+	return &ReleaseBundlePathResolver{
+		project:              project,
+		releaseBundle:        releaseBundle,
+		releaseBundleVersion: releaseBundleVersion,
+	}
+}
+
+func (r *ReleaseBundlePathResolver) ResolveSubjectRepoPath() (string, error) {
+	repoKey := utils.BuildReleaseBundleRepoKey(r.project)
+
+	path := fmt.Sprintf("%s/%s", r.releaseBundle, r.releaseBundleVersion)
+
+	subjectPath := fmt.Sprintf("%s/%s/%s", repoKey, path, "release-bundle.json.evd")
+
+	return subjectPath, nil
+}

--- a/evidence/resolver/release_bundle_path_resolver_test.go
+++ b/evidence/resolver/release_bundle_path_resolver_test.go
@@ -1,0 +1,14 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleaseBundlePathResolver(t *testing.T) {
+	r := NewReleaseBundlePathResolver("proj", "rb", "1.0.0")
+	p, err := r.ResolveSubjectRepoPath()
+	assert.NoError(t, err)
+	assert.Equal(t, "proj-release-bundles-v2/rb/1.0.0/release-bundle.json.evd", p)
+}

--- a/go.mod
+++ b/go.mod
@@ -181,5 +181,5 @@ require (
 )
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.59.2-0.20250804083101-9cf424ecc926
-
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250717041744-d3ea4d99f4e7
+// should be replaced after merging jfrog-client-go PR with delete evidence api call support
+replace github.com/jfrog/jfrog-client-go => github.com/mnsboev/jfrog-client-go v0.0.0-20250810114616-0227b5a7ff44

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,6 @@ github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/jfrog/jfrog-cli-core/v2 v2.59.4 h1:6FU8hR0Niao8PuXh+0jU06lxTRJtDD8r4UL/4T+8yuI=
 github.com/jfrog/jfrog-cli-core/v2 v2.59.4/go.mod h1:agFp57/4zU9J5E3sKyqxIMzqjFpxE+xrWPg3RcjTNbY=
-github.com/jfrog/jfrog-client-go v1.54.4 h1:W5J2WAidEPghlvWl7FbrJUeRyVbNzC6GnihNACVaeEM=
-github.com/jfrog/jfrog-client-go v1.54.4/go.mod h1:+pSVE7Co+ytwhOhmz84/Lpe5fSeTaWJXsP1qt+WVfw0=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
@@ -383,6 +381,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mnsboev/jfrog-client-go v0.0.0-20250810114616-0227b5a7ff44 h1:aia6GTpEx3mQIxG52uLal760objvLcYvvpdGRdz1+Fk=
 github.com/mnsboev/jfrog-client-go v0.0.0-20250810114616-0227b5a7ff44/go.mod h1:+pSVE7Co+ytwhOhmz84/Lpe5fSeTaWJXsP1qt+WVfw0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mnsboev/jfrog-client-go v0.0.0-20250810114616-0227b5a7ff44/go.mod h1:+pSVE7Co+ytwhOhmz84/Lpe5fSeTaWJXsP1qt+WVfw0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
…lete evidence by evidenceName

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
**Description**:
This PR is the part of the two PRs which introduce a new command for the jf evd CLI tool that allows users to delete evidence based on specific criteria. The new delete command resolves the subject and facilitates the deletion of evidence using its name.

jfrog-client-go PR: https://github.com/jfrog/jfrog-client-go/pull/1158

The command uses the same subject definition as create and verify commands.
The output of help command:
```
Name:
  jf evd delete-evidence -  Delete evidence associated with a specified subject by evidence name. 

Usage:
  jf evd delete-evidence [command options] --evidence-name=<value>
  
Options:
  --access-token              [Optional] JFrog access token.
  --build-name                [Optional] Build name.
  --build-number              [Optional] Build number.
  --evidence-name             [Mandatory] Evidence file name.
  --package-name              [Optional] Package name.
  --package-repo-name         [Optional] Package repository Name.
  --package-version           [Optional] Package version.
  --project                   [Optional] Project key associated with the created evidence.
  --release-bundle            [Optional] Release Bundle name.
  --release-bundle-version    [Optional] Release Bundle version.
  --server-id                 [Optional] Server ID configured using the config command.
  --subject-repo-path         [Optional] Full path to some subject location.
  --url                       [Optional] JFrog Platform URL.
  --user                      [Optional] JFrog username
```

Example of call:
`jf evd delete --release-bundle mishas_bundle --release-bundle-version 45  --evidence-name release-bundle-signature-1753360796034-204c2ab4.json`