### PR TITLE
Updated 'vscodeextensions' to 'aieditorextensions' for VSCode config

### DIFF
--- a/artifactory/cli/ide/common.go
+++ b/artifactory/cli/ide/common.go
@@ -33,7 +33,7 @@ func HasServerConfigFlags(c *components.Context) bool {
 
 // ExtractRepoKeyFromURL extracts the repository key from both JetBrains and VSCode extension URLs.
 // For JetBrains: https://mycompany.jfrog.io/artifactory/api/jetbrainsplugins/jetbrains-plugins
-// For VSCode: https://mycompany.jfrog.io/artifactory/api/vscodeextensions/vscode-extensions/_apis/public/gallery
+// For VSCode: https://mycompany.jfrog.io/artifactory/api/aieditorextensions/vscode-extensions/_apis/public/gallery
 // Returns the repo key (e.g., "jetbrains-plugins" or "vscode-extensions")
 func ExtractRepoKeyFromURL(repoURL string) (string, error) {
 	if repoURL == "" {
@@ -56,8 +56,8 @@ func ExtractRepoKeyFromURL(repoURL string) (string, error) {
 	}
 
 	// Check for VSCode extensions API
-	if idx := strings.Index(url, "/api/vscodeextensions/"); idx != -1 {
-		rest := url[idx+len("/api/vscodeextensions/"):]
+	if idx := strings.Index(url, "/api/aieditorextensions/"); idx != -1 {
+		rest := url[idx+len("/api/aieditorextensions/"):]
 		parts := strings.SplitN(rest, "/", 2)
 		if len(parts) == 0 || parts[0] == "" {
 			return "", fmt.Errorf("repository key not found in VSCode URL")
@@ -65,7 +65,7 @@ func ExtractRepoKeyFromURL(repoURL string) (string, error) {
 		return parts[0], nil
 	}
 
-	return "", fmt.Errorf("URL does not contain a supported API type (/api/jetbrainsplugins/ or /api/vscodeextensions/)")
+	return "", fmt.Errorf("URL does not contain a supported API type (/api/jetbrainsplugins/ or /api/aieditorextensions/)")
 }
 
 // IsValidUrl checks if a string is a valid URL with scheme and host

--- a/artifactory/cli/ide/descriptions.go
+++ b/artifactory/cli/ide/descriptions.go
@@ -4,10 +4,10 @@ const VscodeConfigDescription = `
 Configure VSCode to use JFrog Artifactory for extensions.
 
 The service URL should be in the format:
-https://<artifactory-url>/artifactory/api/vscodeextensions/<repo-key>/_apis/public/gallery
+https://<artifactory-url>/artifactory/api/aieditorextensions/<repo-key>/_apis/public/gallery
 
 Examples:
-  jf vscode-config https://mycompany.jfrog.io/artifactory/api/vscodeextensions/vscode-extensions/_apis/public/gallery
+  jf vscode-config https://mycompany.jfrog.io/artifactory/api/aieditorextensions/vscode-extensions/_apis/public/gallery
 
 This command will:
 - Modify the VSCode product.json file to change the extensions gallery URL

--- a/artifactory/cli/ide/vscode/cli.go
+++ b/artifactory/cli/ide/vscode/cli.go
@@ -16,7 +16,7 @@ const (
 	productJsonPath = "product-json-path"
 	repoKeyFlag     = "repo-key"
 	urlSuffixFlag   = "url-suffix"
-	apiType         = "vscodeextensions"
+	apiType         = "aieditorextensions"
 )
 
 func GetCommands() []components.Command {
@@ -127,7 +127,7 @@ func getVscodeRepoKeyAndURL(c *components.Context) (repoKey, serviceURL string, 
 	if urlSuffix == "" {
 		urlSuffix = "_apis/public/gallery"
 	}
-	serviceURL = baseUrl + "/api/vscodeextensions/" + repoKey + "/" + strings.TrimLeft(urlSuffix, "/")
+	serviceURL = baseUrl + "/api/" + apiType + "/" + repoKey + "/" + strings.TrimLeft(urlSuffix, "/")
 	return
 }
 

--- a/artifactory/commands/ide/vscode/vscode_test.go
+++ b/artifactory/commands/ide/vscode/vscode_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewVscodeCommand(t *testing.T) {
-	serviceURL := "https://company.jfrog.io/artifactory/api/vscodeextensions/repo/_apis/public/gallery"
+	serviceURL := "https://company.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery"
 	productPath := "/custom/path/product.json"
 	repoKey := "repo"
 
@@ -153,7 +153,7 @@ func TestVscodeCommand_ModifyProductJson_ValidFile(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := NewVscodeCommand("", productPath, "")
-	newServiceURL := "https://company.jfrog.io/artifactory/api/vscodeextensions/repo/_apis/public/gallery"
+	newServiceURL := "https://company.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery"
 
 	err = cmd.modifyProductJson(newServiceURL)
 	assert.NoError(t, err)
@@ -165,7 +165,7 @@ func TestVscodeCommand_ModifyProductJson_ValidFile(t *testing.T) {
 
 func TestVscodeCommand_ModifyProductJson_NonExistentFile(t *testing.T) {
 	cmd := NewVscodeCommand("", "/non/existent/path/product.json", "")
-	newServiceURL := "https://company.jfrog.io/artifactory/api/vscodeextensions/repo/_apis/public/gallery"
+	newServiceURL := "https://company.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery"
 
 	err := cmd.modifyProductJson(newServiceURL)
 	assert.Error(t, err)
@@ -173,7 +173,7 @@ func TestVscodeCommand_ModifyProductJson_NonExistentFile(t *testing.T) {
 
 func TestVscodeCommand_GetManualSetupInstructions(t *testing.T) {
 	cmd := NewVscodeCommand("", "", "")
-	serviceURL := "https://company.jfrog.io/artifactory/api/vscodeextensions/repo/_apis/public/gallery"
+	serviceURL := "https://company.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery"
 
 	instructions := cmd.getManualSetupInstructions(serviceURL)
 
@@ -206,7 +206,7 @@ func TestVscodeCommand_HandlePermissionError_macOS(t *testing.T) {
 		t.Skip("macOS-specific test")
 	}
 
-	cmd := NewVscodeCommand("https://company.jfrog.io/artifactory/api/vscodeextensions/repo/_apis/public/gallery",
+	cmd := NewVscodeCommand("https://company.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery",
 		"/Applications/Visual Studio Code.app/Contents/Resources/app/product.json", "")
 
 	err := cmd.handlePermissionError()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
# Update VSCode Configuration to Use `aieditorextensions` API Path

## Overview

This PR updates the VSCode configuration functionality in jfrog-cli-artifactory to use the new `aieditorextensions` API path instead of the legacy `vscodeextensions` path, aligning with recent Artifactory API changes.

## Changes Made

### Core Implementation
- **`artifactory/cli/ide/vscode/cli.go`**
  - Updated `apiType` constant from `"vscodeextensions"` to `"aieditorextensions"`
  - Modified URL construction to use the new constant for consistency
  
- **`artifactory/cli/ide/common.go`**
  - Updated URL parsing logic to recognize `/api/aieditorextensions/` paths
  - Updated documentation comments and error messages
  
- **`artifactory/cli/ide/descriptions.go`**
  - Updated command descriptions and example URLs

### Testing
- **`artifactory/commands/ide/vscode/vscode_test.go`**
  - Updated all test URLs to use `aieditorextensions`
  - Maintained test coverage and functionality

## URL Format Change

**Before:**
```
https://<artifactory-url>/artifactory/api/vscodeextensions/<repo-key>/apis/public/gallery
```
**After:**
```
https://<artifactory-url>/artifactory/api/aieditorextensions/<repo-key>/apis/public/gallery
```

## Example Usage
The command usage remains the same:

```bash
# Using direct URL
jf vscode-config https://mycompany.jfrog.io/artifactory/api/aieditorextensions/vscode-extensions/_apis/public/gallery

# Using repo-key flag (now constructs URL with aieditorextensions)
jf vscode-config --repo-key=vscode-extensions --url=https://mycompany.jfrog.io/artifactory
```

This change addresses the Artifactory API update where the VSCode extensions service has been moved from the `vscodeextensions` endpoint to the `aieditorextensions` endpoint.
