### PR TITLE
Export GetJavaUserHome function

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -385,7 +385,7 @@ func WriteInitScript(initScript string) error {
 	gradleHome := os.Getenv(UserHomeEnv)
 	if gradleHome == "" {
 		// Try Java's user.home first (fixes container issue where $HOME != user.home)
-		if javaHome, err := getJavaUserHome(); err == nil && javaHome != "" {
+		if javaHome, err := GetJavaUserHome(); err == nil && javaHome != "" {
 			log.Debug("Using Java user.home for Gradle:", javaHome)
 			gradleHome = filepath.Join(javaHome, ".gradle")
 		} else {
@@ -407,10 +407,10 @@ func WriteInitScript(initScript string) error {
 	return nil
 }
 
-// getJavaUserHome queries Java for its user.home system property.
+// GetJavaUserHome queries Java for its user.home system property.
 // Gradle uses this property (not $HOME) to determine where to look for init scripts.
 // This fixes issues in containers where $HOME and Java's user.home can differ.
-func getJavaUserHome() (string, error) {
+func GetJavaUserHome() (string, error) {
 	cmd := exec.Command("java", "-XshowSettings:properties", "-version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -420,7 +420,7 @@ func getJavaUserHome() (string, error) {
 }
 
 // parseUserHomeFromJavaOutput extracts the user.home property from Java's -XshowSettings:properties output.
-// This is separated from getJavaUserHome for unit testing purposes.
+// This is separated from GetJavaUserHome for unit testing purposes.
 func parseUserHomeFromJavaOutput(output string) (string, error) {
 	for _, line := range strings.Split(output, "\n") {
 		if strings.Contains(line, javaUserHome) {

--- a/artifactory/commands/gradle/gradle_test.go
+++ b/artifactory/commands/gradle/gradle_test.go
@@ -251,7 +251,7 @@ func TestParseUserHomeFromJavaOutput(t *testing.T) {
 // This is the fix for container environments where $HOME differs from Java's user.home.
 func TestWriteInitScriptUsesJavaUserHome(t *testing.T) {
 	// Get Java's user.home - skip if Java is not available
-	javaHome, err := getJavaUserHome()
+	javaHome, err := GetJavaUserHome()
 	if err != nil {
 		t.Skip("Java not available, skipping test")
 	}
@@ -282,10 +282,8 @@ func TestWriteInitScriptUsesJavaUserHome(t *testing.T) {
 	_, err = os.Stat(wrongPath)
 	assert.True(t, os.IsNotExist(err), "Init script should NOT be written to $HOME: %s", wrongPath)
 
-	// Cleanup - use t.Cleanup for deferred cleanup
-	t.Cleanup(func() {
-		_ = os.Remove(expectedPath)
-	})
+	// Cleanup
+	os.Remove(expectedPath)
 }
 
 // TestWriteInitScriptFallsBackToHome tests that WriteInitScript falls back to $HOME
@@ -300,8 +298,9 @@ func TestWriteInitScriptFallsBackToHome(t *testing.T) {
 
 	// Temporarily modify PATH to ensure Java is not found
 	// This simulates an environment where Java is not installed
-	// Note: t.Setenv automatically restores the original value after the test
+	originalPath := os.Getenv("PATH")
 	t.Setenv("PATH", "/nonexistent")
+	defer os.Setenv("PATH", originalPath)
 
 	initScript := "test init script for HOME fallback case"
 


### PR DESCRIPTION
Make GetJavaUserHome public so external packages can reuse the Java user.home detection logic for Gradle configuration.
