### PR TITLE
fix(helm): separate build-info modules by type

### DIFF
--- a/artifactory/commands/helm/push.go
+++ b/artifactory/commands/helm/push.go
@@ -64,7 +64,7 @@ func handlePushCommand(buildInfo *entities.BuildInfo, helmArgs []string, service
 	for _, artLayer := range artifactsLayers {
 		artifacts = append(artifacts, artLayer.ToArtifact())
 	}
-	addArtifactsInBuildInfo(buildInfo, artifacts, chartName, chartVersion)
+	addArtifactsInBuildInfo(buildInfo, artifacts, chartName, chartVersion, entities.ModuleType("helm"))
 	removeDuplicateArtifacts(buildInfo)
 	return saveBuildInfo(buildInfo, buildName, buildNumber, project)
 }

--- a/artifactory/commands/helm/utils.go
+++ b/artifactory/commands/helm/utils.go
@@ -151,13 +151,13 @@ func removeDuplicateDependencies(buildInfo *entities.BuildInfo) {
 	}
 }
 
-func addArtifactsInBuildInfo(buildInfo *entities.BuildInfo, artifacts []entities.Artifact, chartName, chartVersion string) {
+func addArtifactsInBuildInfo(buildInfo *entities.BuildInfo, artifacts []entities.Artifact, chartName, chartVersion string, moduleType entities.ModuleType) {
 	if buildInfo == nil {
 		return
 	}
 	moduleId := fmt.Sprintf("%s:%s", chartName, chartVersion)
 	for moduleIdx, module := range buildInfo.Modules {
-		if module.Id == moduleId {
+		if module.Type == moduleType && module.Id == moduleId {
 			module.Artifacts = append(module.Artifacts, artifacts...)
 			buildInfo.Modules[moduleIdx] = module
 		}
@@ -192,7 +192,7 @@ func appendModuleInExistingBuildInfo(buildInfo *entities.BuildInfo, moduleToAdd 
 		return
 	}
 	for moduleIdx, module := range buildInfo.Modules {
-		if module.Id == moduleToAdd.Id {
+		if module.Type == moduleToAdd.Type && module.Id == moduleToAdd.Id {
 			dependencies := moduleToAdd.Dependencies
 			if len(dependencies) > 0 {
 				buildInfo.Modules[moduleIdx].Dependencies = append(buildInfo.Modules[moduleIdx].Dependencies, dependencies...)

--- a/artifactory/commands/helm/utils.go
+++ b/artifactory/commands/helm/utils.go
@@ -25,12 +25,19 @@ func appendModuleAndBuildAgentIfAbsent(buildInfo *entities.BuildInfo, chartName 
 		log.Debug("No build info collected, skipping further processing")
 		return
 	}
-	if len(buildInfo.Modules) == 0 {
-		module := entities.Module{
-			Id:   fmt.Sprintf("%s:%s", chartName, chartVersion),
-			Type: "helm",
+	moduleId := fmt.Sprintf("%s:%s", chartName, chartVersion)
+	moduleExists := false
+	for _, module := range buildInfo.Modules {
+		if module.Type == entities.ModuleType("helm") && module.Id == moduleId {
+			moduleExists = true
+			break
 		}
-		buildInfo.Modules = append(buildInfo.Modules, module)
+	}
+	if !moduleExists {
+		buildInfo.Modules = append(buildInfo.Modules, entities.Module{
+			Id:   moduleId,
+			Type: entities.ModuleType("helm"),
+		})
 	}
 	if buildInfo.BuildAgent == nil || buildInfo.BuildAgent.Version == "" {
 		if buildInfo.BuildAgent == nil {

--- a/artifactory/commands/helm/utils_test.go
+++ b/artifactory/commands/helm/utils_test.go
@@ -225,15 +225,38 @@ func TestAppendModuleAndBuildAgentIfAbsent(t *testing.T) {
 		assert.Equal(t, "Helm", buildInfo.BuildAgent.Name)
 		assert.NotEmpty(t, buildInfo.BuildAgent.Version)
 	})
-	t.Run("Existing module does not add", func(t *testing.T) {
+	t.Run("Existing matching helm module does not add duplicate", func(t *testing.T) {
 		buildInfo := &entities.BuildInfo{
 			Modules: []entities.Module{
-				{Id: "existing:1.0.0", Type: "helm"},
+				{Id: "test-chart:1.0.0", Type: "helm"},
 			},
 		}
 		initialCount := len(buildInfo.Modules)
 		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "1.0.0")
 		assert.Equal(t, initialCount, len(buildInfo.Modules))
+	})
+	t.Run("Existing different module still adds missing helm module", func(t *testing.T) {
+		buildInfo := &entities.BuildInfo{
+			Modules: []entities.Module{
+				{Id: "existing:1.0.0", Type: "helm"},
+			},
+		}
+		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "1.0.0")
+		assert.Len(t, buildInfo.Modules, 2)
+		assert.Equal(t, entities.ModuleType("helm"), buildInfo.Modules[1].Type)
+		assert.Equal(t, "test-chart:1.0.0", buildInfo.Modules[1].Id)
+	})
+	t.Run("Existing docker module with same id adds separate helm module", func(t *testing.T) {
+		buildInfo := &entities.BuildInfo{
+			Modules: []entities.Module{
+				{Id: "test-chart:1.0.0", Type: "docker"},
+			},
+		}
+		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "1.0.0")
+		assert.Len(t, buildInfo.Modules, 2)
+		assert.Equal(t, entities.ModuleType("docker"), buildInfo.Modules[0].Type)
+		assert.Equal(t, entities.ModuleType("helm"), buildInfo.Modules[1].Type)
+		assert.Equal(t, "test-chart:1.0.0", buildInfo.Modules[1].Id)
 	})
 }
 
@@ -486,6 +509,34 @@ func TestAddArtifactsInBuildInfoUsesModuleTypeIdentity(t *testing.T) {
 			assertModuleArtifactsByTypeAndID(t, tt.buildInfo.Modules, tt.expectedArtifacts)
 		})
 	}
+}
+
+func TestAppendModuleAndAddArtifactsPreservesSeparateHelmModule(t *testing.T) {
+	buildInfo := &entities.BuildInfo{Modules: []entities.Module{{
+		Id:   "chart:1.0.0",
+		Type: entities.ModuleType("docker"),
+		Artifacts: []entities.Artifact{{
+			Name:     "docker-artifact",
+			Checksum: entities.Checksum{Sha256: "sha-docker"},
+		}},
+	}}}
+
+	appendModuleAndBuildAgentIfAbsent(buildInfo, "chart", "1.0.0")
+	addArtifactsInBuildInfo(buildInfo, []entities.Artifact{{
+		Name:     "helm-artifact",
+		Checksum: entities.Checksum{Sha256: "sha-helm"},
+	}}, "chart", "1.0.0", entities.ModuleType("helm"))
+
+	assert.Len(t, buildInfo.Modules, 2)
+	assert.Equal(t, entities.ModuleType("docker"), buildInfo.Modules[0].Type)
+	assert.Equal(t, "chart:1.0.0", buildInfo.Modules[0].Id)
+	assert.Len(t, buildInfo.Modules[0].Artifacts, 1)
+	assert.Equal(t, "docker-artifact", buildInfo.Modules[0].Artifacts[0].Name)
+
+	assert.Equal(t, entities.ModuleType("helm"), buildInfo.Modules[1].Type)
+	assert.Equal(t, "chart:1.0.0", buildInfo.Modules[1].Id)
+	assert.Len(t, buildInfo.Modules[1].Artifacts, 1)
+	assert.Equal(t, "helm-artifact", buildInfo.Modules[1].Artifacts[0].Name)
 }
 
 func TestRemoveDuplicateArtifacts(t *testing.T) {

--- a/artifactory/commands/helm/utils_test.go
+++ b/artifactory/commands/helm/utils_test.go
@@ -362,7 +362,7 @@ func TestRemoveDuplicateDependencies(t *testing.T) {
 
 func TestAddArtifactsInBuildInfo(t *testing.T) {
 	t.Run("Nil build info", func(t *testing.T) {
-		addArtifactsInBuildInfo(nil, []entities.Artifact{}, "chart", "1.0.0")
+		addArtifactsInBuildInfo(nil, []entities.Artifact{}, "chart", "1.0.0", entities.ModuleType("helm"))
 	})
 
 	t.Run("Add artifacts to matching module", func(t *testing.T) {
@@ -379,7 +379,7 @@ func TestAddArtifactsInBuildInfo(t *testing.T) {
 			{Name: "artifact1", Checksum: entities.Checksum{Sha256: "sha1"}},
 			{Name: "artifact2", Checksum: entities.Checksum{Sha256: "sha2"}},
 		}
-		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0")
+		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0", entities.ModuleType("helm"))
 		assert.Len(t, buildInfo.Modules[0].Artifacts, 2)
 		assert.Equal(t, "artifact1", buildInfo.Modules[0].Artifacts[0].Name)
 		assert.Equal(t, "artifact2", buildInfo.Modules[0].Artifacts[1].Name)
@@ -398,7 +398,7 @@ func TestAddArtifactsInBuildInfo(t *testing.T) {
 		artifacts := []entities.Artifact{
 			{Name: "artifact1", Checksum: entities.Checksum{Sha256: "sha1"}},
 		}
-		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0")
+		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0", entities.ModuleType("helm"))
 		assert.Len(t, buildInfo.Modules[0].Artifacts, 0)
 	})
 
@@ -418,12 +418,74 @@ func TestAddArtifactsInBuildInfo(t *testing.T) {
 			{Name: "new1", Checksum: entities.Checksum{Sha256: "sha1"}},
 			{Name: "new2", Checksum: entities.Checksum{Sha256: "sha2"}},
 		}
-		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0")
+		addArtifactsInBuildInfo(buildInfo, artifacts, "chart", "1.0.0", entities.ModuleType("helm"))
 		assert.Len(t, buildInfo.Modules[0].Artifacts, 3)
 		assert.Equal(t, "existing", buildInfo.Modules[0].Artifacts[0].Name)
 		assert.Equal(t, "new1", buildInfo.Modules[0].Artifacts[1].Name)
 		assert.Equal(t, "new2", buildInfo.Modules[0].Artifacts[2].Name)
 	})
+}
+
+func TestAddArtifactsInBuildInfoUsesModuleTypeIdentity(t *testing.T) {
+	tests := []struct {
+		name                string
+		moduleType          entities.ModuleType
+		buildInfo           *entities.BuildInfo
+		expectedArtifacts   map[string][]string
+		expectedModuleCount int
+	}{
+		{
+			name:       "same id and same type appends artifacts",
+			moduleType: entities.ModuleType("helm"),
+			buildInfo: &entities.BuildInfo{Modules: []entities.Module{{
+				Id:   "chart:1.0.0",
+				Type: entities.ModuleType("helm"),
+				Artifacts: []entities.Artifact{
+					{Name: "existing", Checksum: entities.Checksum{Sha256: "sha-existing"}},
+				},
+			}}},
+			expectedArtifacts: map[string][]string{
+				"helm|chart:1.0.0": {"existing", "new-artifact"},
+			},
+			expectedModuleCount: 1,
+		},
+		{
+			name:       "same id and different type does not merge",
+			moduleType: entities.ModuleType("helm"),
+			buildInfo: &entities.BuildInfo{Modules: []entities.Module{
+				{
+					Id:   "chart:1.0.0",
+					Type: entities.ModuleType("docker"),
+					Artifacts: []entities.Artifact{
+						{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}},
+					},
+				},
+				{
+					Id:   "chart:1.0.0",
+					Type: entities.ModuleType("helm"),
+					Artifacts: []entities.Artifact{
+						{Name: "helm-artifact", Checksum: entities.Checksum{Sha256: "sha-helm"}},
+					},
+				},
+			}},
+			expectedArtifacts: map[string][]string{
+				"docker|chart:1.0.0": {"docker-artifact"},
+				"helm|chart:1.0.0":   {"helm-artifact", "new-artifact"},
+			},
+			expectedModuleCount: 2,
+		},
+	}
+
+	artifactsToAdd := []entities.Artifact{{Name: "new-artifact", Checksum: entities.Checksum{Sha256: "sha-new"}}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addArtifactsInBuildInfo(tt.buildInfo, artifactsToAdd, "chart", "1.0.0", tt.moduleType)
+
+			assert.Len(t, tt.buildInfo.Modules, tt.expectedModuleCount)
+			assertModuleArtifactsByTypeAndID(t, tt.buildInfo.Modules, tt.expectedArtifacts)
+		})
+	}
 }
 
 func TestRemoveDuplicateArtifacts(t *testing.T) {
@@ -641,4 +703,217 @@ func TestAppendModuleInExistingBuildInfo(t *testing.T) {
 		assert.Equal(t, "dep2", buildInfo.Modules[0].Dependencies[1].Id)
 		assert.Equal(t, "new1", buildInfo.Modules[0].Artifacts[0].Name)
 	})
+}
+
+func TestAppendModuleInExistingBuildInfoUsesModuleTypeIdentity(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialModules      []entities.Module
+		moduleToAdd         entities.Module
+		expectedModules     []moduleExpectation
+		expectedModuleCount int
+	}{
+		{
+			name: "same id and same type merges into existing module",
+			initialModules: []entities.Module{{
+				Id:           "chart:1.0.0",
+				Type:         entities.ModuleType("helm"),
+				Artifacts:    []entities.Artifact{{Name: "old-artifact", Checksum: entities.Checksum{Sha256: "sha-old"}}},
+				Dependencies: []entities.Dependency{{Id: "dep-old", Checksum: entities.Checksum{Sha256: "dep-sha-old"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:           "chart:1.0.0",
+				Type:         entities.ModuleType("helm"),
+				Artifacts:    []entities.Artifact{{Name: "new-artifact", Checksum: entities.Checksum{Sha256: "sha-new"}}},
+				Dependencies: []entities.Dependency{{Id: "dep-new", Checksum: entities.Checksum{Sha256: "dep-sha-new"}}},
+			},
+			expectedModules: []moduleExpectation{{
+				Type:          entities.ModuleType("helm"),
+				ID:            "chart:1.0.0",
+				ArtifactNames: []string{"new-artifact"},
+				DependencyIDs: []string{"dep-old", "dep-new"},
+			}},
+			expectedModuleCount: 1,
+		},
+		{
+			name: "same id and different type stays separate docker to helm",
+			initialModules: []entities.Module{{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("docker"),
+				Artifacts: []entities.Artifact{{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("helm"),
+				Artifacts: []entities.Artifact{{Name: "helm-artifact", Checksum: entities.Checksum{Sha256: "sha-helm"}}},
+			},
+			expectedModules: []moduleExpectation{
+				{Type: entities.ModuleType("docker"), ID: "img:1.0", ArtifactNames: []string{"docker-artifact"}},
+				{Type: entities.ModuleType("helm"), ID: "img:1.0", ArtifactNames: []string{"helm-artifact"}},
+			},
+			expectedModuleCount: 2,
+		},
+		{
+			name: "same id and different type stays separate helm to docker",
+			initialModules: []entities.Module{{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("helm"),
+				Artifacts: []entities.Artifact{{Name: "helm-artifact", Checksum: entities.Checksum{Sha256: "sha-helm"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("docker"),
+				Artifacts: []entities.Artifact{{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}}},
+			},
+			expectedModules: []moduleExpectation{
+				{Type: entities.ModuleType("helm"), ID: "img:1.0", ArtifactNames: []string{"helm-artifact"}},
+				{Type: entities.ModuleType("docker"), ID: "img:1.0", ArtifactNames: []string{"docker-artifact"}},
+			},
+			expectedModuleCount: 2,
+		},
+		{
+			name: "empty type matches empty type",
+			initialModules: []entities.Module{{
+				Id:        "x:1",
+				Type:      entities.ModuleType(""),
+				Artifacts: []entities.Artifact{{Name: "old-empty", Checksum: entities.Checksum{Sha256: "sha-empty-old"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "x:1",
+				Type:      entities.ModuleType(""),
+				Artifacts: []entities.Artifact{{Name: "new-empty", Checksum: entities.Checksum{Sha256: "sha-empty-new"}}},
+			},
+			expectedModules:     []moduleExpectation{{Type: entities.ModuleType(""), ID: "x:1", ArtifactNames: []string{"new-empty"}}},
+			expectedModuleCount: 1,
+		},
+		{
+			name: "empty type does not match non empty type",
+			initialModules: []entities.Module{{
+				Id:        "x:1",
+				Type:      entities.ModuleType("docker"),
+				Artifacts: []entities.Artifact{{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "x:1",
+				Type:      entities.ModuleType(""),
+				Artifacts: []entities.Artifact{{Name: "empty-artifact", Checksum: entities.Checksum{Sha256: "sha-empty"}}},
+			},
+			expectedModules: []moduleExpectation{
+				{Type: entities.ModuleType("docker"), ID: "x:1", ArtifactNames: []string{"docker-artifact"}},
+				{Type: entities.ModuleType(""), ID: "x:1", ArtifactNames: []string{"empty-artifact"}},
+			},
+			expectedModuleCount: 2,
+		},
+		{
+			name: "order independence docker then helm",
+			initialModules: []entities.Module{{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("docker"),
+				Artifacts: []entities.Artifact{{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("helm"),
+				Artifacts: []entities.Artifact{{Name: "helm-artifact", Checksum: entities.Checksum{Sha256: "sha-helm"}}},
+			},
+			expectedModules: []moduleExpectation{
+				{Type: entities.ModuleType("docker"), ID: "img:1.0", ArtifactNames: []string{"docker-artifact"}},
+				{Type: entities.ModuleType("helm"), ID: "img:1.0", ArtifactNames: []string{"helm-artifact"}},
+			},
+			expectedModuleCount: 2,
+		},
+		{
+			name: "order independence helm then docker",
+			initialModules: []entities.Module{{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("helm"),
+				Artifacts: []entities.Artifact{{Name: "helm-artifact", Checksum: entities.Checksum{Sha256: "sha-helm"}}},
+			}},
+			moduleToAdd: entities.Module{
+				Id:        "img:1.0",
+				Type:      entities.ModuleType("docker"),
+				Artifacts: []entities.Artifact{{Name: "docker-artifact", Checksum: entities.Checksum{Sha256: "sha-docker"}}},
+			},
+			expectedModules: []moduleExpectation{
+				{Type: entities.ModuleType("helm"), ID: "img:1.0", ArtifactNames: []string{"helm-artifact"}},
+				{Type: entities.ModuleType("docker"), ID: "img:1.0", ArtifactNames: []string{"docker-artifact"}},
+			},
+			expectedModuleCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildInfo := &entities.BuildInfo{Modules: append([]entities.Module(nil), tt.initialModules...)}
+			moduleToAdd := tt.moduleToAdd
+
+			appendModuleInExistingBuildInfo(buildInfo, &moduleToAdd)
+
+			assert.Len(t, buildInfo.Modules, tt.expectedModuleCount)
+			assertModulesByTypeAndID(t, buildInfo.Modules, tt.expectedModules)
+		})
+	}
+}
+
+type moduleExpectation struct {
+	Type          entities.ModuleType
+	ID            string
+	ArtifactNames []string
+	DependencyIDs []string
+}
+
+func assertModulesByTypeAndID(t *testing.T, modules []entities.Module, expected []moduleExpectation) {
+	t.Helper()
+
+	assert.Len(t, modules, len(expected))
+	for _, expectedModule := range expected {
+		var matched *entities.Module
+		for i := range modules {
+			if modules[i].Type == expectedModule.Type && modules[i].Id == expectedModule.ID {
+				matched = &modules[i]
+				break
+			}
+		}
+		if assert.NotNil(t, matched, "module %s|%s should exist", expectedModule.Type, expectedModule.ID) {
+			assert.Equal(t, expectedModule.ArtifactNames, artifactNames(matched.Artifacts))
+			assert.Equal(t, expectedModule.DependencyIDs, dependencyIDs(matched.Dependencies))
+		}
+	}
+}
+
+func assertModuleArtifactsByTypeAndID(t *testing.T, modules []entities.Module, expected map[string][]string) {
+	t.Helper()
+
+	assert.Len(t, modules, len(expected))
+	for key, names := range expected {
+		matched := false
+		for i := range modules {
+			moduleKey := string(modules[i].Type) + "|" + modules[i].Id
+			if moduleKey == key {
+				assert.Equal(t, names, artifactNames(modules[i].Artifacts))
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched, "module %s should exist", key)
+	}
+}
+
+func artifactNames(artifacts []entities.Artifact) []string {
+	names := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		names = append(names, artifact.Name)
+	}
+	return names
+}
+
+func dependencyIDs(dependencies []entities.Dependency) []string {
+	if len(dependencies) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		ids = append(ids, dependency.Id)
+	}
+	return ids
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----

Fixes #426

## Summary

This PR fixes the Helm OCI build-info bug reported in #426, where
Helm and Docker modules could be merged together when they shared the same
`name:version`.

The linked issue contains the full bug report and reproduction details. In
short, Helm build-info helpers were matching modules by `Id` only, which made
cross-type collisions possible in mixed Helm/Docker build-info flows.

## Proposed Fix

This change makes module matching use `(Type, Id)` instead of `Id` alone.

### Implementation details

- `addArtifactsInBuildInfo` now receives the expected module type and only
  appends artifacts when both `module.Type` and `module.Id` match
- `appendModuleInExistingBuildInfo` now merges modules only when both fields
  match
- the Helm push flow now passes `entities.ModuleType("helm")` explicitly when
  adding artifacts into build-info

This preserves the external module ID format while correcting the internal
merge semantics.

## Why this approach

Using `(Type, Id)` as the merge identity is the smaller and safer fix because:

- it addresses the real collision source directly
- it preserves existing output format expectations
- it keeps the change localized and avoids broader refactoring

## Test Coverage

Added table-driven tests covering:

- same ID + same type -> modules still merge
- same ID + different type -> modules stay separate
- Docker -> Helm order independence
- Helm -> Docker order independence
- empty type matching semantics

Validation run locally:

- `go test -v ./artifactory/commands/helm/...`
- `go vet ./artifactory/commands/helm/...`

## Files changed

| File | Change |
|------|--------|
| `artifactory/commands/helm/utils.go` | Match build-info modules by `(Type, Id)` in both merge helpers |
| `artifactory/commands/helm/push.go` | Pass Helm module type explicitly when adding pushed artifacts |
| `artifactory/commands/helm/utils_test.go` | Add regression coverage for cross-type separation and order independence |

## Notes for Reviewers

- This PR intentionally does not change the external module ID format
- The fix is scoped to Helm build-info merge behavior only
- The goal is to preserve existing same-type merge behavior while preventing
  Helm/Docker cross-type collisions
