### PR TITLE
add timestamp as props for twine 

### DIFF
--- a/artifactory/commands/python/twine.go
+++ b/artifactory/commands/python/twine.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jfrog/build-info-go/build"
 	"github.com/jfrog/build-info-go/utils/pythonutils"
@@ -215,9 +217,10 @@ func (tc *TwineCommand) uploadAndCollectBuildInfo() error {
 		return err
 	}
 
+	timestamp := strconv.FormatInt(buildInfo.GetBuildTimestamp().UnixNano()/int64(time.Millisecond), 10)
 	propsParams := services.PropsParams{
 		Reader: searchReader,
-		Props:  fmt.Sprintf("build.name=%s;build.number=%s", buildName, buildNumber),
+		Props:  fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp),
 	}
 
 	_, err = servicesManager.SetProps(propsParams)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Problem: When publishing artifacts to artifactory using the jf-cli,  uploading Python packages to a PyPI repository via the `jf twine command`, and other artifacts to a generic repository using `jf rt upload`, all under the same build name and build number. The build.timestamp property was not applied to the artifacts uploaded to the PyPI repository, whereas it is correctly applied to artifacts in the generic repository.

Solution: Added build.timestamp as one of props for python packages.
