### PR TITLE
Fix: DeleteCommand returns 0 for SuccessCount and FailCount when errors occur

### DIFF
--- a/artifactory/commands/generic/delete.go
+++ b/artifactory/commands/generic/delete.go
@@ -48,13 +48,13 @@ func (dc *DeleteCommand) Run() (err error) {
 		}
 	}
 	if allowDelete {
-		successCount, failedCount, deleteErr := dc.DeleteFiles(reader)
+		var successCount, failedCount int
+		successCount, failedCount, err = dc.DeleteFiles(reader)
 		// Always set the result counts, even if an error occurred
 		// This follows the pattern used by move/copy commands
 		result := dc.Result()
 		result.SetSuccessCount(successCount)
 		result.SetFailCount(failedCount)
-		err = deleteErr
 	}
 	return
 }

--- a/artifactory/commands/generic/delete_test.go
+++ b/artifactory/commands/generic/delete_test.go
@@ -250,11 +250,11 @@ func TestErrorsJoin(t *testing.T) {
 // length - deletedCount represents failed items
 func TestDeleteFilesCountBehavior(t *testing.T) {
 	tests := []struct {
-		name                  string
-		deletedCount          int
-		totalLength           int
-		expectedSuccessCount  int
-		expectedFailedCount   int
+		name                 string
+		deletedCount         int
+		totalLength          int
+		expectedSuccessCount int
+		expectedFailedCount  int
 	}{
 		{
 			name:                 "All items deleted successfully",
@@ -304,4 +304,3 @@ func TestDeleteFilesCountBehavior(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
## Description

This PR fixes a bug where DeleteCommand.Result().SuccessCount() and Result().FailCount() return 0 when 404 errors (or other errors) occur during deletion, even though some files may have been successfully deleted.

When using DeleteCommand and encountering errors (e.g., 404 errors when items are already deleted by another process), both SuccessCount() and FailCount() returned 0

## solution
Changed to capture the deletion error separately and return actual counts regardless of whether an error occurred.