### PR TITLE
fix/reference-token-privilege-escalation

### DIFF
--- a/.github/tools/detect-deps/main.go
+++ b/.github/tools/detect-deps/main.go
@@ -121,9 +121,9 @@ func detectDependency(name, modulePath string, replaces map[string]Replace, curr
 		// Parse the replace target
 		newPath := replace.New.Path
 		if strings.HasPrefix(newPath, "github.com/") {
-			// Extract repo and version/ref
+			// Extract repo and version/ref, stripping Go module major version suffixes (e.g. /v2)
 			parts := strings.TrimPrefix(newPath, "github.com/")
-			repo := parts
+			repo := stripMajorVersionSuffix(parts)
 			ref := replace.New.Version
 
 			if ref != "" {
@@ -211,6 +211,15 @@ func resolveFullSHA(repo, shortHash string) string {
 		return sha
 	}
 	return ""
+}
+
+// majorVersionSuffix matches Go module major version suffixes like /v2, /v3, etc.
+var majorVersionSuffix = regexp.MustCompile(`/v\d+$`)
+
+// stripMajorVersionSuffix removes the Go module major version suffix (e.g. /v2)
+// from a repo path, since it's not part of the actual GitHub repository name.
+func stripMajorVersionSuffix(repoPath string) string {
+	return majorVersionSuffix.ReplaceAllString(repoPath, "")
 }
 
 // isValidGitRef validates that a string is a valid git reference name

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - main
 
-  pull_request_target:
-    types: [labeled]
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - main
 
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches:
       - main
 

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
-	github.com/go-git/go-git/v5 v5.17.0 // indirect
+	github.com/go-git/go-git/v5 v5.17.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.25.0 // indirect
@@ -197,6 +197,8 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f
 	github.com/pkg/errors v0.9.1
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7
+// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d
 
 // replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
 

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDz
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.17.0 h1:AbyI4xf+7DsjINHMu35quAh4wJygKBKBuXVjV/pxesM=
-github.com/go-git/go-git/v5 v5.17.0/go.mod h1:f82C4YiLx+Lhi8eHxltLeGC5uBTXSFa6PC5WW9o4SjI=
+github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
+github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -384,8 +384,6 @@ github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b h1:gGGmYXuYvcNns1BnLQI13lC+pgMxrmenx+ramtolQuA=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b/go.mod h1:+Hnaikp/xCSPD/q7txxRy4Zc0wzjW/usrCSf+6uONSQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f h1:zooemucdHsJcRfGhKkyStpOZvJ3ErOTOkOIQULVKOgw=
@@ -500,6 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25 h1:2GzroMG5IbGoIAEhrEhvrLv3Z4o0vihdtpdUmf/5idQ=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25/go.mod h1:nYC5zoLtokfPvNfc/04XS+1F/SmOQebCo17Tq2R9KgQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d h1:qZDBbj25QT3b1Ox/J1kWGrfO4+YvdM2CTKpSgSdZZeA=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881 h1:KfOzEnU2njIb15edAXwRcDOkcibbhR0YP27cOSsvVvs=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25 h1:2GzroMG5IbGoIAEhrEhvrLv3Z4o0vihdtpdUmf/5idQ=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260410091830-f78ad14cae25/go.mod h1:nYC5zoLtokfPvNfc/04XS+1F/SmOQebCo17Tq2R9KgQ=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d h1:qZDBbj25QT3b1Ox/J1kWGrfO4+YvdM2CTKpSgSdZZeA=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260412122158-8266c74b588d/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881 h1:KfOzEnU2njIb15edAXwRcDOkcibbhR0YP27cOSsvVvs=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260413084200-144c73906881/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7 h1:JPpNHfRgqFshE5BMCGgOoFxsbUO1cwVRo//1CgW/GBo=
+github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b h1:PCvNCdTYojr9u5X5TVTj/3oSnHEe8kJ9I50X0Wb5iJg=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f h1:zooemucdHsJcRfGhKkyStpOZvJ3ErOTOkOIQULVKOgw=
@@ -498,8 +500,6 @@ github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5/go.mod h1:WZjPDy7VNzn77AAfnAfVjZNvfJTYfPetfZk5yoSTLaQ=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7 h1:JPpNHfRgqFshE5BMCGgOoFxsbUO1cwVRo//1CgW/GBo=
-github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Problem: When a user configures JFrog CLI with a restricted reference token (e.g Viewer scope) as the password, the CLI automatically creates a new token using the deprecated Artifactory API (POST /api/security/token) with scope=member-of-groups:*. This deprecated API does not enforce scope ceiling, so it issues a fully privileged token escalating from read-only to full delete permissions.
Solution: Migrated the CLI's token creation from the deprecated Artifactory API to the current Access API (POST /access/api/v1/tokens) with scope=applied-permissions/user. The Access API enforces server-side scope ceiling if the authenticating credential has restricted scope, the server rejects the request with 403 Forbidden, preventing privilege escalation at its root.