### PR TITLE
Narrow down search criteria to uploaded file only

### DIFF
--- a/artifactory/commands/python/twine.go
+++ b/artifactory/commands/python/twine.go
@@ -193,7 +193,7 @@ func (tc *TwineCommand) uploadAndCollectBuildInfo() error {
 
 	var fileInitials string
 	for _, arg := range artifacts {
-		if strings.HasSuffix(arg.Name, "tar.gz") {
+		if strings.HasSuffix(arg.Name, ".tar.gz") {
 			fileInitials = arg.Name
 		}
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
what: Previously it was searching for all file by removing .tar.gz suffix, resulting to find the files which have similar names.
Now, changed has been made to search only for uploaded file.