### PR TITLE
RTECO-976 - fixed docker oom issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Go
 *_mock.go
 .env
+
+.gradle
+**/gradle*/**/bin

--- a/artifactory/commands/ocicontainer/containermanager.go
+++ b/artifactory/commands/ocicontainer/containermanager.go
@@ -72,7 +72,7 @@ func (containerManager *containerManager) Id(image *Image) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		localImage, err := daemon.Image(ref)
+		localImage, err := daemon.Image(ref, daemon.WithUnbufferedOpener())
 		if err != nil {
 			return "", err
 		}

--- a/artifactory/commands/ocicontainer/containermanager_test.go
+++ b/artifactory/commands/ocicontainer/containermanager_test.go
@@ -1,0 +1,86 @@
+package ocicontainer
+
+import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func isDockerAvailable() bool {
+	cmd := exec.Command("docker", "info")
+	return cmd.Run() == nil
+}
+
+func getImageSizeMB(t *testing.T, imageName string) uint64 {
+	cmd := exec.Command("docker", "inspect", "--format", "{{.Size}}", imageName)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	sizeBytes, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	require.NoError(t, err)
+	return sizeBytes / 1024 / 1024
+}
+
+// Verifies that Id() does not buffer the entire image in memory (OOM fix for #3382).
+func TestDockerClientId_MemoryUsage(t *testing.T) {
+	if !isDockerAvailable() {
+		t.Skip("Docker daemon not available")
+	}
+
+	cmd := exec.Command("docker", "pull", "busybox:latest")
+	if err := cmd.Run(); err != nil {
+		t.Skip("Cannot pull Docker images (no Docker engine or network access)")
+	}
+
+	imageSizeMB := getImageSizeMB(t, "busybox:latest")
+	t.Logf("Image size: %d MB", imageSizeMB)
+
+	ref, err := name.ParseReference("busybox:latest")
+	require.NoError(t, err)
+
+	// --- Buffered (default, the bug) ---
+	runtime.GC()
+	var memBeforeBuffered runtime.MemStats
+	runtime.ReadMemStats(&memBeforeBuffered)
+
+	bufferedImg, err := daemon.Image(ref)
+	require.NoError(t, err)
+	_, err = bufferedImg.Manifest()
+	require.NoError(t, err)
+
+	var memAfterBuffered runtime.MemStats
+	runtime.ReadMemStats(&memAfterBuffered)
+	bufferedAllocMB := (memAfterBuffered.TotalAlloc - memBeforeBuffered.TotalAlloc) / 1024 / 1024
+	t.Logf("[BUFFERED]   Memory allocated: %d MB (default — causes OOM on large images)", bufferedAllocMB)
+
+	// --- Unbuffered (the fix) ---
+	runtime.GC()
+	var memBeforeUnbuffered runtime.MemStats
+	runtime.ReadMemStats(&memBeforeUnbuffered)
+
+	cm := &containerManager{Type: DockerClient}
+	image := NewImage("busybox:latest")
+	_, err = cm.Id(image)
+	require.NoError(t, err)
+
+	var memAfterUnbuffered runtime.MemStats
+	runtime.ReadMemStats(&memAfterUnbuffered)
+	unbufferedAllocMB := (memAfterUnbuffered.TotalAlloc - memBeforeUnbuffered.TotalAlloc) / 1024 / 1024
+	t.Logf("[UNBUFFERED] Memory allocated: %d MB (fix — streams without buffering)", unbufferedAllocMB)
+
+	t.Logf("Savings: %d MB", bufferedAllocMB-unbufferedAllocMB)
+
+	// Unbuffered should allocate less than half the image size
+	threshold := imageSizeMB / 2
+	if threshold < 10 {
+		threshold = 10
+	}
+	assert.Less(t, unbufferedAllocMB, threshold,
+		"Id() allocated %d MB for a %d MB image — may be buffering entire image in memory (OOM risk for large images)", unbufferedAllocMB, imageSizeMB)
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----

Description:
This is fix to provide solution to the problem where we need to calculate config Id of an docker image with 2 factor verification:

1. earlier docker save triggered due to daemon.Image().Manifest call used to load entire tarball saved into memory.
2. now docker save will stream the tarball into disk to avoid buffering, (UnbufferedOpener)