### PR TITLE
Add checkout step for Frogbot scan workflow

### DIFF
--- a/.github/workflows/frogbot-scan-pr.yml
+++ b/.github/workflows/frogbot-scan-pr.yml
@@ -1,6 +1,6 @@
 name: "Frogbot Scan Pull Request"
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize ]
 permissions:
   pull-requests: write


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
- The install-go-with-cache@main action was recently updated to read go.mod to determine which Go version to install 
- go.mod is a file inside our repository, so the repo must be cloned first, The checkout step downloads the repository files onto the runner so that go.mod is available
