### PR TITLE
fix/build-filter-in-pattern-aql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -198,6 +198,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263
+
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416095522-06d5912f4061
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4
+replace github.com/jfrog/jfrog-client-go => github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4 h1:5g4+HFhY49547g6OVb8xhipM8rlZHdbbFS08kt2MMxc=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad h1:jeJm/+EO7qlkNJ/oCQ22kdSspZL/A2OQHWMn8b81px8=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad h1:jeJm/+EO7qlkNJ/oCQ22kdSspZL/A2OQHWMn8b81px8=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416080213-1b67032ca9ad/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416095522-06d5912f4061 h1:mm3A8OnpbV64I3lF8r121LOWvF37noSnGDfQqIFYLZY=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416095522-06d5912f4061/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894 h1:tMDXcEIJx+OR87K99QjJ7DNKzfafi+7yVO4J8TbIBrg=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470 h1:86rsA8CgTT3hZhMWIjg10PHlPqIiYDgQKTBQ2oypyYo=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,6 @@ github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b h1:gGGm
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b/go.mod h1:+Hnaikp/xCSPD/q7txxRy4Zc0wzjW/usrCSf+6uONSQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f h1:zooemucdHsJcRfGhKkyStpOZvJ3ErOTOkOIQULVKOgw=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
@@ -500,6 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263 h1:KGsvHb99jPwj1VWWJD2FgjD41F6w+HD3LSBEAUkql1U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470 h1:86rsA8CgTT3hZhMWIjg10PHlPqIiYDgQKTBQ2oypyYo=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412212001-56962407f470/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4 h1:5g4+HFhY49547g6OVb8xhipM8rlZHdbbFS08kt2MMxc=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260412222345-fd75f1bb2fc4/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263 h1:KGsvHb99jPwj1VWWJD2FgjD41F6w+HD3LSBEAUkql1U=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260330041950-e22db0130263/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894 h1:tMDXcEIJx+OR87K99QjJ7DNKzfafi+7yVO4J8TbIBrg=
+github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260407063057-516ee84a5894/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b h1:PCvN
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b h1:45UJJVG/jAA7/q2c/I6wOvKx8wu7EqTD2tEUtktgyug=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
@@ -498,8 +500,6 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416095522-06d5912f4061 h1:mm3A8OnpbV64I3lF8r121LOWvF37noSnGDfQqIFYLZY=
-github.com/reshmifrog/jfrog-client-go v1.52.1-0.20260416095522-06d5912f4061/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
**Problem:**  
 When a spec has both build AND pattern, the old code didn't recognize it as a build search. It treated it as a pattern-only search (WILDCARD), which meant:

  1. It generated an AQL query from the pattern — completely ignoring the build name
  2. This AQL scanned the entire repository matching the pattern (could be millions of files)
  3. Only after downloading all those results, it filtered them by the build's checksums in memory

 For large repositories like the customer's docker-local-ash, this made the command run for an extremely long time or timeout.

 Why Not Use a REST API Instead of AQL?

 We explored this. Artifactory has several REST APIs:

  - Build Info API (GET /api/build/{name}/{number}) — returns build metadata, but artifact paths are relative to the module, not the full Artifactory path. You'd need extra lookups to find where each file actually lives.
  - Build Artifacts API (GET /api/builds/buildArtifacts/...) — returns file locations, but has indexing delays for recently-published builds (our CI tests caught this — it returned 0 results for a build that was just published).
  - Checksum Search (GET /api/search/checksum) — requires one HTTP call per artifact. For a build with 500 artifacts, that's 500 HTTP round-trips.

 None of these REST APIs support combining a build filter with a pattern filter in a single call. We'd always need multiple API calls + client-side merging, which adds complexity and is slower than a single well-scoped AQL query.

 **The Fix:**

  We flipped the search strategy from "scan by pattern first, filter by build second" to "search by build first, filter by pattern second".

 A build typically has 50–500 artifacts. A broad pattern can match millions of files. So searching the build first and then filtering by pattern is dramatically faster.

**What we changed:**

  1. Routing — When the spec has both build and pattern, we now route it to the BUILD strategy instead of WILDCARD
  2. Pattern filter — After the BUILD strategy fetches the build's artifacts (small set), we added a step that filters those results to only include files matching the pattern
  3. AQL over dedicated API — When a pattern is present, we use build-scoped AQL (artifact.module.build.name = "X") instead of the dedicated build-artifacts REST API, because the REST API has indexing delays for recently-published builds