### PR TITLE
Addressed the subpath in helm push command

### DIFF
--- a/artifactory/commands/helm/layers.go
+++ b/artifactory/commands/helm/layers.go
@@ -69,15 +69,19 @@ func addOCILayersForDependency(dep entities.Dependency, serviceManager artifacto
 		log.Error("Failed to find a valid version for dependency: ", dep.Id)
 		return
 	}
-	repoName := extractRepositoryNameFromURL(dep.Repository)
+	repoName, subPath := extractRepoAndSubPath(dep.Repository)
 	if repoName == "" {
 		log.Error("Failed to find a valid repository for dependency: ", dep.Id)
 		return
 	}
+	fullPath := versionPath
+	if subPath != "" {
+		fullPath = subPath + "/" + versionPath
+	}
 	aqlQuery := fmt.Sprintf(`{
 	  "repo": "%s",
 	  "path": "%s"
-	}`, repoName, versionPath)
+	}`, repoName, fullPath)
 	resultMap, err := searchOCIArtifactsByAQL(serviceManager, aqlQuery)
 	if err != nil {
 		log.Debug("Failed to search OCI artifacts for dependency ", dep.Id, " : ", err)

--- a/artifactory/commands/helm/push.go
+++ b/artifactory/commands/helm/push.go
@@ -29,18 +29,19 @@ func handlePushCommand(buildInfo *entities.BuildInfo, helmArgs []string, service
 	}
 	appendModuleAndBuildAgentIfAbsent(buildInfo, chartName, chartVersion)
 	log.Debug("Processing push command for chart: ", filePath, " to registry: ", registryURL)
-	repoName := extractRepositoryNameFromURL(registryURL)
+	repoName, subPath := extractRepoAndSubPath(registryURL)
+	ociChartPath := buildOCIChartPath(subPath, chartName, chartVersion)
 	timestamp := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
 	buildProps := fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp)
 	if project != "" {
 		buildProps += fmt.Sprintf(";build.project=%s", project)
 	}
-	resultMap, err := searchPushedArtifacts(serviceManager, repoName, chartName, chartVersion, buildProps)
+	resultMap, err := searchPushedArtifacts(serviceManager, repoName, ociChartPath, buildProps)
 	if err != nil {
-		return fmt.Errorf("failed to search oci layers for %s : %s: %w", chartName, chartVersion, err)
+		return fmt.Errorf("failed to search oci layers for %s: %w", ociChartPath, err)
 	}
 	if len(resultMap) == 0 {
-		return fmt.Errorf("no oci layers found for chart: %s : %s", chartName, chartVersion)
+		return fmt.Errorf("no oci layers found for chart path: %s", ociChartPath)
 	}
 	artifactManifest, err := getManifest(resultMap, serviceManager, repoName)
 	if err != nil {
@@ -69,12 +70,13 @@ func handlePushCommand(buildInfo *entities.BuildInfo, helmArgs []string, service
 	return saveBuildInfo(buildInfo, buildName, buildNumber, project)
 }
 
-// searchPushedArtifacts searches for pushed OCI artifacts using a search pattern
-func searchPushedArtifacts(serviceManager artifactory.ArtifactoryServicesManager, repoName, chartName, chartVersion string, buildProperties string) (map[string]*servicesUtils.ResultItem, error) {
+// searchPushedArtifacts searches for pushed OCI artifacts using a search pattern.
+// ociChartPath is the full path under the repository, e.g. "subdir1/subdir2/chart-name/1.0.0".
+func searchPushedArtifacts(serviceManager artifactory.ArtifactoryServicesManager, repoName, ociChartPath string, buildProperties string) (map[string]*servicesUtils.ResultItem, error) {
 	aqlQuery := fmt.Sprintf(`{
 	  "repo": "%s",
-	  "path": "%s/%s"
-	}`, repoName, chartName, chartVersion)
+	  "path": "%s"
+	}`, repoName, ociChartPath)
 	searchParams := services.SearchParams{
 		CommonParams: &servicesUtils.CommonParams{
 			Aql: servicesUtils.Aql{ItemsFind: aqlQuery},
@@ -101,7 +103,8 @@ func searchPushedArtifacts(serviceManager artifactory.ArtifactoryServicesManager
 		}
 	}
 	if buildProperties != "" {
-		err = overwriteReaderWithManifestFolder(reader, repoName, chartName, chartVersion)
+		manifestPath, manifestName := splitOCIChartPath(ociChartPath)
+		err = overwriteReaderWithManifestFolder(reader, repoName, manifestPath, manifestName)
 		if err != nil {
 			return nil, err
 		}
@@ -109,6 +112,33 @@ func searchPushedArtifacts(serviceManager artifactory.ArtifactoryServicesManager
 		addBuildPropertiesOnArtifacts(serviceManager, reader, buildProperties)
 	}
 	return artifacts, nil
+}
+
+// buildOCIChartPath constructs the full Artifactory storage path for an OCI chart
+// by joining the optional subpath (nested directory segments from the OCI URL),
+// chartName, and chartVersion. For example:
+//
+//	subpath="team/app", chartName="mychart", chartVersion="1.0.0"
+//	  → "team/app/mychart/1.0.0"
+//
+//	subpath="", chartName="mychart", chartVersion="1.0.0"
+//	  → "mychart/1.0.0"
+func buildOCIChartPath(subpath, chartName, chartVersion string) string {
+	if subpath != "" {
+		return fmt.Sprintf("%s/%s/%s", subpath, chartName, chartVersion)
+	}
+	return fmt.Sprintf("%s/%s", chartName, chartVersion)
+}
+
+// splitOCIChartPath splits a full OCI chart path into the parent directory
+// (path) and the leaf directory (name), suitable for Artifactory's folder
+// result item format. For "team/app/mychart/1.0.0" it returns
+// ("team/app/mychart", "1.0.0").
+func splitOCIChartPath(ociChartPath string) (path, name string) {
+	if idx := strings.LastIndex(ociChartPath, "/"); idx >= 0 {
+		return ociChartPath[:idx], ociChartPath[idx+1:]
+	}
+	return ociChartPath, ""
 }
 
 // updateReaderContents updates the reader contents by writing the specified JSON value to all file paths

--- a/artifactory/commands/helm/repository.go
+++ b/artifactory/commands/helm/repository.go
@@ -15,28 +15,47 @@ const (
 // Supports both path-based access (oci://registry.com/repo-name) and
 // subdomain access (oci://repo-name.registry.com) methods
 func extractRepositoryNameFromURL(repositoryURL string) string {
-	if repositoryURL == "" {
-		return ""
+	repoName, _ := extractRepoAndSubPath(repositoryURL)
+	return repoName
+}
+
+// extractRepoAndSubPath extracts the Artifactory repository name and any
+// sub-path from an OCI or HTTPS URL. For path-based access like
+// oci://registry.example.com/my-repo/subdir1/subdir2, the repo is "my-repo"
+// and the sub-path is "subdir1/subdir2". For subdomain access like
+// oci://demo-helm-local.jfrog.io, the repo comes from the subdomain and
+// the sub-path is empty.
+func extractRepoAndSubPath(registryURL string) (repoName, subPath string) {
+	if registryURL == "" {
+		return "", ""
 	}
-	if !strings.Contains(repositoryURL, "://") {
-		return repositoryURL
+	if !strings.Contains(registryURL, "://") {
+		return registryURL, ""
 	}
-	repoURL := removeProtocolPrefix(repositoryURL)
+	repoURL := removeProtocolPrefix(registryURL)
 	if repoURL == "" {
-		return repositoryURL
+		return registryURL, ""
 	}
 	parts := strings.Split(repoURL, "/")
 	if len(parts) > 1 && parts[0] == "" {
 		if len(parts) > 2 && parts[2] != "" {
-			return parts[2]
+			repoName = parts[2]
+			if remaining := parts[3:]; len(remaining) > 0 {
+				subPath = strings.TrimRight(strings.Join(remaining, "/"), "/")
+			}
+			return
 		}
 	} else if len(parts) > 1 && parts[1] != "" {
-		return parts[1]
+		repoName = parts[1]
+		if remaining := parts[2:]; len(remaining) > 0 {
+			subPath = strings.TrimRight(strings.Join(remaining, "/"), "/")
+		}
+		return
 	}
 	// No path segments found — try subdomain Docker access method where the
 	// repository name is encoded as the first hostname label:
 	// oci://demo-helm-local.jfrog.io  →  repo = "demo-helm-local"
-	return extractRepositoryFromHostSubdomain(parts[0])
+	return extractRepositoryFromHostSubdomain(parts[0]), ""
 }
 
 // extractRepositoryFromHostSubdomain extracts the repository name from the

--- a/artifactory/commands/helm/repository_test.go
+++ b/artifactory/commands/helm/repository_test.go
@@ -157,6 +157,90 @@ func TestExtractDependencyPathInRepository(t *testing.T) {
 	}
 }
 
+func TestExtractRepoAndSubPath(t *testing.T) {
+	tests := []struct {
+		name            string
+		url             string
+		expectedRepo    string
+		expectedSubPath string
+	}{
+		{
+			name:            "No subpath - simple repo",
+			url:             "oci://example.com/my-repo",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "",
+		},
+		{
+			name:            "Single-level subpath",
+			url:             "oci://example.com/my-repo/team",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "team",
+		},
+		{
+			name:            "Multi-level subpath",
+			url:             "oci://example.com/my-repo/team/app/env",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "team/app/env",
+		},
+		{
+			name:            "OCI URL with artifactory prefix",
+			url:             "oci://example.com/artifactory/my-repo",
+			expectedRepo:    "artifactory",
+			expectedSubPath: "my-repo",
+		},
+		{
+			name:            "HTTPS URL with subpath",
+			url:             "https://example.com/my-repo/subdir",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "subdir",
+		},
+		{
+			name:            "Empty string",
+			url:             "",
+			expectedRepo:    "",
+			expectedSubPath: "",
+		},
+		{
+			name:            "No protocol",
+			url:             "my-repo",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "",
+		},
+		{
+			name:            "Subdomain only - no path segments",
+			url:             "oci://demo-helm-local.jfrog.io",
+			expectedRepo:    "demo-helm-local",
+			expectedSubPath: "",
+		},
+		{
+			name:            "OCI subdomain with port",
+			url:             "oci://my-helm-repo.registry.example.com:8443",
+			expectedRepo:    "my-helm-repo",
+			expectedSubPath: "",
+		},
+		{
+			name:            "Trailing slash is trimmed",
+			url:             "oci://example.com/my-repo/team/",
+			expectedRepo:    "my-repo",
+			expectedSubPath: "team",
+		},
+		{
+			name:            "Deep nesting",
+			url:             "oci://registry.example.com/helm-local/org/team/project/charts",
+			expectedRepo:    "helm-local",
+			expectedSubPath: "org/team/project/charts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, subPath := extractRepoAndSubPath(tt.url)
+			assert.Equal(t, tt.expectedRepo, repo)
+			assert.Equal(t, tt.expectedSubPath, subPath)
+		})
+	}
+}
+
 // TestIsOCIRepository tests the isOCIRepository function
 func TestIsOCIRepository(t *testing.T) {
 	tests := []struct {

--- a/artifactory/commands/helm/utils.go
+++ b/artifactory/commands/helm/utils.go
@@ -25,12 +25,19 @@ func appendModuleAndBuildAgentIfAbsent(buildInfo *entities.BuildInfo, chartName 
 		log.Debug("No build info collected, skipping further processing")
 		return
 	}
-	if len(buildInfo.Modules) == 0 {
-		module := entities.Module{
-			Id:   fmt.Sprintf("%s:%s", chartName, chartVersion),
-			Type: "helm",
+	moduleId := fmt.Sprintf("%s:%s", chartName, chartVersion)
+	moduleExists := false
+	for _, module := range buildInfo.Modules {
+		if module.Id == moduleId {
+			moduleExists = true
+			break
 		}
-		buildInfo.Modules = append(buildInfo.Modules, module)
+	}
+	if !moduleExists {
+		buildInfo.Modules = append(buildInfo.Modules, entities.Module{
+			Id:   moduleId,
+			Type: "helm",
+		})
 	}
 	if buildInfo.BuildAgent == nil || buildInfo.BuildAgent.Version == "" {
 		if buildInfo.BuildAgent == nil {

--- a/artifactory/commands/helm/utils_test.go
+++ b/artifactory/commands/helm/utils_test.go
@@ -209,6 +209,87 @@ func TestParseOCIReference(t *testing.T) {
 	}
 }
 
+func TestBuildOCIChartPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		subpath      string
+		chartName    string
+		chartVersion string
+		expected     string
+	}{
+		{
+			name:         "No subpath - root level chart",
+			subpath:      "",
+			chartName:    "mychart",
+			chartVersion: "1.0.0",
+			expected:     "mychart/1.0.0",
+		},
+		{
+			name:         "Single-level subpath",
+			subpath:      "team",
+			chartName:    "mychart",
+			chartVersion: "1.0.0",
+			expected:     "team/mychart/1.0.0",
+		},
+		{
+			name:         "Multi-level subpath",
+			subpath:      "team/app/env",
+			chartName:    "mychart",
+			chartVersion: "2.3.4",
+			expected:     "team/app/env/mychart/2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildOCIChartPath(tt.subpath, tt.chartName, tt.chartVersion)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSplitOCIChartPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		ociChartPath string
+		expectedPath string
+		expectedName string
+	}{
+		{
+			name:         "Simple chart/version",
+			ociChartPath: "mychart/1.0.0",
+			expectedPath: "mychart",
+			expectedName: "1.0.0",
+		},
+		{
+			name:         "Nested path with chart/version",
+			ociChartPath: "team/app/mychart/1.0.0",
+			expectedPath: "team/app/mychart",
+			expectedName: "1.0.0",
+		},
+		{
+			name:         "Deeply nested",
+			ociChartPath: "org/team/env/mychart/2.3.4",
+			expectedPath: "org/team/env/mychart",
+			expectedName: "2.3.4",
+		},
+		{
+			name:         "No slash",
+			ociChartPath: "single",
+			expectedPath: "single",
+			expectedName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, name := splitOCIChartPath(tt.ociChartPath)
+			assert.Equal(t, tt.expectedPath, path)
+			assert.Equal(t, tt.expectedName, name)
+		})
+	}
+}
+
 func TestAppendModuleAndBuildAgentIfAbsent(t *testing.T) {
 	t.Run("Nil build info", func(t *testing.T) {
 		appendModuleAndBuildAgentIfAbsent(nil, "test-chart", "1.0.0")
@@ -225,15 +306,37 @@ func TestAppendModuleAndBuildAgentIfAbsent(t *testing.T) {
 		assert.Equal(t, "Helm", buildInfo.BuildAgent.Name)
 		assert.NotEmpty(t, buildInfo.BuildAgent.Version)
 	})
-	t.Run("Existing module does not add", func(t *testing.T) {
+	t.Run("Same module ID already exists - no duplicate", func(t *testing.T) {
 		buildInfo := &entities.BuildInfo{
 			Modules: []entities.Module{
-				{Id: "existing:1.0.0", Type: "helm"},
+				{Id: "test-chart:1.0.0", Type: "helm"},
 			},
 		}
-		initialCount := len(buildInfo.Modules)
 		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "1.0.0")
-		assert.Equal(t, initialCount, len(buildInfo.Modules))
+		assert.Len(t, buildInfo.Modules, 1)
+	})
+	t.Run("Different modules exist - adds new helm module", func(t *testing.T) {
+		buildInfo := &entities.BuildInfo{
+			Modules: []entities.Module{
+				{Id: "docker-image:0.20.0", Type: "docker"},
+				{Id: "legacy-chart:0.20.0", Type: "generic"},
+			},
+		}
+		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "1.0.0")
+		assert.Len(t, buildInfo.Modules, 3)
+		assert.Equal(t, "test-chart:1.0.0", buildInfo.Modules[2].Id)
+		assert.Equal(t, entities.ModuleType("helm"), buildInfo.Modules[2].Type)
+	})
+	t.Run("Preserves existing modules when adding new one", func(t *testing.T) {
+		buildInfo := &entities.BuildInfo{
+			Modules: []entities.Module{
+				{Id: "existing:1.0.0", Type: "docker"},
+			},
+		}
+		appendModuleAndBuildAgentIfAbsent(buildInfo, "test-chart", "2.0.0")
+		assert.Len(t, buildInfo.Modules, 2)
+		assert.Equal(t, "existing:1.0.0", buildInfo.Modules[0].Id)
+		assert.Equal(t, "test-chart:2.0.0", buildInfo.Modules[1].Id)
 	})
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
What: Added logic for handling chart name and version in subpath.
Testing: Done, locally also, and updated the e2e also.