### PR TITLE
RTECO-992 - Added support for uv package manager

### DIFF
--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -19,6 +19,7 @@ import (
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	specutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -76,12 +77,17 @@ func (c *NativeUvCommand) Run() error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
+	// Parse pyproject.toml once and reuse across the entire Run invocation.
+	pyproject := parseUvPyproject(workingDir)
+
 	// Resolve publish URL: explicit arg > pyproject.toml
 	deployerRepo := c.deployerRepo
+	// use a local args copy so we don't mutate the receiver
+	args := append([]string(nil), c.args...)
 	if c.commandName == "publish" && deployerRepo == "" {
-		if tomlURL := uvPublishURLFromToml(workingDir); tomlURL != "" {
+		if tomlURL := pyproject.Tool.Uv.PublishURL; tomlURL != "" {
 			deployerRepo = tomlURL
-			c.args = append(c.args, "--publish-url", tomlURL)
+			args = append(args, "--publish-url", tomlURL)
 			log.Info("Using publish URL from pyproject.toml [tool.uv]: " + tomlURL)
 		}
 	}
@@ -94,7 +100,7 @@ func (c *NativeUvCommand) Run() error {
 	}
 
 	log.Info(fmt.Sprintf("Running UV %s.", c.commandName))
-	if err := runUvBinary(append([]string{c.commandName}, c.args...)); err != nil {
+	if err := runUvBinary(append([]string{c.commandName}, args...)); err != nil {
 		return fmt.Errorf("uv %s failed: %w", c.commandName, err)
 	}
 
@@ -114,7 +120,10 @@ func (c *NativeUvCommand) Run() error {
 func (c *NativeUvCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails) {
 	user := serverDetails.User
 	pass := serverDetails.Password
-	if pass == "" {
+	if serverDetails.AccessToken != "" {
+		if user == "" {
+			user = auth.ExtractUsernameFromAccessToken(serverDetails.AccessToken)
+		}
 		pass = serverDetails.AccessToken
 	}
 	if user == "" || pass == "" {
@@ -123,20 +132,19 @@ func (c *NativeUvCommand) injectCredentials(workingDir, deployerRepo string, ser
 
 	injectedAny := false
 
+	// UV_INDEX_URL is UV's legacy global index env var. We log it for visibility but
+	// still proceed with per-index injection below, because UV_INDEX_URL only affects
+	// the default index and does not supply credentials for named [[tool.uv.index]] entries.
 	if os.Getenv("UV_INDEX_URL") != "" {
-		log.Info("UV auth: UV_INDEX_URL is set globally (native)")
+		log.Info("UV auth: UV_INDEX_URL is set globally (native); per-index credential injection still proceeds below")
 	}
 
 	for _, idx := range uvReadIndexesFromToml(workingDir) {
 		envName := uvIndexEnvName(idx.Name)
 		userKey := "UV_INDEX_" + envName + "_USERNAME"
 		switch {
-		case os.Getenv(userKey) != "":
-			log.Info(fmt.Sprintf("UV auth [index %q]: using env var %s (native, step 2)", idx.Name, userKey))
-		case uvURLHasEmbeddedCredentials(idx.URL):
-			log.Info(fmt.Sprintf("UV auth [index %q]: using credentials embedded in URL (native, step 3)", idx.Name))
-		case uvNetrcHasCredentials(idx.URL):
-			log.Info(fmt.Sprintf("UV auth [index %q]: using %s (native, step 4)", idx.Name, uvNetrcPath()))
+		case uvIndexHasNativeCredentials(idx.URL, userKey):
+			log.Info(fmt.Sprintf("UV auth [index %q]: native credentials already present (env var, embedded URL, or netrc)", idx.Name))
 		default:
 			if uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl) {
 				os.Setenv(userKey, user)
@@ -171,24 +179,11 @@ func runUvBinary(args []string) error {
 	return cmd.Run()
 }
 
-// uvGetCommandName strips the first non-flag argument from a slice and returns
-// (commandName, remainingArgs).
-func uvGetCommandName(orgArgs []string) (string, []string) {
-	cmdArgs := make([]string, len(orgArgs))
-	copy(cmdArgs, orgArgs)
-	for i, arg := range cmdArgs {
-		if !strings.HasPrefix(arg, "-") {
-			return arg, append(cmdArgs[:i], cmdArgs[i+1:]...)
-		}
-	}
-	return "", cmdArgs
-}
-
 // ── TOML types ───────────────────────────────────────────────────────────────
 
 type uvIndexEntry struct {
-	Name string
-	URL  string
+	Name string `toml:"name"`
+	URL  string `toml:"url"`
 }
 
 type uvToolUv struct {
@@ -438,7 +433,7 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 					sd, _ = coreConfig.GetDefaultServerConf()
 				}
 				if sd != nil {
-					if indexURL := uvIndexURLFromToml(workingDir); indexURL != "" && !uvServerHostMatches(indexURL, sd.ArtifactoryUrl) {
+					if indexURL := uvIndexURLFromToml(workingDir); indexURL != "" && !uvHostMatchesServer(indexURL, sd.ArtifactoryUrl) {
 						log.Warn(fmt.Sprintf(
 							"UV build-info: jf server config host (%s) differs from index URL host (%s) — "+
 								"dependency checksum enrichment (sha1/md5) will be skipped. "+
@@ -479,7 +474,7 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 			break
 		}
 		if repoKey != "" {
-			if deployerRepo != "" && !uvServerHostMatches(deployerRepo, sd.ArtifactoryUrl) {
+			if deployerRepo != "" && !uvHostMatchesServer(deployerRepo, sd.ArtifactoryUrl) {
 				log.Warn(fmt.Sprintf(
 					"UV build-info: jf server config host (%s) differs from publish URL host (%s) — "+
 						"artifact lookup and build property setting will be skipped. "+
@@ -535,12 +530,6 @@ func uvIndexURLFromToml(workingDir string) string {
 	return ""
 }
 
-// uvServerHostMatches returns true when rawURL's hostname matches the Artifactory server URL hostname.
-func uvServerHostMatches(rawURL, serverURL string) bool {
-	h := uvHostOf(rawURL)
-	return h != "" && h == uvHostOf(serverURL)
-}
-
 // uvEnrichDepsFromArtifactory searches each dependency by filename in the given Artifactory repo
 // and updates the dependency's sha1 and md5 checksums.
 func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, serverDetails *coreConfig.ServerDetails) {
@@ -573,9 +562,9 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, se
 		}
 		var aql struct {
 			Results []struct {
-				Actual_Sha1 string `json:"actual_sha1"`
-				Actual_Md5  string `json:"actual_md5"`
-				Sha256      string `json:"sha256"`
+				ActualSha1 string `json:"actual_sha1"`
+				ActualMd5  string `json:"actual_md5"`
+				Sha256     string `json:"sha256"`
 			} `json:"results"`
 		}
 		if err := json.Unmarshal(result, &aql); err != nil || len(aql.Results) == 0 {
@@ -583,13 +572,13 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, se
 			continue
 		}
 		r := aql.Results[0]
-		deps[i].Checksum.Sha1 = r.Actual_Sha1
-		deps[i].Checksum.Md5 = r.Actual_Md5
+		deps[i].Checksum.Sha1 = r.ActualSha1
+		deps[i].Checksum.Md5 = r.ActualMd5
 		if r.Sha256 != "" {
 			deps[i].Checksum.Sha256 = r.Sha256
 		}
 		enriched++
-		log.Debug(fmt.Sprintf("Enriched %s with sha1=%s md5=%s", dep.Id, r.Actual_Sha1, r.Actual_Md5))
+		log.Debug(fmt.Sprintf("Enriched %s with sha1=%s md5=%s", dep.Id, r.ActualSha1, r.ActualMd5))
 	}
 	if enriched > 0 {
 		log.Info(fmt.Sprintf("Enriched %d/%d UV dependencies with Artifactory checksums (repo: %s)", enriched, len(deps), searchRepo))
@@ -645,7 +634,7 @@ func uvCollectDistArtifacts(workingDir string) ([]buildinfo.Artifact, error) {
 		artifact := buildinfo.Artifact{
 			Name: filename,
 			Path: ".",
-			Type: uvArtifactType(filename),
+			Type: getArtifactType(filename),
 		}
 		if checksums, csErr := uvFileChecksums(filepath.Join(distDir, filename)); csErr == nil {
 			artifact.Checksum = checksums
@@ -668,16 +657,6 @@ func uvFileChecksums(filePath string) (buildinfo.Checksum, error) {
 		Sha256: fileDetails.Checksum.Sha256,
 		Md5:    fileDetails.Checksum.Md5,
 	}, nil
-}
-
-func uvArtifactType(filename string) string {
-	if strings.HasSuffix(filename, ".whl") {
-		return "wheel"
-	}
-	if strings.HasSuffix(filename, ".tar.gz") {
-		return "sdist"
-	}
-	return "unknown"
 }
 
 // uvAddArtifactsToBuildInfo looks up uploaded artifacts in Artifactory and adds them
@@ -717,7 +696,7 @@ func uvAddArtifactsToBuildInfo(bi *buildinfo.BuildInfo, serverDetails *coreConfi
 			artifacts = append(artifacts, buildinfo.Artifact{
 				Name:     result.Name,
 				Path:     result.Path,
-				Type:     uvArtifactType(result.Name),
+				Type:     getArtifactType(result.Name),
 				Checksum: localArtifact.Checksum,
 			})
 			break
@@ -764,6 +743,9 @@ func uvSetBuildProperties(serverDetails *coreConfig.ServerDetails, targetRepo, b
 			continue
 		}
 		_, err = servicesManager.SetProps(services.PropsParams{Reader: searchReader, Props: buildProps})
+		if closeErr := searchReader.Close(); closeErr != nil {
+			log.Warn("Failed to close search reader:", closeErr)
+		}
 		if err != nil {
 			log.Warn(fmt.Sprintf("Failed to set properties on artifact %s: %v", artifact.Name, err))
 		}

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -178,16 +178,15 @@ func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, ser
 	}
 	for _, idx := range indexes {
 		envName := uvIndexEnvName(idx.Name)
-		userKey := "UV_INDEX_" + envName + "_USERNAME"
-		switch {
-		case uvIndexHasNativeCredentials(idx.URL, userKey):
+		userKey := uvIndexUsernameKey(envName)
+		if uvIndexHasNativeCredentials(idx.URL, userKey) {
 			log.Info(fmt.Sprintf("UV auth [index %q]: native credentials already present (env var, embedded URL, or netrc)", idx.Name))
-		default:
+		} else {
 			hostMatches := uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl)
 			explicitServerID := c.serverID != ""
 			if hostMatches || explicitServerID {
 				_ = os.Setenv(userKey, user)
-				_ = os.Setenv("UV_INDEX_"+envName+"_PASSWORD", pass)
+				_ = os.Setenv(uvIndexPasswordKey(envName), pass)
 				injectedAny = true
 				if explicitServerID && !hostMatches {
 					log.Info(fmt.Sprintf("UV auth [index %q]: injecting credentials from --server-id (host override)", idx.Name))
@@ -501,8 +500,8 @@ func uvMatchingIndexCredentials(publishURL, workingDir string) (username, passwo
 			continue
 		}
 		envName := uvIndexEnvName(idx.Name)
-		u := os.Getenv("UV_INDEX_" + envName + "_USERNAME")
-		p := os.Getenv("UV_INDEX_" + envName + "_PASSWORD")
+		u := os.Getenv(uvIndexUsernameKey(envName))
+		p := os.Getenv(uvIndexPasswordKey(envName))
 		if u != "" {
 			return u, p
 		}
@@ -573,6 +572,12 @@ func uvIndexEnvName(name string) string {
 	return strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(upper)
 }
 
+// uvIndexUsernameKey returns the UV_INDEX_<NAME>_USERNAME env var name for a given index env suffix.
+func uvIndexUsernameKey(envName string) string { return "UV_INDEX_" + envName + "_USERNAME" }
+
+// uvIndexPasswordKey returns the UV_INDEX_<NAME>_PASSWORD env var name for a given index env suffix.
+func uvIndexPasswordKey(envName string) string { return "UV_INDEX_" + envName + "_PASSWORD" }
+
 // uvResolveServerDetails returns server details for the given server ID.
 // If serverID is empty, the default configured server is used.
 func uvResolveServerDetails(serverID string) (*coreConfig.ServerDetails, error) {
@@ -588,9 +593,9 @@ func uvResolveServerDetails(serverID string) (*coreConfig.ServerDetails, error) 
 func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string, explicitServerID bool) {
 	switch {
 	case os.Getenv("UV_PUBLISH_TOKEN") != "":
-		log.Info("UV auth [publish]: using UV_PUBLISH_TOKEN (native, step 2a)")
+		log.Debug("UV auth [publish]: using UV_PUBLISH_TOKEN")
 	case os.Getenv("UV_PUBLISH_USERNAME") != "" || os.Getenv("UV_PUBLISH_PASSWORD") != "":
-		log.Info("UV auth [publish]: using UV_PUBLISH_USERNAME/PASSWORD (native, step 2b)")
+		log.Debug("UV auth [publish]: using UV_PUBLISH_USERNAME/PASSWORD")
 	case uvURLHasEmbeddedCredentials(publishURL):
 		log.Info("UV auth [publish]: using credentials embedded in publish URL (native, step 3)")
 	case uvNetrcHasCredentials(publishURL):
@@ -785,13 +790,8 @@ func uvIndexURLFromToml(workingDir string) string {
 
 // uvEnrichDepsFromArtifactory fetches sha1/md5 for all dependencies in a single batched AQL call.
 //
-// Dep IDs are in "name:version" format; actual filenames use "name-version[-platform].whl" or
-// "name-version.tar.gz" with either hyphens or underscores in the name. We search both variants
-// so platform-specific wheels (e.g. macos arm64) and universal wheels both resolve correctly.
-// uvEnrichDirectURLChecksums computes sha1/md5 for direct URL deps (source = { url = "..." })
-// by streaming the file from its URL. Git deps (source = { git = "..." }) are skipped because
-// rebuilding from source would be required to produce a deterministic archive.
-// If a URL is inaccessible (network error, auth required) the dep retains sha256-only — no error.
+// uvEnrichDirectURLChecksums fetches sha1/md5 for direct-URL deps by streaming each file.
+// Git deps are skipped (no downloadable archive). Unreachable URLs retain sha256-only.
 func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[string]string) {
 	for i, dep := range deps {
 		sourceURL, ok := directURLDeps[dep.Id]
@@ -1062,6 +1062,10 @@ func uvAddArtifactsToBuildInfo(bi *buildinfo.BuildInfo, serverDetails *coreConfi
 		}
 	}
 
+	// Modules[0] is safe: guarded by the len(bi.Modules)==0 check at function entry.
+	if len(bi.Modules) == 0 {
+		return nil
+	}
 	bi.Modules[0].Artifacts = artifacts
 	log.Info(fmt.Sprintf("Added %d artifacts to build info", len(artifacts)))
 	return nil

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -23,8 +23,8 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-// NativeUvCommand runs `uv` directly (no config file required) and collects build info.
-type NativeUvCommand struct {
+// NativeUVCommand runs `uv` directly (no config file required) and collects build info.
+type NativeUVCommand struct {
 	commandName        string
 	args               []string
 	serverID           string
@@ -32,46 +32,46 @@ type NativeUvCommand struct {
 	buildConfiguration *buildUtils.BuildConfiguration
 }
 
-// NewNativeUvCommand creates a new NativeUvCommand instance.
-func NewNativeUvCommand() *NativeUvCommand {
-	return &NativeUvCommand{}
+// NewNativeUVCommand creates a new NativeUVCommand instance.
+func NewNativeUVCommand() *NativeUVCommand {
+	return &NativeUVCommand{}
 }
 
-func (c *NativeUvCommand) SetCommandName(name string) *NativeUvCommand {
+func (c *NativeUVCommand) SetCommandName(name string) *NativeUVCommand {
 	c.commandName = name
 	return c
 }
 
-func (c *NativeUvCommand) SetArgs(args []string) *NativeUvCommand {
+func (c *NativeUVCommand) SetArgs(args []string) *NativeUVCommand {
 	c.args = args
 	return c
 }
 
-func (c *NativeUvCommand) SetServerID(serverID string) *NativeUvCommand {
+func (c *NativeUVCommand) SetServerID(serverID string) *NativeUVCommand {
 	c.serverID = serverID
 	return c
 }
 
-func (c *NativeUvCommand) SetDeployerRepo(deployerRepo string) *NativeUvCommand {
+func (c *NativeUVCommand) SetDeployerRepo(deployerRepo string) *NativeUVCommand {
 	c.deployerRepo = deployerRepo
 	return c
 }
 
-func (c *NativeUvCommand) SetBuildConfiguration(bc *buildUtils.BuildConfiguration) *NativeUvCommand {
+func (c *NativeUVCommand) SetBuildConfiguration(bc *buildUtils.BuildConfiguration) *NativeUVCommand {
 	c.buildConfiguration = bc
 	return c
 }
 
-func (c *NativeUvCommand) CommandName() string {
+func (c *NativeUVCommand) CommandName() string {
 	return "rt_uv_native"
 }
 
-func (c *NativeUvCommand) ServerDetails() (*coreConfig.ServerDetails, error) {
+func (c *NativeUVCommand) ServerDetails() (*coreConfig.ServerDetails, error) {
 	return uvResolveServerDetails(c.serverID)
 }
 
 // Run executes the UV command with auth injection and optional build info collection.
-func (c *NativeUvCommand) Run() error {
+func (c *NativeUVCommand) Run() error {
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -117,7 +117,7 @@ func (c *NativeUvCommand) Run() error {
 
 // injectCredentials sets UV_INDEX_* and UV_PUBLISH_* env vars from jf config,
 // only when native UV mechanisms (env vars, embedded URL, netrc) don't already cover the host.
-func (c *NativeUvCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails) {
+func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails) {
 	user := serverDetails.User
 	pass := serverDetails.Password
 	if serverDetails.AccessToken != "" {
@@ -406,11 +406,11 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 		return fmt.Errorf("GetBuildNumber failed: %w", err)
 	}
 
-	uvConfig := flexpack.UvConfig{
+	uvConfig := flexpack.UVConfig{
 		WorkingDirectory:       workingDir,
 		IncludeDevDependencies: false,
 	}
-	collector, err := flexpack.NewUvFlexPack(uvConfig)
+	collector, err := flexpack.NewUVFlexPack(uvConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create UV FlexPack collector: %w", err)
 	}

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -919,14 +919,14 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, di
 			continue
 		}
 		for _, e := range entries {
-			if deps[e.idx].Checksum.Sha1 != "" {
+			if deps[e.idx].Sha1 != "" {
 				continue // already enriched
 			}
 			if strings.HasPrefix(r.Name, e.prefix+"-") || strings.HasPrefix(r.Name, e.prefix+".") {
-				deps[e.idx].Checksum.Sha1 = r.ActualSha1
-				deps[e.idx].Checksum.Md5 = r.ActualMd5
-				if r.Sha256 != "" && deps[e.idx].Checksum.Sha256 == "" {
-					deps[e.idx].Checksum.Sha256 = r.Sha256
+				deps[e.idx].Sha1 = r.ActualSha1
+				deps[e.idx].Md5 = r.ActualMd5
+				if r.Sha256 != "" && deps[e.idx].Sha256 == "" {
+					deps[e.idx].Sha256 = r.Sha256
 				}
 				enriched++
 				break

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -186,8 +186,8 @@ func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, ser
 			hostMatches := uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl)
 			explicitServerID := c.serverID != ""
 			if hostMatches || explicitServerID {
-				os.Setenv(userKey, user)
-				os.Setenv("UV_INDEX_"+envName+"_PASSWORD", pass)
+				_ = os.Setenv(userKey, user)
+				_ = os.Setenv("UV_INDEX_"+envName+"_PASSWORD", pass)
 				injectedAny = true
 				if explicitServerID && !hostMatches {
 					log.Info(fmt.Sprintf("UV auth [index %q]: injecting credentials from --server-id (host override)", idx.Name))
@@ -205,7 +205,7 @@ func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, ser
 	}
 
 	if injectedAny {
-		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+		_ = os.Setenv("UV_KEYRING_PROVIDER", "disabled")
 	}
 
 	if c.commandName == "publish" {
@@ -270,7 +270,7 @@ func uvScriptPath(cmdName string, args []string) string {
 //
 // This gives accurate dependency tracking for the script's isolated environment
 // rather than reporting the surrounding project's dependencies.
-func uvGetScriptBuildInfo(scriptPath string, buildConfiguration *buildUtils.BuildConfiguration, serverDetails *coreConfig.ServerDetails) error {
+func uvGetScriptBuildInfo(scriptPath string, buildConfiguration *buildUtils.BuildConfiguration, _ *coreConfig.ServerDetails) error {
 	lockPath := scriptPath + ".lock"
 	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
 		log.Info(fmt.Sprintf("UV script: creating lock file at %s", lockPath))
@@ -444,9 +444,6 @@ func parseUvPyproject(workingDir string) uvPyprojectToml {
 	return p
 }
 
-func uvPublishURLFromToml(workingDir string) string {
-	return parseUvPyproject(workingDir).Tool.Uv.PublishURL
-}
 
 func uvReadIndexesFromToml(workingDir string) []uvIndexEntry {
 	p := parseUvPyproject(workingDir)
@@ -607,16 +604,16 @@ func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig
 // or the jf server config. When explicitServerID is true, the host-mismatch check is skipped.
 func uvInjectPublishCredentials(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string, explicitServerID bool) {
 	if idxUser, idxPass := uvMatchingIndexCredentials(publishURL, workingDir); idxUser != "" {
-		os.Setenv("UV_PUBLISH_USERNAME", idxUser)
-		os.Setenv("UV_PUBLISH_PASSWORD", idxPass)
-		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+		_ = os.Setenv("UV_PUBLISH_USERNAME", idxUser)
+		_ = os.Setenv("UV_PUBLISH_PASSWORD", idxPass)
+		_ = os.Setenv("UV_KEYRING_PROVIDER", "disabled")
 		log.Info("UV auth [publish]: reusing same-host index credentials for publish")
 		return
 	}
 	if uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) || explicitServerID {
-		os.Setenv("UV_PUBLISH_USERNAME", user)
-		os.Setenv("UV_PUBLISH_PASSWORD", pass)
-		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+		_ = os.Setenv("UV_PUBLISH_USERNAME", user)
+		_ = os.Setenv("UV_PUBLISH_PASSWORD", pass)
+		_ = os.Setenv("UV_KEYRING_PROVIDER", "disabled")
 		if explicitServerID && !uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) {
 			log.Info("UV auth [publish]: injecting credentials from --server-id (host override)")
 		} else {
@@ -798,7 +795,7 @@ func uvIndexURLFromToml(workingDir string) string {
 func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[string]string) {
 	for i, dep := range deps {
 		sourceURL, ok := directURLDeps[dep.Id]
-		if !ok || dep.Checksum.Sha1 != "" {
+		if !ok || dep.Sha1 != "" {
 			continue
 		}
 		// Skip git URLs — no deterministic archive to download
@@ -820,13 +817,13 @@ func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[s
 		sha1w := sha1.New()   //nolint:gosec
 		md5w := md5.New()     //nolint:gosec
 		_, copyErr := io.Copy(io.MultiWriter(sha1w, md5w), resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if copyErr != nil {
 			log.Info(fmt.Sprintf("UV build-info: dep %s could not stream URL — sha256 only", dep.Id))
 			continue
 		}
-		deps[i].Checksum.Sha1 = fmt.Sprintf("%x", sha1w.Sum(nil))
-		deps[i].Checksum.Md5 = fmt.Sprintf("%x", md5w.Sum(nil))
+		deps[i].Sha1 = fmt.Sprintf("%x", sha1w.Sum(nil))
+		deps[i].Md5 = fmt.Sprintf("%x", md5w.Sum(nil))
 		log.Info(fmt.Sprintf("UV build-info: dep %s enriched sha1/md5 from direct URL", dep.Id))
 	}
 }
@@ -898,7 +895,7 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, di
 		return
 	}
 	raw, _ := io.ReadAll(stream)
-	stream.Close()
+	_ = stream.Close()
 
 	var aqlResult struct {
 		Results []struct {

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -1,8 +1,8 @@
 package python
 
 import (
-	"crypto/md5"  //nolint:gosec // #nosec G501 -- sha1/md5 used for Artifactory build-info checksums, not security
-	"crypto/sha1" //nolint:gosec // #nosec G505
+	"crypto/md5"  // #nosec G501 -- sha1/md5 are used for Artifactory build-info checksums, not for security
+	"crypto/sha1" // #nosec G505
 	"encoding/json"
 	"fmt"
 	"io"
@@ -809,13 +809,13 @@ func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[s
 			continue
 		}
 		// Stream the file and compute sha1 + md5 in a single pass — no disk write needed.
-		resp, err := http.Get(sourceURL) //nolint:gosec // #nosec G107 -- URL is from uv.lock, not user input
+		resp, err := http.Get(sourceURL) // #nosec G107 -- URL is from uv.lock, not user input
 		if err != nil {
 			log.Info(fmt.Sprintf("UV build-info: dep %s direct URL not reachable (%v) — sha256 only", dep.Id, err))
 			continue
 		}
-		sha1w := sha1.New() //nolint:gosec // #nosec G401 -- sha1 used for Artifactory build-info, not security
-		md5w := md5.New()   //nolint:gosec // #nosec G401
+		sha1w := sha1.New() // #nosec G401 -- sha1 used for Artifactory build-info checksums, not security
+		md5w := md5.New()   // #nosec G401
 		_, copyErr := io.Copy(io.MultiWriter(sha1w, md5w), resp.Body)
 		_ = resp.Body.Close()
 		if copyErr != nil {

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -1,0 +1,791 @@
+package python
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	buildinfo "github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/build-info-go/flexpack"
+	"github.com/jfrog/gofrog/crypto"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	buildUtils "github.com/jfrog/jfrog-cli-core/v2/common/build"
+	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	specutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// NativeUvCommand runs `uv` directly (no config file required) and collects build info.
+type NativeUvCommand struct {
+	commandName        string
+	args               []string
+	serverID           string
+	deployerRepo       string
+	buildConfiguration *buildUtils.BuildConfiguration
+}
+
+// NewNativeUvCommand creates a new NativeUvCommand instance.
+func NewNativeUvCommand() *NativeUvCommand {
+	return &NativeUvCommand{}
+}
+
+func (c *NativeUvCommand) SetCommandName(name string) *NativeUvCommand {
+	c.commandName = name
+	return c
+}
+
+func (c *NativeUvCommand) SetArgs(args []string) *NativeUvCommand {
+	c.args = args
+	return c
+}
+
+func (c *NativeUvCommand) SetServerID(serverID string) *NativeUvCommand {
+	c.serverID = serverID
+	return c
+}
+
+func (c *NativeUvCommand) SetDeployerRepo(deployerRepo string) *NativeUvCommand {
+	c.deployerRepo = deployerRepo
+	return c
+}
+
+func (c *NativeUvCommand) SetBuildConfiguration(bc *buildUtils.BuildConfiguration) *NativeUvCommand {
+	c.buildConfiguration = bc
+	return c
+}
+
+func (c *NativeUvCommand) CommandName() string {
+	return "rt_uv_native"
+}
+
+func (c *NativeUvCommand) ServerDetails() (*coreConfig.ServerDetails, error) {
+	return uvResolveServerDetails(c.serverID)
+}
+
+// Run executes the UV command with auth injection and optional build info collection.
+func (c *NativeUvCommand) Run() error {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Resolve publish URL: explicit arg > pyproject.toml
+	deployerRepo := c.deployerRepo
+	if c.commandName == "publish" && deployerRepo == "" {
+		if tomlURL := uvPublishURLFromToml(workingDir); tomlURL != "" {
+			deployerRepo = tomlURL
+			c.args = append(c.args, "--publish-url", tomlURL)
+			log.Info("Using publish URL from pyproject.toml [tool.uv]: " + tomlURL)
+		}
+	}
+
+	serverDetails, credErr := uvResolveServerDetails(c.serverID)
+	if credErr != nil {
+		log.Warn("UV auth: could not load jf server config — " + credErr.Error())
+	} else if serverDetails != nil {
+		c.injectCredentials(workingDir, deployerRepo, serverDetails)
+	}
+
+	log.Info(fmt.Sprintf("Running UV %s.", c.commandName))
+	if err := runUvBinary(append([]string{c.commandName}, c.args...)); err != nil {
+		return fmt.Errorf("uv %s failed: %w", c.commandName, err)
+	}
+
+	if c.buildConfiguration != nil {
+		buildName, err := c.buildConfiguration.GetBuildName()
+		if err == nil && buildName != "" {
+			if biErr := uvGetBuildInfo(workingDir, c.buildConfiguration, deployerRepo, c.commandName, serverDetails); biErr != nil {
+				log.Warn("Failed to collect UV build info: " + biErr.Error())
+			}
+		}
+	}
+	return nil
+}
+
+// injectCredentials sets UV_INDEX_* and UV_PUBLISH_* env vars from jf config,
+// only when native UV mechanisms (env vars, embedded URL, netrc) don't already cover the host.
+func (c *NativeUvCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails) {
+	user := serverDetails.User
+	pass := serverDetails.Password
+	if pass == "" {
+		pass = serverDetails.AccessToken
+	}
+	if user == "" || pass == "" {
+		return
+	}
+
+	injectedAny := false
+
+	if os.Getenv("UV_INDEX_URL") != "" {
+		log.Info("UV auth: UV_INDEX_URL is set globally (native)")
+	}
+
+	for _, idx := range uvReadIndexesFromToml(workingDir) {
+		envName := uvIndexEnvName(idx.Name)
+		userKey := "UV_INDEX_" + envName + "_USERNAME"
+		switch {
+		case os.Getenv(userKey) != "":
+			log.Info(fmt.Sprintf("UV auth [index %q]: using env var %s (native, step 2)", idx.Name, userKey))
+		case uvURLHasEmbeddedCredentials(idx.URL):
+			log.Info(fmt.Sprintf("UV auth [index %q]: using credentials embedded in URL (native, step 3)", idx.Name))
+		case uvNetrcHasCredentials(idx.URL):
+			log.Info(fmt.Sprintf("UV auth [index %q]: using %s (native, step 4)", idx.Name, uvNetrcPath()))
+		default:
+			if uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl) {
+				os.Setenv(userKey, user)
+				os.Setenv("UV_INDEX_"+envName+"_PASSWORD", pass)
+				injectedAny = true
+				log.Info(fmt.Sprintf("UV auth [index %q]: using jf server config (user: %s, fallback)", idx.Name, user))
+			} else {
+				log.Warn(fmt.Sprintf(
+					"UV auth [index %q]: index host (%s) differs from jf server config host (%s) — "+
+						"set UV_INDEX_%s_USERNAME/PASSWORD, embed credentials in the URL, or add ~/.netrc entry for %s",
+					idx.Name, uvHostOf(idx.URL), uvHostOf(serverDetails.ArtifactoryUrl),
+					envName, uvHostOf(idx.URL)))
+			}
+		}
+	}
+
+	if injectedAny {
+		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+	}
+
+	if c.commandName == "publish" {
+		uvApplyPublishAuth(deployerRepo, workingDir, serverDetails, user, pass)
+	}
+}
+
+// runUvBinary executes the uv binary with stdio pass-through.
+func runUvBinary(args []string) error {
+	cmd := exec.Command("uv", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// uvGetCommandName strips the first non-flag argument from a slice and returns
+// (commandName, remainingArgs).
+func uvGetCommandName(orgArgs []string) (string, []string) {
+	cmdArgs := make([]string, len(orgArgs))
+	copy(cmdArgs, orgArgs)
+	for i, arg := range cmdArgs {
+		if !strings.HasPrefix(arg, "-") {
+			return arg, append(cmdArgs[:i], cmdArgs[i+1:]...)
+		}
+	}
+	return "", cmdArgs
+}
+
+// ── TOML types ───────────────────────────────────────────────────────────────
+
+type uvIndexEntry struct {
+	Name string
+	URL  string
+}
+
+type uvToolUv struct {
+	PublishURL string         `toml:"publish-url"`
+	Index      []uvIndexEntry `toml:"index"`
+}
+
+type uvPyprojectToml struct {
+	Tool struct {
+		Uv uvToolUv `toml:"uv"`
+	} `toml:"tool"`
+}
+
+// parseUvPyproject reads and parses pyproject.toml from workingDir.
+// Returns a zero-value struct on any error (missing file is normal).
+func parseUvPyproject(workingDir string) uvPyprojectToml {
+	data, err := os.ReadFile(filepath.Join(workingDir, "pyproject.toml"))
+	if err != nil {
+		return uvPyprojectToml{}
+	}
+	var p uvPyprojectToml
+	if err := toml.Unmarshal(data, &p); err != nil {
+		return uvPyprojectToml{}
+	}
+	return p
+}
+
+func uvPublishURLFromToml(workingDir string) string {
+	return parseUvPyproject(workingDir).Tool.Uv.PublishURL
+}
+
+func uvReadIndexesFromToml(workingDir string) []uvIndexEntry {
+	p := parseUvPyproject(workingDir)
+	var entries []uvIndexEntry
+	for _, idx := range p.Tool.Uv.Index {
+		if idx.Name != "" {
+			entries = append(entries, idx)
+		}
+	}
+	return entries
+}
+
+// ── Credential helpers ────────────────────────────────────────────────────────
+
+// uvIndexHasNativeCredentials returns true when any native UV mechanism
+// (env var, embedded URL, netrc) already provides credentials for the index,
+// so jf config injection should be skipped.
+func uvIndexHasNativeCredentials(indexURL, envVarUsername string) bool {
+	if os.Getenv(envVarUsername) != "" {
+		return true
+	}
+	if uvURLHasEmbeddedCredentials(indexURL) {
+		return true
+	}
+	return uvNetrcHasCredentials(indexURL)
+}
+
+// uvHostOf returns the hostname from a URL, or empty string on parse error.
+func uvHostOf(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+// uvHostMatchesServer returns true when publishURL's hostname equals the Artifactory
+// server's hostname, preventing credential injection onto a different instance.
+func uvHostMatchesServer(publishURL, serverURL string) bool {
+	return uvHostOf(publishURL) != "" && uvHostOf(publishURL) == uvHostOf(serverURL)
+}
+
+// uvMatchingIndexCredentials looks for a [[tool.uv.index]] whose URL shares the
+// same hostname as publishURL and returns credentials from the first matching source.
+func uvMatchingIndexCredentials(publishURL, workingDir string) (username, password string) {
+	publishHost := uvHostOf(publishURL)
+	if publishHost == "" {
+		return "", ""
+	}
+	for _, idx := range uvReadIndexesFromToml(workingDir) {
+		if uvHostOf(idx.URL) != publishHost {
+			continue
+		}
+		envName := uvIndexEnvName(idx.Name)
+		u := os.Getenv("UV_INDEX_" + envName + "_USERNAME")
+		p := os.Getenv("UV_INDEX_" + envName + "_PASSWORD")
+		if u != "" {
+			return u, p
+		}
+		if parsed, err := url.Parse(idx.URL); err == nil && parsed.User != nil {
+			u = parsed.User.Username()
+			p, _ = parsed.User.Password()
+			if u != "" {
+				return u, p
+			}
+		}
+	}
+	return "", ""
+}
+
+// uvURLHasEmbeddedCredentials returns true when the URL contains a userinfo component.
+func uvURLHasEmbeddedCredentials(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return parsed.User != nil && parsed.User.Username() != ""
+}
+
+// uvNetrcPath returns the effective netrc file path (respecting the NETRC env var).
+func uvNetrcPath() string {
+	if custom := os.Getenv("NETRC"); custom != "" {
+		return custom
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(homeDir, ".netrc")
+}
+
+// uvNetrcHasCredentials returns true when the netrc file contains a `machine <host>`
+// entry for the hostname of rawURL.
+func uvNetrcHasCredentials(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := parsed.Hostname()
+
+	data, err := os.ReadFile(uvNetrcPath())
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "machine" && fields[1] == host {
+			return true
+		}
+	}
+	return false
+}
+
+// uvIndexEnvName converts a UV index name to the env var suffix UV expects.
+// e.g. "agrasth-uv-local" → "AGRASTH_UV_LOCAL"
+func uvIndexEnvName(name string) string {
+	upper := strings.ToUpper(name)
+	return strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(upper)
+}
+
+// uvResolveServerDetails returns server details for the given server ID.
+// If serverID is empty, the default configured server is used.
+func uvResolveServerDetails(serverID string) (*coreConfig.ServerDetails, error) {
+	if serverID == "" {
+		return coreConfig.GetDefaultServerConf()
+	}
+	return coreConfig.GetSpecificConfig(serverID, true, true)
+}
+
+// uvApplyPublishAuth selects and applies publish credentials following UV's priority chain.
+func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string) {
+	switch {
+	case os.Getenv("UV_PUBLISH_TOKEN") != "":
+		log.Info("UV auth [publish]: using UV_PUBLISH_TOKEN (native, step 2a)")
+	case os.Getenv("UV_PUBLISH_USERNAME") != "" || os.Getenv("UV_PUBLISH_PASSWORD") != "":
+		log.Info("UV auth [publish]: using UV_PUBLISH_USERNAME/PASSWORD (native, step 2b)")
+	case uvURLHasEmbeddedCredentials(publishURL):
+		log.Info("UV auth [publish]: using credentials embedded in publish URL (native, step 3)")
+	case uvNetrcHasCredentials(publishURL):
+		log.Info(fmt.Sprintf("UV auth [publish]: using %s (native, step 4)", uvNetrcPath()))
+	default:
+		uvInjectPublishCredentials(publishURL, workingDir, serverDetails, user, pass)
+	}
+}
+
+// uvInjectPublishCredentials injects publish credentials from same-host index credentials
+// or the jf server config (in that priority order).
+func uvInjectPublishCredentials(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string) {
+	if idxUser, idxPass := uvMatchingIndexCredentials(publishURL, workingDir); idxUser != "" {
+		os.Setenv("UV_PUBLISH_USERNAME", idxUser)
+		os.Setenv("UV_PUBLISH_PASSWORD", idxPass)
+		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+		log.Info("UV auth [publish]: using same-host index credentials (native, step 4b)")
+		return
+	}
+	if uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) {
+		os.Setenv("UV_PUBLISH_USERNAME", user)
+		os.Setenv("UV_PUBLISH_PASSWORD", pass)
+		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
+		log.Info(fmt.Sprintf("UV auth [publish]: using jf server config (user: %s, fallback)", user))
+		return
+	}
+	log.Warn(fmt.Sprintf(
+		"UV auth [publish]: publish URL host (%s) does not match jf server config host (%s) — "+
+			"set UV_PUBLISH_USERNAME/UV_PUBLISH_PASSWORD or UV_PUBLISH_TOKEN to authenticate",
+		uvHostOf(publishURL), uvHostOf(serverDetails.ArtifactoryUrl)))
+}
+
+// ── Build info collection ────────────────────────────────────────────────────
+
+// uvGetBuildInfo collects build info for UV projects using the FlexPack native implementation.
+func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfiguration, deployerRepo, cmdName string, serverDetails *coreConfig.ServerDetails) error {
+	log.Debug(fmt.Sprintf("Collecting UV build info for command '%s' in: %s", cmdName, workingDir))
+
+	buildName, err := buildConfiguration.GetBuildName()
+	if err != nil {
+		return fmt.Errorf("GetBuildName failed: %w", err)
+	}
+	buildNumber, err := buildConfiguration.GetBuildNumber()
+	if err != nil {
+		return fmt.Errorf("GetBuildNumber failed: %w", err)
+	}
+
+	uvConfig := flexpack.UvConfig{
+		WorkingDirectory:       workingDir,
+		IncludeDevDependencies: false,
+	}
+	collector, err := flexpack.NewUvFlexPack(uvConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create UV FlexPack collector: %w", err)
+	}
+
+	bi, err := collector.CollectBuildInfo(buildName, buildNumber)
+	if err != nil {
+		return fmt.Errorf("failed to collect UV build info: %w", err)
+	}
+
+	if customModule := buildConfiguration.GetModule(); customModule != "" && len(bi.Modules) > 0 {
+		bi.Modules[0].Id = customModule
+	}
+
+	switch cmdName {
+	case "sync", "install", "lock", "add", "remove", "run":
+		if len(bi.Modules) > 0 && len(bi.Modules[0].Dependencies) > 0 {
+			if repoKey := uvResolverRepoFromToml(workingDir); repoKey != "" {
+				sd := serverDetails
+				if sd == nil {
+					sd, _ = coreConfig.GetDefaultServerConf()
+				}
+				if sd != nil {
+					if indexURL := uvIndexURLFromToml(workingDir); indexURL != "" && !uvServerHostMatches(indexURL, sd.ArtifactoryUrl) {
+						log.Warn(fmt.Sprintf(
+							"UV build-info: jf server config host (%s) differs from index URL host (%s) — "+
+								"dependency checksum enrichment (sha1/md5) will be skipped. "+
+								"Use --server-id to specify the Artifactory instance that hosts your uv packages.",
+							uvHostOf(sd.ArtifactoryUrl), uvHostOf(indexURL)))
+					}
+					uvEnrichDepsFromArtifactory(bi.Modules[0].Dependencies, repoKey, sd)
+				}
+			}
+		}
+	}
+
+	switch cmdName {
+	case "build":
+		if artifacts, scanErr := uvCollectDistArtifacts(workingDir); scanErr == nil && len(artifacts) > 0 {
+			if len(bi.Modules) > 0 {
+				bi.Modules[0].Artifacts = artifacts
+				log.Info(fmt.Sprintf("Collected %d artifact(s) from dist/", len(artifacts)))
+			}
+		} else if scanErr != nil {
+			log.Warn("Could not scan dist/ for artifacts: " + scanErr.Error())
+		}
+	case "publish":
+		repoKey := uvExtractRepoKeyFromURL(deployerRepo)
+		sd := serverDetails
+		if sd == nil {
+			var sdErr error
+			sd, sdErr = coreConfig.GetDefaultServerConf()
+			if sdErr != nil {
+				log.Warn("Could not load server config for artifact lookup: " + sdErr.Error())
+				sd = nil
+			}
+		}
+		if sd == nil {
+			if artifacts, scanErr := uvCollectDistArtifacts(workingDir); scanErr == nil && len(bi.Modules) > 0 {
+				bi.Modules[0].Artifacts = artifacts
+			}
+			break
+		}
+		if repoKey != "" {
+			if deployerRepo != "" && !uvServerHostMatches(deployerRepo, sd.ArtifactoryUrl) {
+				log.Warn(fmt.Sprintf(
+					"UV build-info: jf server config host (%s) differs from publish URL host (%s) — "+
+						"artifact lookup and build property setting will be skipped. "+
+						"Use --server-id to specify the Artifactory instance that hosts your uv packages.",
+					uvHostOf(sd.ArtifactoryUrl), uvHostOf(deployerRepo)))
+			} else {
+				if artErr := uvAddArtifactsToBuildInfo(bi, sd, repoKey, workingDir); artErr != nil {
+					log.Warn("Could not look up artifact repo paths, using local checksums: " + artErr.Error())
+					if artifacts, scanErr := uvCollectDistArtifacts(workingDir); scanErr == nil && len(bi.Modules) > 0 {
+						bi.Modules[0].Artifacts = artifacts
+					}
+				}
+				if propErr := uvSetBuildProperties(sd, repoKey, buildName, buildNumber, buildConfiguration.GetProject(), bi); propErr != nil {
+					log.Warn("Failed to set build properties on artifacts: " + propErr.Error())
+				}
+			}
+		} else {
+			if artifacts, scanErr := uvCollectDistArtifacts(workingDir); scanErr == nil && len(artifacts) > 0 {
+				if len(bi.Modules) > 0 {
+					bi.Modules[0].Artifacts = artifacts
+					log.Info(fmt.Sprintf("Collected %d artifact(s) from dist/ (no deployer repo set)", len(artifacts)))
+				}
+			}
+		}
+	}
+
+	if err = uvSaveBuildInfo(bi, buildConfiguration); err != nil {
+		return fmt.Errorf("failed to save UV build info: %w", err)
+	}
+
+	log.Info(fmt.Sprintf("UV build info collected. Use 'jf rt bp %s %s' to publish.", buildName, buildNumber))
+	return nil
+}
+
+// uvResolverRepoFromToml extracts the Artifactory repo key from the first
+// [[tool.uv.index]] URL in pyproject.toml.
+func uvResolverRepoFromToml(workingDir string) string {
+	for _, idx := range uvReadIndexesFromToml(workingDir) {
+		if idx.URL != "" {
+			return uvExtractRepoKeyFromURL(idx.URL)
+		}
+	}
+	return ""
+}
+
+// uvIndexURLFromToml returns the raw URL of the first [[tool.uv.index]] entry.
+func uvIndexURLFromToml(workingDir string) string {
+	for _, idx := range uvReadIndexesFromToml(workingDir) {
+		if idx.URL != "" {
+			return idx.URL
+		}
+	}
+	return ""
+}
+
+// uvServerHostMatches returns true when rawURL's hostname matches the Artifactory server URL hostname.
+func uvServerHostMatches(rawURL, serverURL string) bool {
+	h := uvHostOf(rawURL)
+	return h != "" && h == uvHostOf(serverURL)
+}
+
+// uvEnrichDepsFromArtifactory searches each dependency by filename in the given Artifactory repo
+// and updates the dependency's sha1 and md5 checksums.
+func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, serverDetails *coreConfig.ServerDetails) {
+	servicesManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		log.Warn("Could not create services manager for dependency enrichment: " + err.Error())
+		return
+	}
+	searchRepo, err := utils.GetRepoNameForDependenciesSearch(repoKey, servicesManager)
+	if err != nil {
+		log.Warn("Could not resolve repo for dependency search, using as-is: " + err.Error())
+		searchRepo = repoKey
+	}
+
+	enriched := 0
+	for i, dep := range deps {
+		if dep.Id == "" {
+			continue
+		}
+		aqlQuery := specutils.CreateAqlQueryForPypi(searchRepo, dep.Id)
+		stream, err := servicesManager.Aql(aqlQuery)
+		if err != nil {
+			log.Debug(fmt.Sprintf("AQL search failed for %s: %v", dep.Id, err))
+			continue
+		}
+		result, err := io.ReadAll(stream)
+		stream.Close()
+		if err != nil {
+			continue
+		}
+		var aql struct {
+			Results []struct {
+				Actual_Sha1 string `json:"actual_sha1"`
+				Actual_Md5  string `json:"actual_md5"`
+				Sha256      string `json:"sha256"`
+			} `json:"results"`
+		}
+		if err := json.Unmarshal(result, &aql); err != nil || len(aql.Results) == 0 {
+			log.Debug(fmt.Sprintf("Dependency %s not found in repo %s", dep.Id, searchRepo))
+			continue
+		}
+		r := aql.Results[0]
+		deps[i].Checksum.Sha1 = r.Actual_Sha1
+		deps[i].Checksum.Md5 = r.Actual_Md5
+		if r.Sha256 != "" {
+			deps[i].Checksum.Sha256 = r.Sha256
+		}
+		enriched++
+		log.Debug(fmt.Sprintf("Enriched %s with sha1=%s md5=%s", dep.Id, r.Actual_Sha1, r.Actual_Md5))
+	}
+	if enriched > 0 {
+		log.Info(fmt.Sprintf("Enriched %d/%d UV dependencies with Artifactory checksums (repo: %s)", enriched, len(deps), searchRepo))
+	}
+}
+
+// uvExtractRepoKeyFromURL returns just the repo key from a full Artifactory URL or a bare key.
+func uvExtractRepoKeyFromURL(repoOrURL string) string {
+	if repoOrURL == "" {
+		return ""
+	}
+	if !strings.HasPrefix(repoOrURL, "http://") && !strings.HasPrefix(repoOrURL, "https://") {
+		return repoOrURL
+	}
+	parsed, err := url.Parse(repoOrURL)
+	if err != nil {
+		return repoOrURL
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i, seg := range segments {
+		if seg == "api" && i+2 < len(segments) {
+			return segments[i+2]
+		}
+	}
+	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i] != "" && segments[i] != "simple" {
+			return segments[i]
+		}
+	}
+	return repoOrURL
+}
+
+// uvCollectDistArtifacts collects wheel/sdist artifacts from the dist/ directory.
+func uvCollectDistArtifacts(workingDir string) ([]buildinfo.Artifact, error) {
+	distDir := filepath.Join(workingDir, "dist")
+	if _, err := os.Stat(distDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("dist directory not found: %s", distDir)
+	}
+	entries, err := os.ReadDir(distDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read dist directory: %w", err)
+	}
+
+	var artifacts []buildinfo.Artifact
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filename := entry.Name()
+		if !strings.HasSuffix(filename, ".whl") && !strings.HasSuffix(filename, ".tar.gz") {
+			continue
+		}
+		artifact := buildinfo.Artifact{
+			Name: filename,
+			Path: ".",
+			Type: uvArtifactType(filename),
+		}
+		if checksums, csErr := uvFileChecksums(filepath.Join(distDir, filename)); csErr == nil {
+			artifact.Checksum = checksums
+		} else {
+			log.Warn(fmt.Sprintf("Failed to calculate checksums for %s: %v", filename, csErr))
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts, nil
+}
+
+// uvFileChecksums calculates SHA1, SHA256, and MD5 checksums for a file.
+func uvFileChecksums(filePath string) (buildinfo.Checksum, error) {
+	fileDetails, err := crypto.GetFileDetails(filePath, true)
+	if err != nil {
+		return buildinfo.Checksum{}, fmt.Errorf("failed to calculate checksums: %w", err)
+	}
+	return buildinfo.Checksum{
+		Sha1:   fileDetails.Checksum.Sha1,
+		Sha256: fileDetails.Checksum.Sha256,
+		Md5:    fileDetails.Checksum.Md5,
+	}, nil
+}
+
+func uvArtifactType(filename string) string {
+	if strings.HasSuffix(filename, ".whl") {
+		return "wheel"
+	}
+	if strings.HasSuffix(filename, ".tar.gz") {
+		return "sdist"
+	}
+	return "unknown"
+}
+
+// uvAddArtifactsToBuildInfo looks up uploaded artifacts in Artifactory and adds them
+// to the build info module.
+func uvAddArtifactsToBuildInfo(bi *buildinfo.BuildInfo, serverDetails *coreConfig.ServerDetails, targetRepo, workingDir string) error {
+	if len(bi.Modules) == 0 {
+		return fmt.Errorf("no modules found in build info")
+	}
+	localArtifacts, err := uvCollectDistArtifacts(workingDir)
+	if err != nil {
+		return fmt.Errorf("failed to get local artifacts: %w", err)
+	}
+	if len(localArtifacts) == 0 {
+		return nil
+	}
+
+	servicesManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return fmt.Errorf("failed to create services manager: %w", err)
+	}
+
+	var artifacts []buildinfo.Artifact
+	for _, localArtifact := range localArtifacts {
+		searchParams := services.SearchParams{
+			CommonParams: &specutils.CommonParams{
+				Aql: specutils.Aql{
+					ItemsFind: uvAqlQueryForSearch(targetRepo, localArtifact.Name),
+				},
+			},
+		}
+		searchReader, err := servicesManager.SearchFiles(searchParams)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Failed to search for artifact %s: %v", localArtifact.Name, err))
+			continue
+		}
+		for result := new(specutils.ResultItem); searchReader.NextRecord(result) == nil; result = new(specutils.ResultItem) {
+			artifacts = append(artifacts, buildinfo.Artifact{
+				Name:     result.Name,
+				Path:     result.Path,
+				Type:     uvArtifactType(result.Name),
+				Checksum: localArtifact.Checksum,
+			})
+			break
+		}
+		if err := searchReader.Close(); err != nil {
+			log.Warn("Failed to close search reader:", err)
+		}
+	}
+
+	bi.Modules[0].Artifacts = artifacts
+	log.Info(fmt.Sprintf("Added %d artifacts to build info", len(artifacts)))
+	return nil
+}
+
+// uvSetBuildProperties sets build.name / build.number properties on uploaded Python dist artifacts.
+func uvSetBuildProperties(serverDetails *coreConfig.ServerDetails, targetRepo, buildName, buildNumber, project string, bi *buildinfo.BuildInfo) error {
+	servicesManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return fmt.Errorf("failed to create services manager: %w", err)
+	}
+
+	if err := buildUtils.SaveBuildGeneralDetails(buildName, buildNumber, project); err != nil {
+		return fmt.Errorf("SaveBuildGeneralDetails failed: %w", err)
+	}
+	buildProps, err := buildUtils.CreateBuildProperties(buildName, buildNumber, project)
+	if err != nil {
+		return fmt.Errorf("CreateBuildProperties failed: %w", err)
+	}
+
+	if len(bi.Modules) == 0 || len(bi.Modules[0].Artifacts) == 0 {
+		return nil
+	}
+	for _, artifact := range bi.Modules[0].Artifacts {
+		searchParams := services.SearchParams{
+			CommonParams: &specutils.CommonParams{
+				Aql: specutils.Aql{
+					ItemsFind: uvAqlQueryForSearch(targetRepo, artifact.Name),
+				},
+			},
+		}
+		searchReader, err := servicesManager.SearchFiles(searchParams)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Failed to find artifact %s: %v", artifact.Name, err))
+			continue
+		}
+		_, err = servicesManager.SetProps(services.PropsParams{Reader: searchReader, Props: buildProps})
+		if err != nil {
+			log.Warn(fmt.Sprintf("Failed to set properties on artifact %s: %v", artifact.Name, err))
+		}
+	}
+	log.Info(fmt.Sprintf("Successfully set build properties on %d artifacts", len(bi.Modules[0].Artifacts)))
+	return nil
+}
+
+// uvSaveBuildInfo saves the build info locally for later publishing with 'jf rt bp'.
+func uvSaveBuildInfo(bi *buildinfo.BuildInfo, buildConfiguration *buildUtils.BuildConfiguration) error {
+	service := buildUtils.CreateBuildInfoService()
+	bld, err := service.GetOrCreateBuildWithProject(bi.Name, bi.Number, buildConfiguration.GetProject())
+	if err != nil {
+		return fmt.Errorf("failed to create build: %w", err)
+	}
+	return bld.SaveBuildInfo(bi)
+}
+
+// uvAqlQueryForSearch returns an AQL items.find query for a file in a repo.
+func uvAqlQueryForSearch(repo, file string) string {
+	return fmt.Sprintf(
+		`{"repo": %q, "$or": [{"$and": [{"path": {"$match": "*"}, "name": {"$match": %q}}]}]}`,
+		repo, file,
+	)
+}

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -1,8 +1,8 @@
 package python
 
 import (
-	"crypto/md5"   //nolint:gosec
-	"crypto/sha1"  //nolint:gosec
+	"crypto/md5"  //nolint:gosec // #nosec G501 -- sha1/md5 used for Artifactory build-info checksums, not security
+	"crypto/sha1" //nolint:gosec // #nosec G505
 	"encoding/json"
 	"fmt"
 	"io"
@@ -809,13 +809,13 @@ func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[s
 			continue
 		}
 		// Stream the file and compute sha1 + md5 in a single pass — no disk write needed.
-		resp, err := http.Get(sourceURL) //nolint:gosec
+		resp, err := http.Get(sourceURL) //nolint:gosec // #nosec G107 -- URL is from uv.lock, not user input
 		if err != nil {
 			log.Info(fmt.Sprintf("UV build-info: dep %s direct URL not reachable (%v) — sha256 only", dep.Id, err))
 			continue
 		}
-		sha1w := sha1.New()   //nolint:gosec
-		md5w := md5.New()     //nolint:gosec
+		sha1w := sha1.New() //nolint:gosec // #nosec G401 -- sha1 used for Artifactory build-info, not security
+		md5w := md5.New()   //nolint:gosec // #nosec G401
 		_, copyErr := io.Copy(io.MultiWriter(sha1w, md5w), resp.Body)
 		_ = resp.Body.Close()
 		if copyErr != nil {

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -1,9 +1,12 @@
 package python
 
 import (
+	"crypto/md5"   //nolint:gosec
+	"crypto/sha1"  //nolint:gosec
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -72,6 +75,13 @@ func (c *NativeUVCommand) ServerDetails() (*coreConfig.ServerDetails, error) {
 
 // Run executes the UV command with auth injection and optional build info collection.
 func (c *NativeUVCommand) Run() error {
+	// Help flags (-h / --help) and the bare "help" sub-command must bypass all auth
+	// injection and Artifactory calls. Injecting credential env vars before calling uv
+	// causes uv to print them in its help output, exposing secrets.
+	if isHelpRequest(c.commandName, c.args) {
+		return runUvBinary(append([]string{c.commandName}, c.args...))
+	}
+
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -92,11 +102,16 @@ func (c *NativeUVCommand) Run() error {
 		}
 	}
 
+	// For --script, also read [[tool.uv.index]] from the script's inline PEP 723 metadata.
+	// The script runs in an isolated temp env separate from the project, so its own
+	// index config must be used for credential injection.
+	scriptIndexes := uvScriptInlineIndexes(c.commandName, c.args)
+
 	serverDetails, credErr := uvResolveServerDetails(c.serverID)
 	if credErr != nil {
 		log.Warn("UV auth: could not load jf server config — " + credErr.Error())
 	} else if serverDetails != nil {
-		c.injectCredentials(workingDir, deployerRepo, serverDetails)
+		c.injectCredentials(workingDir, deployerRepo, serverDetails, scriptIndexes)
 	}
 
 	log.Info(fmt.Sprintf("Running UV %s.", c.commandName))
@@ -107,17 +122,34 @@ func (c *NativeUVCommand) Run() error {
 	if c.buildConfiguration != nil {
 		buildName, err := c.buildConfiguration.GetBuildName()
 		if err == nil && buildName != "" {
-			if biErr := uvGetBuildInfo(workingDir, c.buildConfiguration, deployerRepo, c.commandName, serverDetails); biErr != nil {
+			// PEP 723 inline scripts get their own build-info from the adjacent .lock file.
+			if scriptPath := uvScriptPath(c.commandName, c.args); scriptPath != "" {
+				if biErr := uvGetScriptBuildInfo(scriptPath, c.buildConfiguration, serverDetails); biErr != nil {
+					log.Warn("Failed to collect UV script build info: " + biErr.Error())
+				}
+			} else {
+			// For commands that modify the venv, capture exactly what was installed.
+			var installed map[string]string
+			if uvModifiesVenv(c.commandName) {
+				installed = uvInstalledPackages()
+			}
+			if biErr := uvGetBuildInfo(workingDir, c.buildConfiguration, deployerRepo, c.commandName, c.args, installed, serverDetails); biErr != nil {
 				log.Warn("Failed to collect UV build info: " + biErr.Error())
 			}
+			} // end else (not a --script invocation)
 		}
 	}
 	return nil
 }
 
-// injectCredentials sets UV_INDEX_* and UV_PUBLISH_* env vars from jf config,
-// only when native UV mechanisms (env vars, embedded URL, netrc) don't already cover the host.
-func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails) {
+// injectCredentials sets UV_INDEX_* and UV_PUBLISH_* env vars from jf config.
+// When the user explicitly specified --server-id, credentials are injected regardless of
+// URL hostname — the explicit choice overrides the host-mismatch safety check.
+// Without --server-id (using the default server), credentials are only injected when
+// the index URL hostname matches the jf server to prevent cross-instance credential leakage.
+// scriptIndexes are additional index entries parsed from a PEP 723 inline script's metadata;
+// when non-nil they are used instead of the project's pyproject.toml entries.
+func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, serverDetails *coreConfig.ServerDetails, scriptIndexes []uvIndexEntry) {
 	user := serverDetails.User
 	pass := serverDetails.Password
 	if serverDetails.AccessToken != "" {
@@ -132,25 +164,36 @@ func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, ser
 
 	injectedAny := false
 
-	// UV_INDEX_URL is UV's legacy global index env var. We log it for visibility but
-	// still proceed with per-index injection below, because UV_INDEX_URL only affects
-	// the default index and does not supply credentials for named [[tool.uv.index]] entries.
-	if os.Getenv("UV_INDEX_URL") != "" {
-		log.Info("UV auth: UV_INDEX_URL is set globally (native); per-index credential injection still proceeds below")
+	// UV_INDEX_URL and UV_DEFAULT_INDEX are UV's global default index env vars.
+	// Log them for visibility; per-named-index injection still proceeds because
+	// these vars only affect the default/fallback index, not named [[tool.uv.index]] entries.
+	if os.Getenv("UV_INDEX_URL") != "" || os.Getenv("UV_DEFAULT_INDEX") != "" {
+		log.Info("UV auth: global index env var set (UV_INDEX_URL or UV_DEFAULT_INDEX); per-index credential injection still proceeds below")
 	}
 
-	for _, idx := range uvReadIndexesFromToml(workingDir) {
+	// Use script inline indexes when --script is active; fall back to pyproject.toml entries.
+	indexes := scriptIndexes
+	if len(indexes) == 0 {
+		indexes = uvReadIndexesFromToml(workingDir)
+	}
+	for _, idx := range indexes {
 		envName := uvIndexEnvName(idx.Name)
 		userKey := "UV_INDEX_" + envName + "_USERNAME"
 		switch {
 		case uvIndexHasNativeCredentials(idx.URL, userKey):
 			log.Info(fmt.Sprintf("UV auth [index %q]: native credentials already present (env var, embedded URL, or netrc)", idx.Name))
 		default:
-			if uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl) {
+			hostMatches := uvHostMatchesServer(idx.URL, serverDetails.ArtifactoryUrl)
+			explicitServerID := c.serverID != ""
+			if hostMatches || explicitServerID {
 				os.Setenv(userKey, user)
 				os.Setenv("UV_INDEX_"+envName+"_PASSWORD", pass)
 				injectedAny = true
-				log.Info(fmt.Sprintf("UV auth [index %q]: using jf server config (user: %s, fallback)", idx.Name, user))
+				if explicitServerID && !hostMatches {
+					log.Info(fmt.Sprintf("UV auth [index %q]: injecting credentials from --server-id (host override)", idx.Name))
+				} else {
+					log.Info(fmt.Sprintf("UV auth [index %q]: using jf server config (fallback)", idx.Name))
+				}
 			} else {
 				log.Warn(fmt.Sprintf(
 					"UV auth [index %q]: index host (%s) differs from jf server config host (%s) — "+
@@ -166,11 +209,201 @@ func (c *NativeUVCommand) injectCredentials(workingDir, deployerRepo string, ser
 	}
 
 	if c.commandName == "publish" {
-		uvApplyPublishAuth(deployerRepo, workingDir, serverDetails, user, pass)
+		uvApplyPublishAuth(deployerRepo, workingDir, serverDetails, user, pass, c.serverID != "")
 	}
 }
 
 // runUvBinary executes the uv binary with stdio pass-through.
+// uvModifiesVenv returns true for uv sub-commands that install packages into the venv,
+// meaning uv pip list will reflect exactly what those flags resolved.
+func uvModifiesVenv(cmdName string) bool {
+	switch cmdName {
+	case "sync", "install", "add", "remove":
+		return true
+	}
+	return false
+}
+
+// uvInstalledPackages runs `uv pip list --format=json` and returns the installed set as
+// normalisedName → version. Returns nil on any error (caller falls back to lock-file logic).
+func uvInstalledPackages() map[string]string {
+	out, err := exec.Command("uv", "pip", "list", "--format=json").Output()
+	if err != nil {
+		log.Debug(fmt.Sprintf("uv pip list failed, falling back to lock-file dep resolution: %v", err))
+		return nil
+	}
+	var list []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(out, &list); err != nil {
+		log.Debug(fmt.Sprintf("failed to parse uv pip list output: %v", err))
+		return nil
+	}
+	installed := make(map[string]string, len(list))
+	for _, p := range list {
+		installed[strings.ToLower(strings.ReplaceAll(p.Name, "_", "-"))] = p.Version
+	}
+	return installed
+}
+
+// uvScriptPath returns the script file path when --script <path> is present in
+// a "run" invocation, or "" for all other commands.
+func uvScriptPath(cmdName string, args []string) string {
+	if cmdName != "run" {
+		return ""
+	}
+	for i, a := range args {
+		if a == "--script" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--script=") {
+			return strings.TrimPrefix(a, "--script=")
+		}
+	}
+	return ""
+}
+
+// uvGetScriptBuildInfo collects build-info for a PEP 723 inline script by:
+//  1. Ensuring a <script>.lock file exists (runs `uv lock --script` if needed).
+//  2. Parsing that lock file with UVFlexPack using the script name as module ID.
+//
+// This gives accurate dependency tracking for the script's isolated environment
+// rather than reporting the surrounding project's dependencies.
+func uvGetScriptBuildInfo(scriptPath string, buildConfiguration *buildUtils.BuildConfiguration, serverDetails *coreConfig.ServerDetails) error {
+	lockPath := scriptPath + ".lock"
+	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+		log.Info(fmt.Sprintf("UV script: creating lock file at %s", lockPath))
+		if err := runUvBinary([]string{"lock", "--script", scriptPath}); err != nil {
+			return fmt.Errorf("uv lock --script failed: %w", err)
+		}
+	}
+	buildName, err := buildConfiguration.GetBuildName()
+	if err != nil {
+		return fmt.Errorf("GetBuildName failed: %w", err)
+	}
+	buildNumber, err := buildConfiguration.GetBuildNumber()
+	if err != nil {
+		return fmt.Errorf("GetBuildNumber failed: %w", err)
+	}
+	scriptName := strings.TrimSuffix(filepath.Base(scriptPath), filepath.Ext(scriptPath))
+	collector, err := flexpack.NewUVFlexPack(flexpack.UVConfig{
+		WorkingDirectory:       filepath.Dir(scriptPath),
+		LockFilePath:           lockPath,
+		ProjectName:            scriptName,
+		IncludeDevDependencies: true, // scripts have no dev/main distinction
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create UV FlexPack for script: %w", err)
+	}
+	bi, err := collector.CollectBuildInfo(buildName, buildNumber)
+	if err != nil {
+		return fmt.Errorf("failed to collect script build info: %w", err)
+	}
+	directURLDeps := collector.GetDirectURLDeps()
+	if len(directURLDeps) > 0 && len(bi.Modules) > 0 {
+		uvEnrichDirectURLChecksums(bi.Modules[0].Dependencies, directURLDeps)
+	}
+	service := buildUtils.CreateBuildInfoService()
+	bld, err := service.GetOrCreateBuildWithProject(bi.Name, bi.Number, buildConfiguration.GetProject())
+	if err != nil {
+		return fmt.Errorf("failed to create build: %w", err)
+	}
+	if err := bld.SaveBuildInfo(bi); err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("UV script build info collected. Use 'jf rt bp %s %s' to publish.", buildName, buildNumber))
+	return nil
+}
+
+// uvScriptInlineIndexes returns [[tool.uv.index]] entries parsed from the PEP 723
+// inline metadata block (# /// script ... ///) of the script file referenced by
+// the --script flag in args. Returns nil when not a --script invocation or on any error.
+func uvScriptInlineIndexes(cmdName string, args []string) []uvIndexEntry {
+	if cmdName != "run" {
+		return nil
+	}
+	// Find --script <path> in args
+	scriptPath := ""
+	for i, a := range args {
+		if a == "--script" && i+1 < len(args) {
+			scriptPath = args[i+1]
+			break
+		}
+		if strings.HasPrefix(a, "--script=") {
+			scriptPath = strings.TrimPrefix(a, "--script=")
+			break
+		}
+	}
+	if scriptPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+	// Locate # /// script ... # /// block
+	const startMarker = "# /// script"
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return nil
+	}
+	afterStart := content[startIdx+len(startMarker):]
+	endIdx := strings.Index(afterStart, "# ///")
+	if endIdx == -1 {
+		return nil
+	}
+	// Strip leading "# " from each line to get raw TOML
+	var tomlLines []string
+	for _, line := range strings.Split(afterStart[:endIdx], "\n") {
+		stripped := strings.TrimPrefix(line, "# ")
+		if stripped == "#" {
+			stripped = ""
+		}
+		tomlLines = append(tomlLines, stripped)
+	}
+	var meta uvPyprojectToml
+	if err := toml.Unmarshal([]byte(strings.Join(tomlLines, "\n")), &meta); err != nil {
+		return nil
+	}
+	return meta.Tool.Uv.Index
+}
+
+// uvShouldIncludeDevDeps mirrors uv's own default: dev dependencies are installed
+// unless --no-dev is explicitly passed. Only commands that resolve the environment
+// (sync/install/lock/add/remove) have a dev/group concept; others default to false.
+func uvShouldIncludeDevDeps(cmdName string, args []string) bool {
+	switch cmdName {
+	case "sync", "install", "lock", "add", "remove":
+		// uv's default: dev deps are included unless the caller opts out
+	default:
+		return false
+	}
+	for _, a := range args {
+		if a == "--no-dev" {
+			return false
+		}
+	}
+	// --only-dev, --group, --only-group, --all-groups all still resolve dev deps
+	return true
+}
+
+// isHelpRequest returns true when the user is asking for uv help (-h / --help anywhere
+// in the args, or bare "help" sub-command). In these cases we must skip all auth injection
+// so that credential env vars are never set — uv prints their values in help output.
+func isHelpRequest(cmdName string, args []string) bool {
+	if cmdName == "help" || cmdName == "" {
+		return true
+	}
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
 func runUvBinary(args []string) error {
 	cmd := exec.Command("uv", args...)
 	cmd.Stdin = os.Stdin
@@ -353,7 +586,9 @@ func uvResolveServerDetails(serverID string) (*coreConfig.ServerDetails, error) 
 }
 
 // uvApplyPublishAuth selects and applies publish credentials following UV's priority chain.
-func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string) {
+// explicitServerID is true when the user passed --server-id explicitly; in that case the
+// host-mismatch check is bypassed so credentials are always injected for the publish URL.
+func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string, explicitServerID bool) {
 	switch {
 	case os.Getenv("UV_PUBLISH_TOKEN") != "":
 		log.Info("UV auth [publish]: using UV_PUBLISH_TOKEN (native, step 2a)")
@@ -364,25 +599,29 @@ func uvApplyPublishAuth(publishURL, workingDir string, serverDetails *coreConfig
 	case uvNetrcHasCredentials(publishURL):
 		log.Info(fmt.Sprintf("UV auth [publish]: using %s (native, step 4)", uvNetrcPath()))
 	default:
-		uvInjectPublishCredentials(publishURL, workingDir, serverDetails, user, pass)
+		uvInjectPublishCredentials(publishURL, workingDir, serverDetails, user, pass, explicitServerID)
 	}
 }
 
 // uvInjectPublishCredentials injects publish credentials from same-host index credentials
-// or the jf server config (in that priority order).
-func uvInjectPublishCredentials(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string) {
+// or the jf server config. When explicitServerID is true, the host-mismatch check is skipped.
+func uvInjectPublishCredentials(publishURL, workingDir string, serverDetails *coreConfig.ServerDetails, user, pass string, explicitServerID bool) {
 	if idxUser, idxPass := uvMatchingIndexCredentials(publishURL, workingDir); idxUser != "" {
 		os.Setenv("UV_PUBLISH_USERNAME", idxUser)
 		os.Setenv("UV_PUBLISH_PASSWORD", idxPass)
 		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
-		log.Info("UV auth [publish]: using same-host index credentials (native, step 4b)")
+		log.Info("UV auth [publish]: reusing same-host index credentials for publish")
 		return
 	}
-	if uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) {
+	if uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) || explicitServerID {
 		os.Setenv("UV_PUBLISH_USERNAME", user)
 		os.Setenv("UV_PUBLISH_PASSWORD", pass)
 		os.Setenv("UV_KEYRING_PROVIDER", "disabled")
-		log.Info(fmt.Sprintf("UV auth [publish]: using jf server config (user: %s, fallback)", user))
+		if explicitServerID && !uvHostMatchesServer(publishURL, serverDetails.ArtifactoryUrl) {
+			log.Info("UV auth [publish]: injecting credentials from --server-id (host override)")
+		} else {
+			log.Info("UV auth [publish]: using jf server config (fallback)")
+		}
 		return
 	}
 	log.Warn(fmt.Sprintf(
@@ -394,7 +633,7 @@ func uvInjectPublishCredentials(publishURL, workingDir string, serverDetails *co
 // ── Build info collection ────────────────────────────────────────────────────
 
 // uvGetBuildInfo collects build info for UV projects using the FlexPack native implementation.
-func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfiguration, deployerRepo, cmdName string, serverDetails *coreConfig.ServerDetails) error {
+func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfiguration, deployerRepo, cmdName string, args []string, installed map[string]string, serverDetails *coreConfig.ServerDetails) error {
 	log.Debug(fmt.Sprintf("Collecting UV build info for command '%s' in: %s", cmdName, workingDir))
 
 	buildName, err := buildConfiguration.GetBuildName()
@@ -408,7 +647,8 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 
 	uvConfig := flexpack.UVConfig{
 		WorkingDirectory:       workingDir,
-		IncludeDevDependencies: false,
+		InstalledPackages:      installed, // nil for lock/build/publish → fallback to flag-based logic
+		IncludeDevDependencies: uvShouldIncludeDevDeps(cmdName, args),
 	}
 	collector, err := flexpack.NewUVFlexPack(uvConfig)
 	if err != nil {
@@ -424,38 +664,54 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 		bi.Modules[0].Id = customModule
 	}
 
+	// Collect direct-URL deps (source = { url = "..." } in uv.lock) — these are not in
+	// Artifactory so AQL enrichment must skip them; sha256 from the lock file is sufficient.
+	directURLDeps := collector.GetDirectURLDeps()
+	if len(directURLDeps) > 0 && len(bi.Modules) > 0 {
+		uvEnrichDirectURLChecksums(bi.Modules[0].Dependencies, directURLDeps)
+	}
+
 	switch cmdName {
 	case "sync", "install", "lock", "add", "remove", "run":
 		if len(bi.Modules) > 0 && len(bi.Modules[0].Dependencies) > 0 {
-			if repoKey := uvResolverRepoFromToml(workingDir); repoKey != "" {
+			// Resolve enrichment repo: prefer [[tool.uv.index]] in pyproject.toml,
+			// fall back to UV_DEFAULT_INDEX / UV_INDEX_URL env vars (used when no
+			// pyproject.toml index is configured, e.g. CI workflows that inject creds
+			// via environment).
+			repoKey := uvResolverRepoFromToml(workingDir)
+			indexURL := uvIndexURLFromToml(workingDir)
+			if repoKey == "" {
+				for _, envVar := range []string{"UV_DEFAULT_INDEX", "UV_INDEX_URL"} {
+					if val := os.Getenv(envVar); val != "" {
+						repoKey = uvExtractRepoKeyFromURL(val)
+						indexURL = val
+						if repoKey != "" {
+							log.Debug(fmt.Sprintf("UV build-info: using %s for dependency enrichment repo: %s", envVar, repoKey))
+							break
+						}
+					}
+				}
+			}
+			if repoKey != "" {
 				sd := serverDetails
 				if sd == nil {
 					sd, _ = coreConfig.GetDefaultServerConf()
 				}
 				if sd != nil {
-					if indexURL := uvIndexURLFromToml(workingDir); indexURL != "" && !uvHostMatchesServer(indexURL, sd.ArtifactoryUrl) {
+					if indexURL != "" && !uvHostMatchesServer(indexURL, sd.ArtifactoryUrl) {
 						log.Warn(fmt.Sprintf(
 							"UV build-info: jf server config host (%s) differs from index URL host (%s) — "+
 								"dependency checksum enrichment (sha1/md5) will be skipped. "+
 								"Use --server-id to specify the Artifactory instance that hosts your uv packages.",
 							uvHostOf(sd.ArtifactoryUrl), uvHostOf(indexURL)))
 					}
-					uvEnrichDepsFromArtifactory(bi.Modules[0].Dependencies, repoKey, sd)
+					uvEnrichDepsFromArtifactory(bi.Modules[0].Dependencies, repoKey, directURLDeps, sd)
 				}
 			}
 		}
 	}
 
 	switch cmdName {
-	case "build":
-		if artifacts, scanErr := uvCollectDistArtifacts(workingDir); scanErr == nil && len(artifacts) > 0 {
-			if len(bi.Modules) > 0 {
-				bi.Modules[0].Artifacts = artifacts
-				log.Info(fmt.Sprintf("Collected %d artifact(s) from dist/", len(artifacts)))
-			}
-		} else if scanErr != nil {
-			log.Warn("Could not scan dist/ for artifacts: " + scanErr.Error())
-		}
 	case "publish":
 		repoKey := uvExtractRepoKeyFromURL(deployerRepo)
 		sd := serverDetails
@@ -530,9 +786,58 @@ func uvIndexURLFromToml(workingDir string) string {
 	return ""
 }
 
-// uvEnrichDepsFromArtifactory searches each dependency by filename in the given Artifactory repo
-// and updates the dependency's sha1 and md5 checksums.
-func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, serverDetails *coreConfig.ServerDetails) {
+// uvEnrichDepsFromArtifactory fetches sha1/md5 for all dependencies in a single batched AQL call.
+//
+// Dep IDs are in "name:version" format; actual filenames use "name-version[-platform].whl" or
+// "name-version.tar.gz" with either hyphens or underscores in the name. We search both variants
+// so platform-specific wheels (e.g. macos arm64) and universal wheels both resolve correctly.
+// uvEnrichDirectURLChecksums computes sha1/md5 for direct URL deps (source = { url = "..." })
+// by streaming the file from its URL. Git deps (source = { git = "..." }) are skipped because
+// rebuilding from source would be required to produce a deterministic archive.
+// If a URL is inaccessible (network error, auth required) the dep retains sha256-only — no error.
+func uvEnrichDirectURLChecksums(deps []buildinfo.Dependency, directURLDeps map[string]string) {
+	for i, dep := range deps {
+		sourceURL, ok := directURLDeps[dep.Id]
+		if !ok || dep.Checksum.Sha1 != "" {
+			continue
+		}
+		// Skip git URLs — no deterministic archive to download
+		if strings.HasPrefix(sourceURL, "git+") || strings.Contains(sourceURL, ".git") ||
+			strings.HasPrefix(sourceURL, "git://") {
+			log.Info(fmt.Sprintf("UV build-info: dep %s is a git dep (%s) — sha256 available, sha1/md5 not computable without rebuilding", dep.Id, sourceURL))
+			continue
+		}
+		if !strings.HasPrefix(sourceURL, "http://") && !strings.HasPrefix(sourceURL, "https://") {
+			log.Info(fmt.Sprintf("UV build-info: dep %s is from a direct URL (%s) — sha256 available, sha1/md5 not enrichable from Artifactory", dep.Id, sourceURL))
+			continue
+		}
+		// Stream the file and compute sha1 + md5 in a single pass — no disk write needed.
+		resp, err := http.Get(sourceURL) //nolint:gosec
+		if err != nil {
+			log.Info(fmt.Sprintf("UV build-info: dep %s direct URL not reachable (%v) — sha256 only", dep.Id, err))
+			continue
+		}
+		sha1w := sha1.New()   //nolint:gosec
+		md5w := md5.New()     //nolint:gosec
+		_, copyErr := io.Copy(io.MultiWriter(sha1w, md5w), resp.Body)
+		resp.Body.Close()
+		if copyErr != nil {
+			log.Info(fmt.Sprintf("UV build-info: dep %s could not stream URL — sha256 only", dep.Id))
+			continue
+		}
+		deps[i].Checksum.Sha1 = fmt.Sprintf("%x", sha1w.Sum(nil))
+		deps[i].Checksum.Md5 = fmt.Sprintf("%x", md5w.Sum(nil))
+		log.Info(fmt.Sprintf("UV build-info: dep %s enriched sha1/md5 from direct URL", dep.Id))
+	}
+}
+
+// uvEnrichDepsFromArtifactory fetches sha1/md5 for all registry-based dependencies in a single
+// batched AQL call. directURLDeps maps dep ID → source URL for deps that were installed from
+// a direct URL — these are skipped since they are not in Artifactory.
+func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, directURLDeps map[string]string, serverDetails *coreConfig.ServerDetails) {
+	if len(deps) == 0 {
+		return
+	}
 	servicesManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
 	if err != nil {
 		log.Warn("Could not create services manager for dependency enrichment: " + err.Error())
@@ -544,44 +849,98 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, se
 		searchRepo = repoKey
 	}
 
-	enriched := 0
+	// Build (depIndex, filePrefix) pairs. dep.Id is "name:version"; filename prefix is "name-version".
+	// We add both the hyphenated and underscored variants to catch all PyPI normalisation forms.
+	type depEntry struct {
+		idx    int
+		prefix string // "name-version" used to match result filenames
+	}
+	var entries []depEntry
 	for i, dep := range deps {
 		if dep.Id == "" {
 			continue
 		}
-		aqlQuery := specutils.CreateAqlQueryForPypi(searchRepo, dep.Id)
-		stream, err := servicesManager.Aql(aqlQuery)
-		if err != nil {
-			log.Debug(fmt.Sprintf("AQL search failed for %s: %v", dep.Id, err))
-			continue
+		if _, isDirectURL := directURLDeps[dep.Id]; isDirectURL {
+			continue // not in Artifactory — sha256 from uv.lock is the only available checksum
 		}
-		result, err := io.ReadAll(stream)
-		stream.Close()
-		if err != nil {
-			continue
+		hyphen := strings.ReplaceAll(dep.Id, ":", "-")
+		underscore := strings.ReplaceAll(hyphen, "-", "_")
+		entries = append(entries, depEntry{i, hyphen})
+		if underscore != hyphen {
+			entries = append(entries, depEntry{i, underscore})
 		}
-		var aql struct {
-			Results []struct {
-				ActualSha1 string `json:"actual_sha1"`
-				ActualMd5  string `json:"actual_md5"`
-				Sha256     string `json:"sha256"`
-			} `json:"results"`
-		}
-		if err := json.Unmarshal(result, &aql); err != nil || len(aql.Results) == 0 {
-			log.Debug(fmt.Sprintf("Dependency %s not found in repo %s", dep.Id, searchRepo))
-			continue
-		}
-		r := aql.Results[0]
-		deps[i].Checksum.Sha1 = r.ActualSha1
-		deps[i].Checksum.Md5 = r.ActualMd5
-		if r.Sha256 != "" {
-			deps[i].Checksum.Sha256 = r.Sha256
-		}
-		enriched++
-		log.Debug(fmt.Sprintf("Enriched %s with sha1=%s md5=%s", dep.Id, r.ActualSha1, r.ActualMd5))
 	}
+	if len(entries) == 0 {
+		return
+	}
+
+	// One AQL query: $or of wildcard name patterns, one per (name, version) variant.
+	var orClauses []string
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		if seen[e.prefix] {
+			continue
+		}
+		seen[e.prefix] = true
+		orClauses = append(orClauses, fmt.Sprintf(
+			`{"$and":[{"path":{"$match":"*"},"name":{"$match":%q}}]}`,
+			e.prefix+"*",
+		))
+	}
+	aqlQuery := fmt.Sprintf(
+		`items.find({"repo":%q,"$or":[%s]}).include("name","actual_sha1","actual_md5","sha256")`,
+		searchRepo, strings.Join(orClauses, ","),
+	)
+
+	stream, err := servicesManager.Aql(aqlQuery)
+	if err != nil {
+		log.Debug(fmt.Sprintf("Batch AQL enrichment failed for repo %s: %v", searchRepo, err))
+		return
+	}
+	raw, _ := io.ReadAll(stream)
+	stream.Close()
+
+	var aqlResult struct {
+		Results []struct {
+			Name       string `json:"name"`
+			ActualSha1 string `json:"actual_sha1"`
+			ActualMd5  string `json:"actual_md5"`
+			Sha256     string `json:"sha256"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &aqlResult); err != nil {
+		log.Debug(fmt.Sprintf("Failed to parse AQL enrichment response: %v", err))
+		return
+	}
+
+	// Match each result back to its dep by filename prefix. A result file like
+	// "certifi-2026.4.22-py3-none-any.whl" starts with prefix "certifi-2026.4.22"
+	// followed by "-" (wheel) or "." (sdist).
+	enriched := 0
+	for _, r := range aqlResult.Results {
+		if r.ActualSha1 == "" {
+			continue
+		}
+		for _, e := range entries {
+			if deps[e.idx].Checksum.Sha1 != "" {
+				continue // already enriched
+			}
+			if strings.HasPrefix(r.Name, e.prefix+"-") || strings.HasPrefix(r.Name, e.prefix+".") {
+				deps[e.idx].Checksum.Sha1 = r.ActualSha1
+				deps[e.idx].Checksum.Md5 = r.ActualMd5
+				if r.Sha256 != "" && deps[e.idx].Checksum.Sha256 == "" {
+					deps[e.idx].Checksum.Sha256 = r.Sha256
+				}
+				enriched++
+				break
+			}
+		}
+	}
+
 	if enriched > 0 {
 		log.Info(fmt.Sprintf("Enriched %d/%d UV dependencies with Artifactory checksums (repo: %s)", enriched, len(deps), searchRepo))
+	} else {
+		log.Debug(fmt.Sprintf("No UV dependencies enriched from repo %s — packages may not be cached yet", searchRepo))
 	}
 }
 

--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -846,8 +846,15 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, di
 		searchRepo = repoKey
 	}
 
-	// Build (depIndex, filePrefix) pairs. dep.Id is "name:version"; filename prefix is "name-version".
-	// We add both the hyphenated and underscored variants to catch all PyPI normalisation forms.
+	// Build (depIndex, filePrefix) pairs. dep.Id is "name:version".
+	//
+	// PyPI wheel filename format: <name>-<version>-<python>-<abi>-<platform>.whl
+	// The name portion normalises hyphens/dots to underscores (PEP 427), but the
+	// separator between name and version is ALWAYS a hyphen. So for:
+	//   charset-normalizer:3.4.7  →  prefix "charset-normalizer-3.4.7"   (hyphenated name)
+	//                               prefix "charset_normalizer-3.4.7"   (underscored name, correct!)
+	// Replacing ALL hyphens (the old approach) produced "charset_normalizer_3.4.7"
+	// which never matches any real filename.
 	type depEntry struct {
 		idx    int
 		prefix string // "name-version" used to match result filenames
@@ -860,11 +867,20 @@ func uvEnrichDepsFromArtifactory(deps []buildinfo.Dependency, repoKey string, di
 		if _, isDirectURL := directURLDeps[dep.Id]; isDirectURL {
 			continue // not in Artifactory — sha256 from uv.lock is the only available checksum
 		}
-		hyphen := strings.ReplaceAll(dep.Id, ":", "-")
-		underscore := strings.ReplaceAll(hyphen, "-", "_")
-		entries = append(entries, depEntry{i, hyphen})
-		if underscore != hyphen {
-			entries = append(entries, depEntry{i, underscore})
+		// Split "name:version" — version separator is always ":"
+		colonIdx := strings.Index(dep.Id, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		name, version := dep.Id[:colonIdx], dep.Id[colonIdx+1:]
+		// Prefix with original name (e.g. "charset-normalizer-3.4.7")
+		prefixHyphen := name + "-" + version
+		// Prefix with underscored name only (e.g. "charset_normalizer-3.4.7")
+		// The version separator before the version tag is always "-", never "_".
+		prefixUnderscore := strings.ReplaceAll(name, "-", "_") + "-" + version
+		entries = append(entries, depEntry{i, prefixHyphen})
+		if prefixUnderscore != prefixHyphen {
+			entries = append(entries, depEntry{i, prefixUnderscore})
 		}
 	}
 	if len(entries) == 0 {

--- a/artifactory/commands/python/uv.go
+++ b/artifactory/commands/python/uv.go
@@ -1,0 +1,82 @@
+package python
+
+import (
+	"io"
+	"os/exec"
+
+	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/build-info-go/utils/pythonutils"
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/python/dependencies"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+)
+
+type UvCommand struct {
+	PythonCommand
+}
+
+const uvTool pythonutils.PythonTool = "uv"
+
+func NewUvCommand() *UvCommand {
+	return &UvCommand{PythonCommand: *NewPythonCommand(uvTool)}
+}
+
+func (pc *UvCommand) Run() (err error) {
+	return pc.PythonCommand.Run()
+}
+
+func (pc *UvCommand) UpdateDepsChecksumInfoFunc(dependenciesMap map[string]entities.Dependency, srcPath string) error {
+	servicesManager, err := utils.CreateServiceManager(pc.serverDetails, -1, 0, false)
+	if err != nil {
+		return err
+	}
+	return dependencies.UpdateDepsChecksumInfo(dependenciesMap, srcPath, servicesManager, pc.repository)
+}
+
+func (pc *UvCommand) SetRepo(repo string) *UvCommand {
+	pc.PythonCommand.SetRepo(repo)
+	return pc
+}
+
+func (pc *UvCommand) SetArgs(arguments []string) *UvCommand {
+	pc.PythonCommand.SetArgs(arguments)
+	return pc
+}
+
+func (pc *UvCommand) SetCommandName(commandName string) *UvCommand {
+	pc.PythonCommand.SetCommandName(commandName)
+	return pc
+}
+
+func (pc *UvCommand) CommandName() string {
+	return "rt_python_uv"
+}
+
+func (pc *UvCommand) SetServerDetails(serverDetails *config.ServerDetails) *UvCommand {
+	pc.PythonCommand.SetServerDetails(serverDetails)
+	return pc
+}
+
+func (pc *UvCommand) ServerDetails() (*config.ServerDetails, error) {
+	return pc.serverDetails, nil
+}
+
+func (pc *UvCommand) GetCmd() *exec.Cmd {
+	var cmd []string
+	cmd = append(cmd, string(pc.pythonTool))
+	cmd = append(cmd, pc.commandName)
+	cmd = append(cmd, pc.args...)
+	return exec.Command(cmd[0], cmd[1:]...)
+}
+
+func (pc *UvCommand) GetEnv() map[string]string {
+	return map[string]string{}
+}
+
+func (pc *UvCommand) GetStdWriter() io.WriteCloser {
+	return nil
+}
+
+func (pc *UvCommand) GetErrWriter() io.WriteCloser {
+	return nil
+}

--- a/artifactory/commands/python/uv.go
+++ b/artifactory/commands/python/uv.go
@@ -15,14 +15,8 @@ type UvCommand struct {
 	PythonCommand
 }
 
-const uvTool pythonutils.PythonTool = "uv"
-
 func NewUvCommand() *UvCommand {
-	return &UvCommand{PythonCommand: *NewPythonCommand(uvTool)}
-}
-
-func (pc *UvCommand) Run() (err error) {
-	return pc.PythonCommand.Run()
+	return &UvCommand{PythonCommand: *NewPythonCommand(pythonutils.UV)}
 }
 
 func (pc *UvCommand) UpdateDepsChecksumInfoFunc(dependenciesMap map[string]entities.Dependency, srcPath string) error {
@@ -62,9 +56,7 @@ func (pc *UvCommand) ServerDetails() (*config.ServerDetails, error) {
 }
 
 func (pc *UvCommand) GetCmd() *exec.Cmd {
-	var cmd []string
-	cmd = append(cmd, string(pc.pythonTool))
-	cmd = append(cmd, pc.commandName)
+	cmd := []string{string(pythonutils.UV), pc.commandName}
 	cmd = append(cmd, pc.args...)
 	return exec.Command(cmd[0], cmd[1:]...)
 }

--- a/artifactory/commands/python/uv.go
+++ b/artifactory/commands/python/uv.go
@@ -11,6 +11,9 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 )
 
+// UvCommand is a placeholder for the future `jf rt python uv` path (non-native,
+// config-file-based). It is not currently wired to any CLI command; the active
+// uv integration uses NativeUvCommand in native_uv.go instead.
 type UvCommand struct {
 	PythonCommand
 }

--- a/artifactory/commands/python/uv_auth_test.go
+++ b/artifactory/commands/python/uv_auth_test.go
@@ -1,0 +1,174 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUvURLHasEmbeddedCredentials is a table-driven test for uvURLHasEmbeddedCredentials.
+// The function returns true when the URL contains a userinfo component (user or user:pass).
+func TestUvURLHasEmbeddedCredentials(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected bool
+	}{
+		{"https://user:pass@host.example.com/path", true},
+		{"https://user@host.example.com/path", true}, // user present, no password still counts
+		{"https://host.example.com/path", false},
+		{"", false},
+		{"not-a-url", false},
+		{"https://host.example.com/api/pypi/repo/simple", false},
+		{"http://user:secret@10.0.0.1:8080/simple", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.url, func(t *testing.T) {
+			assert.Equal(t, tc.expected, uvURLHasEmbeddedCredentials(tc.url),
+				"uvURLHasEmbeddedCredentials(%q)", tc.url)
+		})
+	}
+}
+
+// TestUvNetrcHasCredentials writes a temp .netrc file and verifies that
+// uvNetrcHasCredentials correctly matches the hostname.
+func TestUvNetrcHasCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+	netrcPath := filepath.Join(tmpDir, ".netrc")
+	err := os.WriteFile(netrcPath, []byte(
+		"machine myhost.example.com\nlogin user\npassword pass\n",
+	), 0600)
+	assert.NoError(t, err)
+
+	t.Setenv("HOME", tmpDir)
+
+	// matching host — should return true
+	assert.True(t, uvNetrcHasCredentials("https://myhost.example.com/simple"),
+		"should match machine entry in .netrc")
+
+	// non-matching host — should return false
+	assert.False(t, uvNetrcHasCredentials("https://other.example.com/simple"),
+		"should not match when host is absent from .netrc")
+
+	// empty URL — should return false
+	assert.False(t, uvNetrcHasCredentials(""),
+		"empty URL should return false")
+
+	// URL with no host component — should return false
+	assert.False(t, uvNetrcHasCredentials("not-a-url"),
+		"unparseable/hostless URL should return false")
+}
+
+// TestUvNetrcHasCredentials_CustomPath verifies that the NETRC env var is
+// respected for a custom netrc file location (same as UV and curl behavior).
+func TestUvNetrcHasCredentials_CustomPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	customPath := filepath.Join(tmpDir, "custom_netrc")
+	err := os.WriteFile(customPath, []byte("machine customhost.example.com\nlogin u\npassword p\n"), 0600)
+	assert.NoError(t, err)
+
+	// Point $NETRC at the custom file, HOME at an empty dir (no ~/.netrc)
+	t.Setenv("NETRC", customPath)
+	t.Setenv("HOME", t.TempDir())
+
+	assert.True(t, uvNetrcHasCredentials("https://customhost.example.com/simple"),
+		"should find credentials via $NETRC custom path")
+	assert.False(t, uvNetrcHasCredentials("https://other.example.com/simple"),
+		"non-matching host should return false even with $NETRC set")
+}
+
+// TestUvNetrcHasCredentials_NoFile verifies that when ~/.netrc does not exist,
+// the function returns false rather than erroring.
+func TestUvNetrcHasCredentials_NoFile(t *testing.T) {
+	// Point HOME at an empty dir so there is no .netrc
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	assert.False(t, uvNetrcHasCredentials("https://myhost.example.com/simple"),
+		"should return false when .netrc file does not exist")
+}
+
+// TestUvNetrcHasCredentials_MultipleEntries verifies correct entry selection
+// when .netrc contains multiple machine entries.
+func TestUvNetrcHasCredentials_MultipleEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	netrcContent := "machine first.example.com\nlogin u1\npassword p1\n" +
+		"machine second.example.com\nlogin u2\npassword p2\n"
+	err := os.WriteFile(filepath.Join(tmpDir, ".netrc"), []byte(netrcContent), 0600)
+	assert.NoError(t, err)
+	t.Setenv("HOME", tmpDir)
+
+	assert.True(t, uvNetrcHasCredentials("https://first.example.com/path"))
+	assert.True(t, uvNetrcHasCredentials("https://second.example.com/path"))
+	assert.False(t, uvNetrcHasCredentials("https://third.example.com/path"))
+}
+
+// TestUvIndexEnvName is a table-driven test for uvIndexEnvName.
+// UV uppercases the name and replaces hyphens, dots, and spaces with underscores.
+func TestUvIndexEnvName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"pypi-virtual", "PYPI_VIRTUAL"},
+		{"my.index", "MY_INDEX"},
+		{"MyIndex", "MYINDEX"},
+		{"index-with-multiple-hyphens", "INDEX_WITH_MULTIPLE_HYPHENS"},
+		{"index.with.dots", "INDEX_WITH_DOTS"},
+		{"index name", "INDEX_NAME"},
+		{"jfrog-pypi-virtual", "JFROG_PYPI_VIRTUAL"},
+		{"ALREADY_UPPER", "ALREADY_UPPER"},
+		{"mixed.case-name", "MIXED_CASE_NAME"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.expected, uvIndexEnvName(tc.input),
+				"uvIndexEnvName(%q)", tc.input)
+		})
+	}
+}
+
+// TestUvIndexHasNativeCredentials verifies the composite logic of
+// uvIndexHasNativeCredentials: env var takes priority over URL credentials,
+// which take priority over .netrc.
+func TestUvIndexHasNativeCredentials(t *testing.T) {
+	t.Run("env var set", func(t *testing.T) {
+		t.Setenv("UV_INDEX_MY_INDEX_USERNAME", "testuser")
+		assert.True(t, uvIndexHasNativeCredentials(
+			"https://host.example.com/simple",
+			"UV_INDEX_MY_INDEX_USERNAME",
+		))
+	})
+
+	t.Run("env var not set, URL has credentials", func(t *testing.T) {
+		// ensure env var is not set (t.Setenv restores on cleanup)
+		assert.True(t, uvIndexHasNativeCredentials(
+			"https://user:pass@host.example.com/simple",
+			"UV_INDEX_NONEXISTENT_VAR_XYZ",
+		))
+	})
+
+	t.Run("no env var, no URL credentials, netrc match", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmpDir, ".netrc"),
+			[]byte("machine netrchost.example.com\nlogin u\npassword p\n"), 0600)
+		assert.NoError(t, err)
+		t.Setenv("HOME", tmpDir)
+		assert.True(t, uvIndexHasNativeCredentials(
+			"https://netrchost.example.com/simple",
+			"UV_INDEX_NONEXISTENT_VAR_XYZ2",
+		))
+	})
+
+	t.Run("none of the above", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir) // no .netrc
+		assert.False(t, uvIndexHasNativeCredentials(
+			"https://host.example.com/simple",
+			"UV_INDEX_NONEXISTENT_VAR_XYZ3",
+		))
+	})
+}

--- a/artifactory/commands/python/uv_auth_test.go
+++ b/artifactory/commands/python/uv_auth_test.go
@@ -42,7 +42,9 @@ func TestUvNetrcHasCredentials(t *testing.T) {
 	), 0600)
 	assert.NoError(t, err)
 
-	t.Setenv("HOME", tmpDir)
+	// Use NETRC env var so uvNetrcPath() resolves correctly on all platforms
+	// (HOME is ignored by os.UserHomeDir on Windows which uses USERPROFILE instead).
+	t.Setenv("NETRC", netrcPath)
 
 	// matching host — should return true
 	assert.True(t, uvNetrcHasCredentials("https://myhost.example.com/simple"),
@@ -79,12 +81,11 @@ func TestUvNetrcHasCredentials_CustomPath(t *testing.T) {
 		"non-matching host should return false even with $NETRC set")
 }
 
-// TestUvNetrcHasCredentials_NoFile verifies that when ~/.netrc does not exist,
+// TestUvNetrcHasCredentials_NoFile verifies that when .netrc does not exist,
 // the function returns false rather than erroring.
 func TestUvNetrcHasCredentials_NoFile(t *testing.T) {
-	// Point HOME at an empty dir so there is no .netrc
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	// Point NETRC at a non-existent path — works on all platforms.
+	t.Setenv("NETRC", filepath.Join(t.TempDir(), ".netrc"))
 
 	assert.False(t, uvNetrcHasCredentials("https://myhost.example.com/simple"),
 		"should return false when .netrc file does not exist")
@@ -94,11 +95,12 @@ func TestUvNetrcHasCredentials_NoFile(t *testing.T) {
 // when .netrc contains multiple machine entries.
 func TestUvNetrcHasCredentials_MultipleEntries(t *testing.T) {
 	tmpDir := t.TempDir()
+	netrcPath := filepath.Join(tmpDir, ".netrc")
 	netrcContent := "machine first.example.com\nlogin u1\npassword p1\n" +
 		"machine second.example.com\nlogin u2\npassword p2\n"
-	err := os.WriteFile(filepath.Join(tmpDir, ".netrc"), []byte(netrcContent), 0600)
+	err := os.WriteFile(netrcPath, []byte(netrcContent), 0600)
 	assert.NoError(t, err)
-	t.Setenv("HOME", tmpDir)
+	t.Setenv("NETRC", netrcPath)
 
 	assert.True(t, uvNetrcHasCredentials("https://first.example.com/path"))
 	assert.True(t, uvNetrcHasCredentials("https://second.example.com/path"))
@@ -153,10 +155,11 @@ func TestUvIndexHasNativeCredentials(t *testing.T) {
 
 	t.Run("no env var, no URL credentials, netrc match", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(tmpDir, ".netrc"),
+		netrcPath := filepath.Join(tmpDir, ".netrc")
+		err := os.WriteFile(netrcPath,
 			[]byte("machine netrchost.example.com\nlogin u\npassword p\n"), 0600)
 		assert.NoError(t, err)
-		t.Setenv("HOME", tmpDir)
+		t.Setenv("NETRC", netrcPath)
 		assert.True(t, uvIndexHasNativeCredentials(
 			"https://netrchost.example.com/simple",
 			"UV_INDEX_NONEXISTENT_VAR_XYZ2",

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
-	github.com/go-git/go-git/v5 v5.17.0 // indirect
+	github.com/go-git/go-git/v5 v5.17.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.25.0 // indirect
@@ -198,7 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
+
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260415170232-c7deee20eae5
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880
+	github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
@@ -198,9 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153
 
-replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
+	github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
@@ -198,9 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jfrog/jfrog-cli-artifactory
 go 1.25.7
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/c-bata/go-prompt v0.2.6
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
@@ -26,7 +27,6 @@ require golang.org/x/net v0.52.0 // indirect
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/CycloneDX/cyclonedx-go v0.10.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -198,9 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
+	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260429073430-5723b4f21705
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b
 	github.com/pkg/errors v0.9.1
@@ -198,9 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153
+// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153
 
-replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
+// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce
+	github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
@@ -68,7 +68,7 @@ require (
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
-	github.com/go-git/go-git/v5 v5.17.1 // indirect
+	github.com/go-git/go-git/v5 v5.18.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.25.0 // indirect
@@ -198,9 +198,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/reshmifrog/jfrog-cli-core/v2 v2.58.5-0.20260414075418-fe058b1664b7
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
 
-// replace github.com/jfrog/build-info-go => github.com/reshmifrog/build-info-go v1.10.11-0.20260303032831-71878c7210bf
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212 h1:8dnvFKaoaMM/WQYz94nReh5XI+f8gLAWIMsmEjN/SpA=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212/go.mod h1:ZQNSUVzfPXZpeD4bYz5xwJrT3PzzFbQE2ZqsiIYqguc=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137 h1:S+eRKkxk8ycATJhn2ZPydcDkGJO/O2KPdOHv7OMzyOc=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137/go.mod h1:QbLTg09ropV++S60tfYZm6WPXNSm/paaocTyg1enYxw=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -380,8 +380,8 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d h1:5bKXhuCQZ5O2xfRKe2lg+T3b7NOIXnLVjA/X1t1Kc3Q=
-github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5 h1:QXjNn7Cr1tXF6Z+mHxb4Q8UjnMfPOn+T69ZTVT+sSPM=
+github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137 h1:S+eRKkxk8ycATJhn2ZPydcDkGJO/O2KPdOHv7OMzyOc=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260427063453-2fa17939a137/go.mod h1:QbLTg09ropV++S60tfYZm6WPXNSm/paaocTyg1enYxw=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9 h1:r8p3GP4dCW1XsPVLT6KeYXZTjSeOzV1RjyIY086W+TE=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9/go.mod h1:SGZ3E1lWCWrBP7eapOax1ozpladOc8HelRgVYaL4VOQ=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -380,8 +380,8 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5 h1:QXjNn7Cr1tXF6Z+mHxb4Q8UjnMfPOn+T69ZTVT+sSPM=
-github.com/jfrog/build-info-go v1.13.1-0.20260427062847-541623761fa5/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880 h1:T4I9699xpuzj79dmdMJl95o/06TnGYTgSc5nlcjKEjw=
+github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260415170232-c7deee20eae5 h1:RImfru3Efe+8DnbUybG9n012kJeLJRsshm8zcFB069w=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260415170232-c7deee20eae5/go.mod h1:NKVZCyK/cWDA00+JSWS0XgWq5NC5kNqoXoZiD05S1mg=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -212,8 +214,8 @@ github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDz
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.17.0 h1:AbyI4xf+7DsjINHMu35quAh4wJygKBKBuXVjV/pxesM=
-github.com/go-git/go-git/v5 v5.17.0/go.mod h1:f82C4YiLx+Lhi8eHxltLeGC5uBTXSFa6PC5WW9o4SjI=
+github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
+github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -378,14 +380,12 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce h1:Ozuq6iZEFbE8GNk5ROMa0w+v2kmeUdUj95gVN636Lus=
-github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d h1:5bKXhuCQZ5O2xfRKe2lg+T3b7NOIXnLVjA/X1t1Kc3Q=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b h1:gGGmYXuYvcNns1BnLQI13lC+pgMxrmenx+ramtolQuA=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b/go.mod h1:+Hnaikp/xCSPD/q7txxRy4Zc0wzjW/usrCSf+6uONSQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260401053506-cd363617ec8f h1:zooemucdHsJcRfGhKkyStpOZvJ3ErOTOkOIQULVKOgw=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9 h1:r8p3GP4dCW1XsPVLT6KeYXZTjSeOzV1RjyIY086W+TE=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428031130-93d5a38c8ac9/go.mod h1:SGZ3E1lWCWrBP7eapOax1ozpladOc8HelRgVYaL4VOQ=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153 h1:OEEoeuH8+U3g0kgNK117HnCYKz2V6p2SYxz+imBZUIM=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153/go.mod h1:IqbVIEOowMxGZlg3KwJjWhqVdUN0ujk6t0bEBArBJxY=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -380,8 +380,8 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880 h1:T4I9699xpuzj79dmdMJl95o/06TnGYTgSc5nlcjKEjw=
-github.com/jfrog/build-info-go v1.13.1-0.20260428030832-8ebb5e8cc880/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad h1:Ww8KMDpOnnpPX1HIby0cxX83YQurdAYCtVPYxVKxZ6I=
+github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153 h1:OEEoeuH8+U3g0kgNK117HnCYKz2V6p2SYxz+imBZUIM=
-github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153/go.mod h1:IqbVIEOowMxGZlg3KwJjWhqVdUN0ujk6t0bEBArBJxY=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -380,12 +378,14 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad h1:Ww8KMDpOnnpPX1HIby0cxX83YQurdAYCtVPYxVKxZ6I=
-github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86KwGvNHWyEBQoHoU9WfMMKy1GJ6jJQNmfy6E0U=
+github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260429073430-5723b4f21705 h1:J0VjEWHN6iXIWthphaKVakly7ONsN5GyoumMhP/m6yc=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260429073430-5723b4f21705/go.mod h1:bjAkVD8c2W+jg4whqy10bSXDC/c+Se8/ll/GPp5F/+0=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b h1:45UJJVG/jAA7/q2c/I6wOvKx8wu7EqTD2tEUtktgyug=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212 h1:8dnvFKaoaMM/WQYz94nReh5XI+f8gLAWIMsmEjN/SpA=
+github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260424090721-5d2f9a7aa212/go.mod h1:ZQNSUVzfPXZpeD4bYz5xwJrT3PzzFbQE2ZqsiIYqguc=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
@@ -212,8 +214,8 @@ github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDz
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
-github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
+github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -378,14 +380,12 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.3 h1:hkAmPjBw393tPmQ07JknLNWFNZjXdy2xFEnOW9wwOxI=
 github.com/jfrog/archiver/v3 v3.6.3/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce h1:Ozuq6iZEFbE8GNk5ROMa0w+v2kmeUdUj95gVN636Lus=
-github.com/jfrog/build-info-go v1.13.1-0.20260313042712-238e6dca3dce/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d h1:5bKXhuCQZ5O2xfRKe2lg+T3b7NOIXnLVjA/X1t1Kc3Q=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b h1:PCvNCdTYojr9u5X5TVTj/3oSnHEe8kJ9I50X0Wb5iJg=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260414083544-243b4d55328b/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b h1:45UJJVG/jAA7/q2c/I6wOvKx8wu7EqTD2tEUtktgyug=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Adds `NativeUVCommand` — a transparent `uv` proxy with Artifactory credential injection and build-info collection, following the same pattern as `ConanCommand`.

### Credential injection (auth priority chain)
Mirrors UV's own priority order exactly — jf injects credentials only as a last resort when no native UV auth mechanism is present:
1. `UV_INDEX_*_USERNAME` env var (native, step 2)
2. Credentials embedded in index URL (native, step 3)
3. `~/.netrc` entry for the index host (native, step 4)
4. Same-host index credentials reused for publish (step 4b — jf-specific)
5. jf server config credentials — injected only when index/publish URL host matches the configured server (fallback)

`UV_DEFAULT_INDEX` and `UV_INDEX_URL` are both recognised as global index env vars. When `--server-id` is explicitly passed, the host-mismatch check is bypassed so credentials are injected regardless of URL hostname.

### Build-info collection
- **Dependencies:** collected from `uv.lock` via `UVFlexPack`; `uv pip list --format=json` used as ground truth after `sync`/`install`/`add`/`remove` — correctly handles all dev/group flag combinations
- **Artifacts:** populated only after `jf uv publish` confirms upload to Artifactory (AQL path lookup); `jf uv build` alone does not add artifacts to build-info
- **AQL enrichment:** single batched `$or` query using `name-version*` + `name_version*` wildcards — one HTTP call for all deps; direct URL and git deps skip AQL with a clear log
- **Direct URL deps:** `sha1`/`md5` computed by streaming the HTTPS URL; git deps logged as not enrichable
- **Help flags:** `jf uv publish -h` and similar bypass all auth and Artifactory calls to prevent credential exposure in uv's help output
- **`--script` support:** `jf uv run --script <path>` collects build-info from the script's adjacent `<script>.py.lock` (created via `uv lock --script` if absent); inline `[[tool.uv.index]]` in PEP 723 metadata is parsed for credential injection