### PR TITLE
Fix: Support Python-style multi-line values in .pypirc files

### DIFF
--- a/artifactory/commands/python/pypirc.go
+++ b/artifactory/commands/python/pypirc.go
@@ -70,9 +70,10 @@ func loadOrCreatePypirc(pypircPath string) (*ini.File, error) {
 	if exists {
 		// Load ini file with necessary options for cross-platform compatibility
 		pypirc, err = ini.LoadSources(ini.LoadOptions{
-			Loose:               true, // Required for handling non-standard formatting
-			Insensitive:         true, // Required for case-insensitive keys
-			IgnoreInlineComment: true, // Required for values containing special chars
+			Loose:                      true, // Required for handling non-standard formatting
+			Insensitive:                true, // Required for case-insensitive keys
+			IgnoreInlineComment:        true, // Required for values containing special chars
+			AllowPythonMultilineValues: true, // Required for Python-style multi-line values
 		}, pypircPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load .pypirc file: %w", err)


### PR DESCRIPTION
- Add AllowPythonMultilineValues option to INI parser in loadOrCreatePypirc
- Add comprehensive test case TestConfigurePypircWithMultilineIndexServers
- Fixes 'key-value delimiter not found' error when parsing .pypirc files with multi-line index-servers format

Problem:
When users have .pypirc files with Python's standard multi-line format for index-servers:
  [distutils]
  index-servers =
      repo1
      repo2

The setup command would fail with: 'key-value delimiter not found: repo1'

Solution:
Enable AllowPythonMultilineValues option in the INI parser to properly handle Python-style configuration files where values can span multiple indented lines.

This ensures compatibility with .pypirc files created by other Python tools and maintains backward compatibility with single-line formats.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
