### PR TITLE
remove goproxy from integrationTests workflow

### DIFF
--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -72,7 +72,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -129,7 +128,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -176,7 +174,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -252,7 +249,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -310,7 +306,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -367,7 +362,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout jfrog-cli-artifactory
@@ -430,7 +424,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -486,7 +479,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -534,7 +526,6 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -566,7 +557,6 @@ jobs:
           ./start.sh
         env:
           RTLIC: ${{ secrets.RTLIC }}
-          GOPROXY: direct
 
       - name: Wait for Artifactory to finish loading
         uses: nev7n/wait_for_response@v1
@@ -587,7 +577,6 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -633,7 +622,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -697,7 +685,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4
@@ -748,7 +735,6 @@ jobs:
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     env:
       JFROG_CLI_LOG_LEVEL: DEBUG
-      GOPROXY: direct
     steps:
       - name: Checkout jfrog-cli-artifactory
         uses: actions/checkout@v4


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
The workflow was configured to fetch Go modules directly from source servers (GOPROXY: direct), bypassing the Go module proxy. This approach is more prone to network failures like "connection reset by peer" errors. By removing this setting, Go will now use its default behavior (https://proxy.golang.org,direct), which first attempts to fetch from Google's reliable, cached module proxy before falling back to direct fetching. 