### PR TITLE
RTECO-1052 - Docker verification customisable through flags

### DIFF
--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -120,7 +120,7 @@ func (pc *PushCommand) Run() error {
 		var imageSha256 string
 		if pc.IsValidateSha() {
 			log.Info("Performing SHA-based validation for Docker push...")
-			imageSha256, err = cm.Id(pc.image)
+			imageSha256, err = cm.Id(pc.image, containerutils.Push)
 			if err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ func (pc *PushCommand) Run() error {
 	if pc.IsValidateSha() {
 		log.Info("Performing SHA-based validation for Docker push...")
 		// Get image SHA from the container manager
-		imageSha256, err := cm.Id(pc.image)
+		imageSha256, err := cm.Id(pc.image, containerutils.Push)
 		if err != nil {
 			return err
 		}

--- a/artifactory/commands/ocicontainer/containermanager.go
+++ b/artifactory/commands/ocicontainer/containermanager.go
@@ -27,13 +27,13 @@ const MinSupportedApiVersion string = "1.31"
 // Docker login error message
 const LoginFailureMessage string = "%s login failed for: %s.\n%s image must be in the form: registry-domain/path-in-repository/image-name:version."
 
-// SkipDockerImageIdVerificationEnv, when set to "true", tells the CLI to skip
-// the local docker image id lookup (which internally triggers `docker save`
-// on the entire image tarball to read the config digest) and the subsequent
-// manifest verification. Intended for large images where the lookup becomes
-// prohibitively slow. The Artifactory-side manifest's Config.Digest is used
+// EnforceDockerImageIdVerificationEnv, when set to "true", re-enables the
+// local docker image id lookup (which internally triggers `docker save` on the
+// entire image tarball to read the config digest) and the subsequent manifest
+// verification. By default this step is skipped because it is prohibitively
+// slow on large images; the Artifactory-side manifest's Config.Digest is used
 // in place of the local value for build-info construction.
-const SkipDockerImageIdVerificationEnv = "JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION"
+const EnforceDockerImageIdVerificationEnv = "JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION"
 
 func NewManager(containerManagerType ContainerManagerType) ContainerManager {
 	return &containerManager{Type: containerManagerType}
@@ -76,12 +76,14 @@ func (containerManager *containerManager) RunNativeCmd(cmdParams []string) error
 // Get image ID
 func (containerManager *containerManager) Id(image *Image) (string, error) {
 	if containerManager.GetContainerManagerType() == DockerClient {
-		// Opt-out: when this env var is set, skip the expensive daemon.Image
-		// call (which triggers `docker save` over the whole image) and let the
-		// caller fall back to the config digest reported by Artifactory's manifest.
+		// By default, skip the expensive daemon.Image call (which triggers
+		// `docker save` over the whole image) and let the caller fall back to
+		// the config digest reported by Artifactory's manifest. Set
+		// JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true to opt back in
+		// to the slow but strict local verification path.
 		// See isVerifiedManifest / buildInfoBuilder for the matching consumer logic.
-		if strings.EqualFold(os.Getenv(SkipDockerImageIdVerificationEnv), "true") {
-			log.Debug(SkipDockerImageIdVerificationEnv + "=true -> skipping local image id lookup and verification")
+		if !strings.EqualFold(os.Getenv(EnforceDockerImageIdVerificationEnv), "true") {
+			log.Debug("Skipping local image id lookup and verification (set " + EnforceDockerImageIdVerificationEnv + "=true to enforce)")
 			return "", nil
 		}
 		ref, err := name.ParseReference(image.Name())

--- a/artifactory/commands/ocicontainer/containermanager.go
+++ b/artifactory/commands/ocicontainer/containermanager.go
@@ -27,6 +27,14 @@ const MinSupportedApiVersion string = "1.31"
 // Docker login error message
 const LoginFailureMessage string = "%s login failed for: %s.\n%s image must be in the form: registry-domain/path-in-repository/image-name:version."
 
+// SkipDockerImageIdVerificationEnv, when set to "true", tells the CLI to skip
+// the local docker image id lookup (which internally triggers `docker save`
+// on the entire image tarball to read the config digest) and the subsequent
+// manifest verification. Intended for large images where the lookup becomes
+// prohibitively slow. The Artifactory-side manifest's Config.Digest is used
+// in place of the local value for build-info construction.
+const SkipDockerImageIdVerificationEnv = "JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION"
+
 func NewManager(containerManagerType ContainerManagerType) ContainerManager {
 	return &containerManager{Type: containerManagerType}
 }
@@ -68,6 +76,14 @@ func (containerManager *containerManager) RunNativeCmd(cmdParams []string) error
 // Get image ID
 func (containerManager *containerManager) Id(image *Image) (string, error) {
 	if containerManager.GetContainerManagerType() == DockerClient {
+		// Opt-out: when this env var is set, skip the expensive daemon.Image
+		// call (which triggers `docker save` over the whole image) and let the
+		// caller fall back to the config digest reported by Artifactory's manifest.
+		// See isVerifiedManifest / buildInfoBuilder for the matching consumer logic.
+		if strings.EqualFold(os.Getenv(SkipDockerImageIdVerificationEnv), "true") {
+			log.Debug(SkipDockerImageIdVerificationEnv + "=true -> skipping local image id lookup and verification")
+			return "", nil
+		}
 		ref, err := name.ParseReference(image.Name())
 		if err != nil {
 			return "", err

--- a/artifactory/commands/ocicontainer/containermanager.go
+++ b/artifactory/commands/ocicontainer/containermanager.go
@@ -3,12 +3,14 @@ package ocicontainer
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -27,13 +29,25 @@ const MinSupportedApiVersion string = "1.31"
 // Docker login error message
 const LoginFailureMessage string = "%s login failed for: %s.\n%s image must be in the form: registry-domain/path-in-repository/image-name:version."
 
-// EnforceDockerImageIdVerificationEnv, when set to "true", re-enables the
-// local docker image id lookup (which internally triggers `docker save` on the
-// entire image tarball to read the config digest) and the subsequent manifest
-// verification. By default this step is skipped because it is prohibitively
-// slow on large images; the Artifactory-side manifest's Config.Digest is used
-// in place of the local value for build-info construction.
-const EnforceDockerImageIdVerificationEnv = "JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION"
+// SkipDockerImageIdVerificationEnv is an opt-in escape hatch that, when set to
+// a truthy value, skips the local docker image id lookup (which internally
+// triggers `docker save` on the entire image tarball) and the subsequent
+// manifest verification during a docker push. The Artifactory-side manifest's
+// Config.Digest is adopted in place of the local value for build-info
+// construction. The skip is intentionally ignored for pull and other flows —
+// only pushes of large images hit the OOM / latency problem this addresses.
+const SkipDockerImageIdVerificationEnv = "JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION"
+
+// shouldSkipImageIdVerification returns true iff the user opted in via the
+// SkipDockerImageIdVerificationEnv env var AND the caller is on a push flow.
+// Any parse error or missing value is treated as false (i.e. verify).
+func shouldSkipImageIdVerification(commandType CommandType) bool {
+	if commandType != Push {
+		return false
+	}
+	skip, _ := strconv.ParseBool(os.Getenv(SkipDockerImageIdVerificationEnv))
+	return skip
+}
 
 func NewManager(containerManagerType ContainerManagerType) ContainerManager {
 	return &containerManager{Type: containerManagerType}
@@ -52,8 +66,10 @@ func (cmt ContainerManagerType) String() string {
 
 // Container image
 type ContainerManager interface {
-	// Image ID is basically the image's SHA256
-	Id(image *Image) (string, error)
+	// Image ID is basically the image's SHA256. commandType is used to gate
+	// the opt-in skip (SkipDockerImageIdVerificationEnv): non-push flows
+	// always perform the full verification path.
+	Id(image *Image, commandType CommandType) (string, error)
 	OsCompatibility(image *Image) (string, string, error)
 	RunNativeCmd(cmdParams []string) error
 	GetContainerManagerType() ContainerManagerType
@@ -74,23 +90,26 @@ func (containerManager *containerManager) RunNativeCmd(cmdParams []string) error
 }
 
 // Get image ID
-func (containerManager *containerManager) Id(image *Image) (string, error) {
+func (containerManager *containerManager) Id(image *Image, commandType CommandType) (string, error) {
 	if containerManager.GetContainerManagerType() == DockerClient {
-		// By default, skip the expensive daemon.Image call (which triggers
-		// `docker save` over the whole image) and let the caller fall back to
-		// the config digest reported by Artifactory's manifest. Set
-		// JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true to opt back in
-		// to the slow but strict local verification path.
-		// See isVerifiedManifest / buildInfoBuilder for the matching consumer logic.
-		if !strings.EqualFold(os.Getenv(EnforceDockerImageIdVerificationEnv), "true") {
-			log.Debug("Skipping local image id lookup and verification (set " + EnforceDockerImageIdVerificationEnv + "=true to enforce)")
+		// Optional opt-in short-circuit for pushes of large images, where the
+		// daemon.Image call below triggers `docker save` over the whole image
+		// tarball and has caused OOMs / long stalls. When skipped, the caller
+		// falls back to the Artifactory-side manifest Config.Digest — see
+		// localAgentBuildInfoBuilder.resolveAndVerifyManifest for the matching
+		// consumer logic.
+		if shouldSkipImageIdVerification(commandType) {
+			log.Debug("Skipping local image id lookup on docker push (" + SkipDockerImageIdVerificationEnv + "=true); Artifactory manifest digest will be adopted downstream")
 			return "", nil
 		}
 		ref, err := name.ParseReference(image.Name())
 		if err != nil {
 			return "", err
 		}
-		localImage, err := daemon.Image(ref, daemon.WithUnbufferedOpener())
+		// WithFileBufferedOpener spools the `docker save` stream to a temp
+		// file rather than buffering it entirely in memory, which avoids the
+		// OOM on large images without dropping the verification step.
+		localImage, err := daemon.Image(ref, daemon.WithFileBufferedOpener())
 		if err != nil {
 			return "", err
 		}

--- a/artifactory/commands/ocicontainer/containermanager_test.go
+++ b/artifactory/commands/ocicontainer/containermanager_test.go
@@ -1,33 +1,135 @@
 package ocicontainer
 
 import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// By default (env var unset) Id() must short-circuit, returning "" without
-// invoking daemon.Image / docker save. This is the performance fix for #3382.
-// The test does NOT require a running Docker daemon — proof that no daemon
-// call is made.
-func TestDockerClientId_DefaultSkipsDaemon(t *testing.T) {
-	// Force the env var to "false" to protect against a caller having exported
-	// it from the shell.
-	t.Setenv(EnforceDockerImageIdVerificationEnv, "false")
-
-	cm := &containerManager{Type: DockerClient}
-	id, err := cm.Id(NewImage("any-image-that-does-not-exist:latest"))
-	require.NoError(t, err, "Id() must not error when the daemon is not consulted")
-	assert.Empty(t, id, "Id() must return an empty string when the enforcement env var is disabled")
+func isDockerAvailable() bool {
+	cmd := exec.Command("docker", "info")
+	return cmd.Run() == nil
 }
 
-// Any non-"true" value should behave as the default — skip.
-func TestDockerClientId_CaseInsensitiveFalseSkipsDaemon(t *testing.T) {
-	t.Setenv(EnforceDockerImageIdVerificationEnv, "anything-other-than-true")
+func getImageSizeMB(t *testing.T, imageName string) uint64 {
+	cmd := exec.Command("docker", "inspect", "--format", "{{.Size}}", imageName)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	sizeBytes, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	require.NoError(t, err)
+	return sizeBytes / 1024 / 1024
+}
+
+// Verifies that Id() does not buffer the entire image in memory (OOM fix for #3382).
+func TestDockerClientId_MemoryUsage(t *testing.T) {
+	if !isDockerAvailable() {
+		t.Skip("Docker daemon not available")
+	}
+
+	cmd := exec.Command("docker", "pull", "busybox:latest")
+	if err := cmd.Run(); err != nil {
+		t.Skip("Cannot pull Docker images (no Docker engine or network access)")
+	}
+
+	imageSizeMB := getImageSizeMB(t, "busybox:latest")
+	t.Logf("Image size: %d MB", imageSizeMB)
+
+	ref, err := name.ParseReference("busybox:latest")
+	require.NoError(t, err)
+
+	// --- Buffered (default, the bug) ---
+	runtime.GC()
+	var memBeforeBuffered runtime.MemStats
+	runtime.ReadMemStats(&memBeforeBuffered)
+
+	bufferedImg, err := daemon.Image(ref)
+	require.NoError(t, err)
+	_, err = bufferedImg.Manifest()
+	require.NoError(t, err)
+
+	var memAfterBuffered runtime.MemStats
+	runtime.ReadMemStats(&memAfterBuffered)
+	bufferedAllocMB := (memAfterBuffered.TotalAlloc - memBeforeBuffered.TotalAlloc) / 1024 / 1024
+	t.Logf("[BUFFERED]   Memory allocated: %d MB (default — causes OOM on large images)", bufferedAllocMB)
+
+	// --- Unbuffered (the fix) ---
+	runtime.GC()
+	var memBeforeUnbuffered runtime.MemStats
+	runtime.ReadMemStats(&memBeforeUnbuffered)
 
 	cm := &containerManager{Type: DockerClient}
-	id, err := cm.Id(NewImage("any-image:latest"))
+	image := NewImage("busybox:latest")
+	_, err = cm.Id(image, Push)
 	require.NoError(t, err)
-	assert.Empty(t, id)
+
+	var memAfterUnbuffered runtime.MemStats
+	runtime.ReadMemStats(&memAfterUnbuffered)
+	unbufferedAllocMB := (memAfterUnbuffered.TotalAlloc - memBeforeUnbuffered.TotalAlloc) / 1024 / 1024
+	t.Logf("[UNBUFFERED] Memory allocated: %d MB (fix — streams without buffering)", unbufferedAllocMB)
+
+	t.Logf("Savings: %d MB", bufferedAllocMB-unbufferedAllocMB)
+
+	// Unbuffered should allocate less than half the image size
+	threshold := imageSizeMB / 2
+	if threshold < 10 {
+		threshold = 10
+	}
+	assert.Less(t, unbufferedAllocMB, threshold,
+		"Id() allocated %d MB for a %d MB image — may be buffering entire image in memory (OOM risk for large images)", unbufferedAllocMB, imageSizeMB)
+}
+
+// Push + skip env=true => short-circuit, no daemon call, empty id.
+func TestDockerClientId_PushWithSkipEnvTrue_ShortCircuits(t *testing.T) {
+	t.Setenv(SkipDockerImageIdVerificationEnv, "true")
+
+	cm := &containerManager{Type: DockerClient}
+	id, err := cm.Id(NewImage("any-image-that-does-not-exist:latest"), Push)
+	require.NoError(t, err, "Id() must not error when the daemon is not consulted")
+	assert.Empty(t, id, "Id() must return an empty string when skip is opted-in on a push")
+}
+
+// Push + skip env unset => daemon path is taken. Prove by passing a
+// deliberately invalid image name: we expect name.ParseReference to reject it.
+func TestDockerClientId_PushWithoutSkipEnv_GoesToDaemonPath(t *testing.T) {
+	t.Setenv(SkipDockerImageIdVerificationEnv, "")
+
+	cm := &containerManager{Type: DockerClient}
+	_, err := cm.Id(NewImage("INVALID NAME WITH SPACE"), Push)
+	require.Error(t, err, "Id() must reach name.ParseReference on the default path")
+}
+
+// Push + skip env=false (any non-truthy value) => default verify path.
+func TestDockerClientId_PushWithSkipEnvFalse_GoesToDaemonPath(t *testing.T) {
+	t.Setenv(SkipDockerImageIdVerificationEnv, "false")
+
+	cm := &containerManager{Type: DockerClient}
+	_, err := cm.Id(NewImage("INVALID NAME WITH SPACE"), Push)
+	require.Error(t, err, "Id() must reach name.ParseReference when skip is explicitly false")
+}
+
+// Pull must IGNORE the skip env and always take the verify path. This is the
+// reviewer-requested contract: the OOM/skipping opt-out only applies to push.
+func TestDockerClientId_PullWithSkipEnvTrue_StillVerifies(t *testing.T) {
+	t.Setenv(SkipDockerImageIdVerificationEnv, "true")
+
+	cm := &containerManager{Type: DockerClient}
+	_, err := cm.Id(NewImage("INVALID NAME WITH SPACE"), Pull)
+	require.Error(t, err, "Pull must always verify; name.ParseReference should reject the malformed name")
+}
+
+// Non-truthy env values must all be treated as "do not skip" (strconv.ParseBool
+// semantics: everything except 1/t/T/TRUE/true/True returns false or an error).
+func TestDockerClientId_PushWithNonBoolSkipEnv_GoesToDaemonPath(t *testing.T) {
+	t.Setenv(SkipDockerImageIdVerificationEnv, "anything-other-than-true")
+
+	cm := &containerManager{Type: DockerClient}
+	_, err := cm.Id(NewImage("INVALID NAME WITH SPACE"), Push)
+	require.Error(t, err, "strconv.ParseBool returns an error for non-bool values; must fall through to daemon path")
 }

--- a/artifactory/commands/ocicontainer/containermanager_test.go
+++ b/artifactory/commands/ocicontainer/containermanager_test.go
@@ -1,86 +1,33 @@
 package ocicontainer
 
 import (
-	"os/exec"
-	"runtime"
-	"strconv"
-	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func isDockerAvailable() bool {
-	cmd := exec.Command("docker", "info")
-	return cmd.Run() == nil
-}
-
-func getImageSizeMB(t *testing.T, imageName string) uint64 {
-	cmd := exec.Command("docker", "inspect", "--format", "{{.Size}}", imageName)
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	sizeBytes, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
-	require.NoError(t, err)
-	return sizeBytes / 1024 / 1024
-}
-
-// Verifies that Id() does not buffer the entire image in memory (OOM fix for #3382).
-func TestDockerClientId_MemoryUsage(t *testing.T) {
-	if !isDockerAvailable() {
-		t.Skip("Docker daemon not available")
-	}
-
-	cmd := exec.Command("docker", "pull", "busybox:latest")
-	if err := cmd.Run(); err != nil {
-		t.Skip("Cannot pull Docker images (no Docker engine or network access)")
-	}
-
-	imageSizeMB := getImageSizeMB(t, "busybox:latest")
-	t.Logf("Image size: %d MB", imageSizeMB)
-
-	ref, err := name.ParseReference("busybox:latest")
-	require.NoError(t, err)
-
-	// --- Buffered (default, the bug) ---
-	runtime.GC()
-	var memBeforeBuffered runtime.MemStats
-	runtime.ReadMemStats(&memBeforeBuffered)
-
-	bufferedImg, err := daemon.Image(ref)
-	require.NoError(t, err)
-	_, err = bufferedImg.Manifest()
-	require.NoError(t, err)
-
-	var memAfterBuffered runtime.MemStats
-	runtime.ReadMemStats(&memAfterBuffered)
-	bufferedAllocMB := (memAfterBuffered.TotalAlloc - memBeforeBuffered.TotalAlloc) / 1024 / 1024
-	t.Logf("[BUFFERED]   Memory allocated: %d MB (default — causes OOM on large images)", bufferedAllocMB)
-
-	// --- Unbuffered (the fix) ---
-	runtime.GC()
-	var memBeforeUnbuffered runtime.MemStats
-	runtime.ReadMemStats(&memBeforeUnbuffered)
+// By default (env var unset) Id() must short-circuit, returning "" without
+// invoking daemon.Image / docker save. This is the performance fix for #3382.
+// The test does NOT require a running Docker daemon — proof that no daemon
+// call is made.
+func TestDockerClientId_DefaultSkipsDaemon(t *testing.T) {
+	// Force the env var to "false" to protect against a caller having exported
+	// it from the shell.
+	t.Setenv(EnforceDockerImageIdVerificationEnv, "false")
 
 	cm := &containerManager{Type: DockerClient}
-	image := NewImage("busybox:latest")
-	_, err = cm.Id(image)
+	id, err := cm.Id(NewImage("any-image-that-does-not-exist:latest"))
+	require.NoError(t, err, "Id() must not error when the daemon is not consulted")
+	assert.Empty(t, id, "Id() must return an empty string when the enforcement env var is disabled")
+}
+
+// Any non-"true" value should behave as the default — skip.
+func TestDockerClientId_CaseInsensitiveFalseSkipsDaemon(t *testing.T) {
+	t.Setenv(EnforceDockerImageIdVerificationEnv, "anything-other-than-true")
+
+	cm := &containerManager{Type: DockerClient}
+	id, err := cm.Id(NewImage("any-image:latest"))
 	require.NoError(t, err)
-
-	var memAfterUnbuffered runtime.MemStats
-	runtime.ReadMemStats(&memAfterUnbuffered)
-	unbufferedAllocMB := (memAfterUnbuffered.TotalAlloc - memBeforeUnbuffered.TotalAlloc) / 1024 / 1024
-	t.Logf("[UNBUFFERED] Memory allocated: %d MB (fix — streams without buffering)", unbufferedAllocMB)
-
-	t.Logf("Savings: %d MB", bufferedAllocMB-unbufferedAllocMB)
-
-	// Unbuffered should allocate less than half the image size
-	threshold := imageSizeMB / 2
-	if threshold < 10 {
-		threshold = 10
-	}
-	assert.Less(t, unbufferedAllocMB, threshold,
-		"Id() allocated %d MB for a %d MB image — may be buffering entire image in memory (OOM risk for large images)", unbufferedAllocMB, imageSizeMB)
+	assert.Empty(t, id)
 }

--- a/artifactory/commands/ocicontainer/localagent.go
+++ b/artifactory/commands/ocicontainer/localagent.go
@@ -23,7 +23,7 @@ type localAgentBuildInfoBuilder struct {
 
 // Create new build info builder container CLI tool
 func NewLocalAgentBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (*localAgentBuildInfoBuilder, error) {
-	imageSha2, err := containerManager.Id(image)
+	imageSha2, err := containerManager.Id(image, commandType)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (labib *localAgentBuildInfoBuilder) searchImage() (map[string]*utils.Result
 		if err != nil {
 			return nil, nil, err
 		}
-		if manifest != nil && labib.isVerifiedManifest(manifest) {
+		if manifest != nil && labib.resolveAndVerifyManifest(manifest) {
 			return resultMap, manifest, nil
 		}
 	}
@@ -167,14 +167,18 @@ func (labib *localAgentBuildInfoBuilder) search(imagePathPattern string) (result
 	return resultMap, err
 }
 
-// Verify manifest by comparing sha256, which references to the image digest. If there is no match, return nil.
-// By default the local image id lookup is skipped (imageSha2 is empty) and we
-// accept the Artifactory manifest as-is, adopting its Config.Digest for
-// subsequent build-info lookups. Set
-// JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true to re-enable strict local verification.
-func (labib *localAgentBuildInfoBuilder) isVerifiedManifest(imageManifest *manifest) bool {
+// resolveAndVerifyManifest verifies the Artifactory manifest against the
+// locally-computed image id and — as a side effect — adopts the Artifactory
+// manifest's Config.Digest into builder.imageSha2 when no local id is
+// available (e.g. the caller opted into SkipDockerImageIdVerificationEnv on a
+// push). Downstream code relies on builder.imageSha2 being populated for
+// layer lookups, which is why this one function performs both the check and
+// the resolution in a single pass.
+//
+// Returns true if the manifest should be accepted.
+func (labib *localAgentBuildInfoBuilder) resolveAndVerifyManifest(imageManifest *manifest) bool {
 	if labib.buildInfoBuilder.imageSha2 == "" {
-		log.Debug("Image id verification skipped; adopting config digest from Artifactory manifest: " + imageManifest.Config.Digest)
+		log.Debug("Local image id unavailable; adopting Artifactory manifest config digest for build-info: " + imageManifest.Config.Digest)
 		labib.buildInfoBuilder.imageSha2 = imageManifest.Config.Digest
 		return true
 	}

--- a/artifactory/commands/ocicontainer/localagent.go
+++ b/artifactory/commands/ocicontainer/localagent.go
@@ -168,9 +168,10 @@ func (labib *localAgentBuildInfoBuilder) search(imagePathPattern string) (result
 }
 
 // Verify manifest by comparing sha256, which references to the image digest. If there is no match, return nil.
-// When the local image id lookup was skipped (imageSha2 is empty, controlled by
-// JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION), accept the Artifactory manifest
-// as-is and adopt its Config.Digest for subsequent build-info lookups.
+// By default the local image id lookup is skipped (imageSha2 is empty) and we
+// accept the Artifactory manifest as-is, adopting its Config.Digest for
+// subsequent build-info lookups. Set
+// JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true to re-enable strict local verification.
 func (labib *localAgentBuildInfoBuilder) isVerifiedManifest(imageManifest *manifest) bool {
 	if labib.buildInfoBuilder.imageSha2 == "" {
 		log.Debug("Image id verification skipped; adopting config digest from Artifactory manifest: " + imageManifest.Config.Digest)

--- a/artifactory/commands/ocicontainer/localagent.go
+++ b/artifactory/commands/ocicontainer/localagent.go
@@ -168,7 +168,15 @@ func (labib *localAgentBuildInfoBuilder) search(imagePathPattern string) (result
 }
 
 // Verify manifest by comparing sha256, which references to the image digest. If there is no match, return nil.
+// When the local image id lookup was skipped (imageSha2 is empty, controlled by
+// JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION), accept the Artifactory manifest
+// as-is and adopt its Config.Digest for subsequent build-info lookups.
 func (labib *localAgentBuildInfoBuilder) isVerifiedManifest(imageManifest *manifest) bool {
+	if labib.buildInfoBuilder.imageSha2 == "" {
+		log.Debug("Image id verification skipped; adopting config digest from Artifactory manifest: " + imageManifest.Config.Digest)
+		labib.buildInfoBuilder.imageSha2 = imageManifest.Config.Digest
+		return true
+	}
 	if imageManifest.Config.Digest != labib.buildInfoBuilder.imageSha2 {
 		log.Debug(`Found incorrect manifest.json file. Expects digest "` + labib.buildInfoBuilder.imageSha2 + `" found "` + imageManifest.Config.Digest)
 		return false

--- a/artifactory/commands/ocicontainer/localagent_test.go
+++ b/artifactory/commands/ocicontainer/localagent_test.go
@@ -6,43 +6,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// isVerifiedManifest must accept the Artifactory manifest as-is when imageSha2
-// is empty (i.e. containerManager.Id() was short-circuited by the default
-// behavior, or explicitly by JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=false)
-// and must adopt the manifest's Config.Digest into builder.imageSha2 so that
-// downstream digestToLayer(imageSha2) lookups in buildinfo.go still resolve.
-func TestIsVerifiedManifest_EmptyImageSha2_AdoptsFromManifest(t *testing.T) {
+// resolveAndVerifyManifest must accept the Artifactory manifest as-is when
+// imageSha2 is empty (e.g. containerManager.Id() was short-circuited by the
+// opt-in SkipDockerImageIdVerificationEnv on a push) and must adopt the
+// manifest's Config.Digest into builder.imageSha2 so that downstream
+// digestToLayer(imageSha2) lookups in buildinfo.go still resolve.
+func TestResolveAndVerifyManifest_EmptyImageSha2_AdoptsFromManifest(t *testing.T) {
 	const artifactoryDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	labib := &localAgentBuildInfoBuilder{
 		buildInfoBuilder: &buildInfoBuilder{imageSha2: ""},
 	}
 	m := &manifest{Config: manifestConfig{Digest: artifactoryDigest}}
 
-	ok := labib.isVerifiedManifest(m)
+	ok := labib.resolveAndVerifyManifest(m)
 
 	assert.True(t, ok, "verification should succeed when the local id was skipped")
 	assert.Equal(t, artifactoryDigest, labib.buildInfoBuilder.imageSha2,
 		"imageSha2 must be populated from the Artifactory manifest for downstream lookups")
 }
 
-// When imageSha2 is populated (enforcement path) and matches the Artifactory
+// When imageSha2 is populated (verify path) and matches the Artifactory
 // manifest, verification must succeed and imageSha2 must be left untouched.
-func TestIsVerifiedManifest_MatchingDigest_ReturnsTrue(t *testing.T) {
+func TestResolveAndVerifyManifest_MatchingDigest_ReturnsTrue(t *testing.T) {
 	const digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	labib := &localAgentBuildInfoBuilder{
 		buildInfoBuilder: &buildInfoBuilder{imageSha2: digest},
 	}
 	m := &manifest{Config: manifestConfig{Digest: digest}}
 
-	ok := labib.isVerifiedManifest(m)
+	ok := labib.resolveAndVerifyManifest(m)
 
 	assert.True(t, ok)
 	assert.Equal(t, digest, labib.buildInfoBuilder.imageSha2)
 }
 
-// When imageSha2 is populated and does NOT match the Artifactory manifest, the
-// enforcement path must reject the manifest.
-func TestIsVerifiedManifest_MismatchingDigest_ReturnsFalse(t *testing.T) {
+// When imageSha2 is populated and does NOT match the Artifactory manifest,
+// the verify path must reject the manifest and leave imageSha2 alone.
+func TestResolveAndVerifyManifest_MismatchingDigest_ReturnsFalse(t *testing.T) {
 	const localDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	const remoteDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 	labib := &localAgentBuildInfoBuilder{
@@ -50,7 +50,7 @@ func TestIsVerifiedManifest_MismatchingDigest_ReturnsFalse(t *testing.T) {
 	}
 	m := &manifest{Config: manifestConfig{Digest: remoteDigest}}
 
-	ok := labib.isVerifiedManifest(m)
+	ok := labib.resolveAndVerifyManifest(m)
 
 	assert.False(t, ok)
 	assert.Equal(t, localDigest, labib.buildInfoBuilder.imageSha2,

--- a/artifactory/commands/ocicontainer/localagent_test.go
+++ b/artifactory/commands/ocicontainer/localagent_test.go
@@ -1,0 +1,58 @@
+package ocicontainer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// isVerifiedManifest must accept the Artifactory manifest as-is when imageSha2
+// is empty (i.e. containerManager.Id() was short-circuited by the default
+// behavior, or explicitly by JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=false)
+// and must adopt the manifest's Config.Digest into builder.imageSha2 so that
+// downstream digestToLayer(imageSha2) lookups in buildinfo.go still resolve.
+func TestIsVerifiedManifest_EmptyImageSha2_AdoptsFromManifest(t *testing.T) {
+	const artifactoryDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	labib := &localAgentBuildInfoBuilder{
+		buildInfoBuilder: &buildInfoBuilder{imageSha2: ""},
+	}
+	m := &manifest{Config: manifestConfig{Digest: artifactoryDigest}}
+
+	ok := labib.isVerifiedManifest(m)
+
+	assert.True(t, ok, "verification should succeed when the local id was skipped")
+	assert.Equal(t, artifactoryDigest, labib.buildInfoBuilder.imageSha2,
+		"imageSha2 must be populated from the Artifactory manifest for downstream lookups")
+}
+
+// When imageSha2 is populated (enforcement path) and matches the Artifactory
+// manifest, verification must succeed and imageSha2 must be left untouched.
+func TestIsVerifiedManifest_MatchingDigest_ReturnsTrue(t *testing.T) {
+	const digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	labib := &localAgentBuildInfoBuilder{
+		buildInfoBuilder: &buildInfoBuilder{imageSha2: digest},
+	}
+	m := &manifest{Config: manifestConfig{Digest: digest}}
+
+	ok := labib.isVerifiedManifest(m)
+
+	assert.True(t, ok)
+	assert.Equal(t, digest, labib.buildInfoBuilder.imageSha2)
+}
+
+// When imageSha2 is populated and does NOT match the Artifactory manifest, the
+// enforcement path must reject the manifest.
+func TestIsVerifiedManifest_MismatchingDigest_ReturnsFalse(t *testing.T) {
+	const localDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	const remoteDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	labib := &localAgentBuildInfoBuilder{
+		buildInfoBuilder: &buildInfoBuilder{imageSha2: localDigest},
+	}
+	m := &manifest{Config: manifestConfig{Digest: remoteDigest}}
+
+	ok := labib.isVerifiedManifest(m)
+
+	assert.False(t, ok)
+	assert.Equal(t, localDigest, labib.buildInfoBuilder.imageSha2,
+		"imageSha2 must not be mutated when the manifest is rejected")
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----


Docker image id verification: fix OOM, make slow path opt-out
PR #410 introduced daemon.WithUnbufferedOpener() in containerManager.Id() to stop the Docker push flow from OOMing on large images — daemon.Image(ref) buffers the entire docker save tarball in memory. That change fixed the OOM but caused a second regression: on Docker 29 (which most customers now run) and on resource-constrained agents, the unbuffered opener stalls the push for 5+ minutes on multi-GB images. During that stall the jf docker push appears hung, sitting between the Pushed line from the Docker daemon and the subsequent Setting properties... build-info step.

The root cause is daemon.Image(...).Manifest() invoking a full docker save over the whole image just to read the config digest. On Docker 29 the docker images --format {{.ID}} fallback cannot be used because it now reports the manifest digest, not the config digest, so we can't cheaply substitute it.

What this PR does?
Two changes, both scoped to the Docker-client path inside containerManager.Id():

Replace WithUnbufferedOpener with WithFileBufferedOpener — spools the docker save stream to a temp file instead of RAM, permanently removing the OOM risk without needing any flag. Memory usage stays bounded regardless of image size.
Add a Push-only opt-in to skip the local id lookup entirely via a new env var JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION. When set to a truthy value on a docker push, Id() short-circuits and returns an empty string; the build-info builder then adopts the Artifactory-side manifest's Config.Digest for layer lookups, bypassing docker save completely. Pull and all other flows ignore the flag and always verify.
Default behavior is unchanged: we still verify the local id, just with file-backed buffering instead of in-memory buffering.


Depends on:
1. https://github.com/jfrog/jfrog-cli/pull/3447
