### PR TITLE
Fix pip detection to handle pyenv shims that fail at runtime

### DIFF
--- a/artifactory/commands/python/python.go
+++ b/artifactory/commands/python/python.go
@@ -188,13 +188,15 @@ func getExecutable(buildTool project.ProjectType) (string, error) {
 		// Running --version verifies the executable both exists AND works.
 		// This handles tools like pyenv that create shim files which exist in PATH
 		// but fail at runtime when the selected Python version doesn't have pip.
-		if exec.Command("pip", "--version").Run() == nil {
+		pipErr := exec.Command("pip", "--version").Run()
+		if pipErr == nil {
 			return "pip", nil
 		}
-		if exec.Command("pip3", "--version").Run() == nil {
+		pip3Err := exec.Command("pip3", "--version").Run()
+		if pip3Err == nil {
 			return "pip3", nil
 		}
-		return "", errorutils.CheckErrorf("neither pip nor pip3 executable found in PATH")
+		return "", errorutils.CheckErrorf("neither pip nor pip3 executable found in PATH. pip error: %v, pip3 error: %v", pipErr, pip3Err)
 	default:
 		// For all other build tools, use the name directly
 		return buildTool.String(), nil


### PR DESCRIPTION
## Problem

When using pyenv, pip shims exist in PATH but fail at runtime if the selected Python version doesn't have pip installed. This caused setup to fail with 'pip: command not found' even when pip3 was available.

**Customer scenario:**
- pyenv is installed with `pyenv global system`
- System Python has `pip3` but not `pip`
- pyenv creates shims for both `pip` and `pip3` at `~/.pyenv/shims/`
- `exec.LookPath("pip")` finds the shim file → thinks pip is available
- But running `pip` fails: `pyenv: pip: command not found`
- No fallback to pip3 is triggered because code thought pip was available

## Solution

Changed `getExecutable()` in `artifactory/commands/python/python.go` to verify pip/pip3 actually execute (via `--version`) instead of just checking if they exist in PATH (`exec.LookPath`).

**Before:**
```go
if _, err := exec.LookPath("pip"); err == nil {
    return "pip", nil  // Found shim file, but may not work
}
```

**After:**
```go
if exec.Command("pip", "--version").Run() == nil {
    return "pip", nil  // Verified it actually runs
}
```

This ensures fallback to pip3 works correctly with pyenv and similar version managers.

## Testing

- ✅ All existing tests pass
- ✅ `TestGetExecutable` verifies pip detection works
- ✅ No linter errors