### PR TITLE
Fix error in when key pair is incorrect

### DIFF
--- a/evidence/create/create_base_test.go
+++ b/evidence/create/create_base_test.go
@@ -167,7 +167,7 @@ func TestCreateAndSignEnvelope(t *testing.T) {
 			keyPath:          "tests/testdata/unsupported_key.pem",
 			keyId:            "test-key-id",
 			expectError:      true,
-			expectedErrorMsg: "failed to decode the data as PEM block (are you sure this is a pem file?)",
+			expectedErrorMsg: "key pair is incorrect or key alias 'test-key-id' was not found in Artifactory. Original error: failed to decode the data as PEM block (are you sure this is a pem file?)",
 		},
 		{
 			name:             "public key type",
@@ -175,7 +175,15 @@ func TestCreateAndSignEnvelope(t *testing.T) {
 			keyPath:          "tests/testdata/public_key.pem",
 			keyId:            "test-key-id",
 			expectError:      true,
-			expectedErrorMsg: "failed to load private key. please verify provided key",
+			expectedErrorMsg: "key pair is incorrect or key alias 'test-key-id' was not found in Artifactory. Original error: failed to load private key",
+		},
+		{
+			name:             "public key type without keyId",
+			payloadJson:      []byte(`{"foo": "bar"}`),
+			keyPath:          "tests/testdata/public_key.pem",
+			keyId:            "",
+			expectError:      true,
+			expectedErrorMsg: "failed to load private key. Please verify the provided key is correct or check if the key alias exists in Artifactory. Original error: failed to load private key",
 		},
 	}
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----

When key-alias is incorrect we were giving unclear error regarding the problem:
```
[🚨Error] server response: 400 Bad Request
{
  "errors": [
    {
      "message": "not found"
    }
  ]
}
```

Fix the error to be more clear.