### PR TITLE
fix panic on upload evidence in github actions

### DIFF
--- a/evidence/create/create_custom.go
+++ b/evidence/create/create_custom.go
@@ -73,11 +73,11 @@ func (c *createEvidenceCustom) Run() error {
 		return err
 	}
 	response, err := c.uploadEvidence(evidencePayload, c.subjectRepoPath)
-	c.recordSummary(response)
 	if err != nil {
 		err = c.handleSubjectNotFound(err)
 		return err
 	}
+	c.recordSummary(response)
 
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Fix summary generation error in github actions when upload evidence is failed