### PR TITLE
Revert: Go setup - Restore direct suffix

### DIFF
--- a/artifactory/commands/setup/setup.go
+++ b/artifactory/commands/setup/setup.go
@@ -348,7 +348,7 @@ func (sc *SetupCommand) configureYarn() (err error) {
 // configureGo configures Go to use the Artifactory repository for GOPROXY.
 // Runs the following command:
 //
-//	go env -w GOPROXY=https://<user>:<token>@<your-artifactory-url>/artifactory/go/<repo-name>
+//	go env -w GOPROXY=https://<user>:<token>@<your-artifactory-url>/artifactory/go/<repo-name>,direct
 func (sc *SetupCommand) configureGo() error {
 	if goProxyVal := os.Getenv("GOPROXY"); goProxyVal != "" {
 		// Remove the variable so it won't override the newly configured proxy (temporarily).
@@ -363,7 +363,7 @@ func (sc *SetupCommand) configureGo() error {
 		log.Warn(fmt.Sprintf("A local GOPROXY='%s' is set and will override the global setting.\n"+
 			"Unset it in your shell config (e.g., .zshrc, .bashrc).", goProxyVal))
 	}
-	repoWithCredsUrl, err := golang.GetArtifactoryRemoteRepoUrl(sc.serverDetails, sc.repoName, golang.GoProxyUrlParams{Direct: false})
+	repoWithCredsUrl, err := golang.GetArtifactoryRemoteRepoUrl(sc.serverDetails, sc.repoName, golang.GoProxyUrlParams{Direct: true})
 	if err != nil {
 		return fmt.Errorf("failed to get Go repository URL: %w", err)
 	}


### PR DESCRIPTION
Reverts PR #158 to restore the `,direct` suffix in Go GOPROXY setup.