### PR TITLE
Support multi user profile build-info collection

### DIFF
--- a/artifactory/commands/conan/artifacts_test.go
+++ b/artifactory/commands/conan/artifacts_test.go
@@ -149,7 +149,6 @@ func TestBuildArtifactQuery(t *testing.T) {
 	}
 }
 
-
 func TestBuildPropertySetter_FormatBuildProperties(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -192,9 +191,9 @@ func TestBuildPropertySetter_FormatBuildProperties(t *testing.T) {
 
 func TestNewArtifactCollector(t *testing.T) {
 	targetRepo := "conan-local"
-	
+
 	collector := NewArtifactCollector(nil, targetRepo)
-	
+
 	assert.NotNil(t, collector)
 	assert.Equal(t, targetRepo, collector.targetRepo)
 	assert.Nil(t, collector.serverDetails)
@@ -205,16 +204,12 @@ func TestNewBuildPropertySetter(t *testing.T) {
 	buildNumber := "1"
 	projectKey := "test-project"
 	targetRepo := "conan-local"
-	
+
 	setter := NewBuildPropertySetter(nil, targetRepo, buildName, buildNumber, projectKey)
-	
+
 	assert.NotNil(t, setter)
 	assert.Equal(t, buildName, setter.buildName)
 	assert.Equal(t, buildNumber, setter.buildNumber)
 	assert.Equal(t, projectKey, setter.projectKey)
 	assert.Equal(t, targetRepo, setter.targetRepo)
 }
-
-
-
-

--- a/artifactory/commands/conan/command_test.go
+++ b/artifactory/commands/conan/command_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewConanCommand(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	assert.NotNil(t, cmd)
 	assert.Empty(t, cmd.commandName)
 	assert.Nil(t, cmd.args)
@@ -19,9 +19,9 @@ func TestNewConanCommand(t *testing.T) {
 
 func TestConanCommand_SetCommandName(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	result := cmd.SetCommandName("install")
-	
+
 	assert.Equal(t, "install", cmd.commandName)
 	assert.Same(t, cmd, result, "SetCommandName should return same instance for chaining")
 }
@@ -29,9 +29,9 @@ func TestConanCommand_SetCommandName(t *testing.T) {
 func TestConanCommand_SetArgs(t *testing.T) {
 	cmd := NewConanCommand()
 	args := []string{".", "--build=missing"}
-	
+
 	result := cmd.SetArgs(args)
-	
+
 	assert.Equal(t, args, cmd.args)
 	assert.Same(t, cmd, result, "SetArgs should return same instance for chaining")
 }
@@ -41,18 +41,18 @@ func TestConanCommand_SetServerDetails(t *testing.T) {
 	serverDetails := &config.ServerDetails{
 		ServerId: "test-server",
 	}
-	
+
 	result := cmd.SetServerDetails(serverDetails)
-	
+
 	assert.Equal(t, serverDetails, cmd.serverDetails)
 	assert.Same(t, cmd, result, "SetServerDetails should return same instance for chaining")
 }
 
 func TestConanCommand_CommandName(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	result := cmd.CommandName()
-	
+
 	assert.Equal(t, "rt_conan", result)
 }
 
@@ -62,9 +62,9 @@ func TestConanCommand_ServerDetails(t *testing.T) {
 		ServerId: "test-server",
 	}
 	cmd.serverDetails = serverDetails
-	
+
 	result, err := cmd.ServerDetails()
-	
+
 	assert.NoError(t, err)
 	assert.Equal(t, serverDetails, result)
 }
@@ -73,9 +73,9 @@ func TestConanCommand_GetCmd(t *testing.T) {
 	cmd := NewConanCommand()
 	cmd.commandName = "install"
 	cmd.args = []string{".", "--build=missing"}
-	
+
 	execCmd := cmd.GetCmd()
-	
+
 	assert.NotNil(t, execCmd)
 	assert.Equal(t, "conan", execCmd.Path[len(execCmd.Path)-5:]) // ends with "conan"
 	assert.Contains(t, execCmd.Args, "install")
@@ -85,43 +85,38 @@ func TestConanCommand_GetCmd(t *testing.T) {
 
 func TestConanCommand_GetEnv(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	env := cmd.GetEnv()
-	
+
 	assert.NotNil(t, env)
 	assert.Empty(t, env)
 }
 
 func TestConanCommand_GetStdWriter(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	writer := cmd.GetStdWriter()
-	
+
 	assert.Nil(t, writer)
 }
 
 func TestConanCommand_GetErrWriter(t *testing.T) {
 	cmd := NewConanCommand()
-	
+
 	writer := cmd.GetErrWriter()
-	
+
 	assert.Nil(t, writer)
 }
 
 func TestConanCommand_ChainedSetters(t *testing.T) {
 	serverDetails := &config.ServerDetails{ServerId: "test"}
-	
+
 	cmd := NewConanCommand().
 		SetCommandName("upload").
 		SetArgs([]string{"pkg/1.0", "-r", "remote"}).
 		SetServerDetails(serverDetails)
-	
+
 	assert.Equal(t, "upload", cmd.commandName)
 	assert.Equal(t, []string{"pkg/1.0", "-r", "remote"}, cmd.args)
 	assert.Equal(t, serverDetails, cmd.serverDetails)
 }
-
-
-
-
-

--- a/artifactory/commands/conan/login_test.go
+++ b/artifactory/commands/conan/login_test.go
@@ -299,7 +299,3 @@ func TestFormatServerIDs(t *testing.T) {
 		})
 	}
 }
-
-
-
-

--- a/artifactory/commands/conan/upload_test.go
+++ b/artifactory/commands/conan/upload_test.go
@@ -114,19 +114,13 @@ Upload completed in 3s
 	}
 }
 
-
 func TestNewUploadProcessor(t *testing.T) {
 	workingDir := "/test/path"
-	
+
 	processor := NewUploadProcessor(workingDir, nil, nil)
-	
+
 	assert.NotNil(t, processor)
 	assert.Equal(t, workingDir, processor.workingDir)
 	assert.Nil(t, processor.buildConfiguration)
 	assert.Nil(t, processor.serverDetails)
 }
-
-
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.20.7
 	github.com/jedib0t/go-pretty/v6 v6.7.5
-	github.com/jfrog/build-info-go v1.13.1-0.20260106060835-a1a07c967546
+	github.com/jfrog/build-info-go v1.13.1-0.20260106203543-03b99793ca5a
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251223102649-e659f6937251
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20251230061734-d954605bdb23
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.21.0


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----

Description:
Support collection of build-info for multi user builds.

depends on:
1. cli - https://github.com/jfrog/jfrog-cli/pull/3296
2. core - https://github.com/jfrog/jfrog-cli-core/pull/1512
3. bi - https://github.com/jfrog/build-info-go/pull/360