### PR TITLE
Fix panic on upload evidence error

### DIFF
--- a/evidence/create/create_package.go
+++ b/evidence/create/create_package.go
@@ -70,10 +70,10 @@ func (c *createEvidencePackage) Run() error {
 		return err
 	}
 	response, err := c.uploadEvidence(envelope, leadArtifactPath)
-	c.recordSummary(response, leadArtifactPath, leadArtifactChecksum)
 	if err != nil {
 		return err
 	}
+	c.recordSummary(response, leadArtifactPath, leadArtifactChecksum)
 
 	return nil
 }

--- a/evidence/create/create_release_bundle.go
+++ b/evidence/create/create_release_bundle.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"fmt"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/commandsummary"
 
 	"github.com/jfrog/jfrog-cli-artifactory/evidence"
@@ -62,10 +63,10 @@ func (c *createEvidenceReleaseBundle) Run() error {
 		return err
 	}
 	response, err := c.uploadEvidence(envelope, subject)
-	c.recordSummary(response, subject, sha256)
 	if err != nil {
 		return err
 	}
+	c.recordSummary(response, subject, sha256)
 
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Fix possible panic for package and release bundle subject types
