### PR TITLE
Support npm run native

### DIFF
--- a/artifactory/commands/npm/common.go
+++ b/artifactory/commands/npm/common.go
@@ -1,8 +1,11 @@
 package npm
 
 import (
+	"github.com/jfrog/build-info-go/flexpack"
 	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type CommonArgs struct {
@@ -40,4 +43,30 @@ func (ca *CommonArgs) UseNative() bool {
 func (ca *CommonArgs) SetUseNative(useNpmRc bool) *CommonArgs {
 	ca.useNative = useNpmRc
 	return ca
+}
+
+// CheckIsNativeAndFetchFilteredArgs checks if native mode should be enabled.
+// It first checks the JFROG_RUN_NATIVE environment variable (preferred),
+// then falls back to the deprecated --run-native flag for backward compatibility.
+// Returns: useNative flag, filtered args (with --run-native removed if present), error
+func CheckIsNativeAndFetchFilteredArgs(args []string) (useNative bool, filteredArgs []string, err error) {
+	filteredArgs = args
+	// Check JFROG_RUN_NATIVE environment variable first (preferred method)
+	useNative = flexpack.IsFlexPackEnabled()
+	if useNative {
+		log.Info("Running npm in native mode (JFROG_RUN_NATIVE=true)")
+		return
+	}
+
+	// Check deprecated --run-native flag for backward compatibility
+	filteredArgs, useNativeFlag, err := coreutils.ExtractUseNativeFromArgs(args)
+	if err != nil {
+		return false, args, err
+	}
+	if useNativeFlag {
+		log.Warn("The --run-native flag is deprecated. Please use JFROG_RUN_NATIVE=true environment variable instead.")
+		log.Info("Running npm in native mode")
+		useNative = true
+	}
+	return
 }

--- a/artifactory/commands/npm/npmcommand.go
+++ b/artifactory/commands/npm/npmcommand.go
@@ -170,7 +170,8 @@ func (nc *NpmCommand) PreparePrerequisites(repo string) error {
 	}
 	log.Debug("Working directory set to:", nc.workingDirectory)
 
-	_, useNative, err := coreutils.ExtractUseNativeFromArgs(nc.npmArgs)
+	// Check for native mode (env var or deprecated flag)
+	useNative, _, err := CheckIsNativeAndFetchFilteredArgs(nc.npmArgs)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -129,7 +129,8 @@ func (npc *NpmPublishCommand) Init() error {
 	if err != nil {
 		return err
 	}
-	filteredNpmArgs, useNative, err := coreutils.ExtractUseNativeFromArgs(filteredNpmArgs)
+	// Check for native mode (env var or deprecated flag)
+	useNative, filteredNpmArgs, err := CheckIsNativeAndFetchFilteredArgs(filteredNpmArgs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Description:
Earlier for using run native approach for npm, we introduced a --run-native flag but now to align with flexpack approach, we also consider using `JFROG_RUN_NATIVE` env and deprecated the flag.

depends on:
1. https://github.com/jfrog/jfrog-cli/pull/3336