### PR TITLE
Ignore errors in NuGet cleanup command to prevent breaking nuget flow

### DIFF
--- a/artifactory/commands/dotnet/dotnetcommand.go
+++ b/artifactory/commands/dotnet/dotnetcommand.go
@@ -210,13 +210,11 @@ func RemoveSourceFromNugetConfigIfExists(cmdType dotnet.ToolchainType) error {
 		cmd.CommandFlags = append(cmd.CommandFlags, "-name", SourceName)
 	}
 
-	stdOut, stdErr, _, err := frogio.RunCmdWithOutputParser(cmd, false)
-	if err != nil {
-		if strings.Contains(stdOut+stdErr, "Unable to find") || strings.Contains(stdOut+stdErr, "does not exist") {
-			return nil
-		}
-		return errorutils.CheckErrorf("%s\nfailed to remove source: %s", stdErr, err.Error())
-	}
+	// nolint:errcheck
+	// Ignore errors since this is just a cleanup function.
+	// We don't want cleanup failures to break the main flow.
+	// It's also fine if the source doesn't exist.
+	_, _, _, _ = frogio.RunCmdWithOutputParser(cmd, false)
 	return nil
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
