### PR TITLE
set docker test platform url

### DIFF
--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -657,7 +657,7 @@ jobs:
 
       - name: Run Docker tests
         working-directory: jfrog-cli
-        run: go test -v -timeout 0 --test.docker
+        run: go test -v -timeout 0 --test.docker --jfrog.url=http://localhost:8082/
 
   Podman-Tests:
     name: Podman ubuntu


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Problem:
The Docker integration tests were failing with HTTP 401 Unauthorized after migrating the CLI's token creation from the deprecated Artifactory API (/api/security/token) to the Access API (/access/api/v1/tokens).
The root cause is that the Docker tests use a containerized Artifactory that exposes two ports 8081 (Artifactory direct port) and 8082 (platform router). The test was defaulting to http://localhost:8081/ as the platform URL. The old Artifactory token API (/api/security/token) is served directly by Artifactory on port 8081, so it worked. However, the Access API (/access/api/v1/tokens) is only reachable through the platform router on port 8082 requests to port 8081 are not forwarded to the Access service, resulting in a 401 authentication failure.
Solution:
Updated the Docker test command to explicitly pass --jfrog.url=http://localhost:8082/ (the platform router port) instead of relying on the default port 8081. This ensures the Access API is reachable through the platform router, and token creation via the Access API works correctly. No other tests were affected because they already use port 8082 (e.g., Artifactory tests pass --jfrog.url=http://127.0.0.1:8082)