### PR TITLE
Fix Windows temp file cleanup failures in build-add-dependencies command

### DIFF
--- a/artifactory/commands/buildinfo/adddependencies.go
+++ b/artifactory/commands/buildinfo/adddependencies.go
@@ -2,9 +2,10 @@ package buildinfo
 
 import (
 	"errors"
-	ioutils "github.com/jfrog/gofrog/io"
 	regxp "regexp"
 	"strconv"
+
+	ioutils "github.com/jfrog/gofrog/io"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
 	commandsutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
@@ -152,6 +153,7 @@ func (badc *BuildAddDependenciesCommand) collectRemoteDependencies() (success, f
 	if err != nil {
 		return
 	}
+	defer ioutils.Close(reader, &err)
 	success, fail, err = badc.readRemoteDependencies(reader)
 	return
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
## Description

Added missing defer ioutils.Close(reader, &err) in collectRemoteDependencies()