### PR TITLE
RTECO-1016 - Implement jf skills update command

### DIFF
--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -502,6 +502,7 @@ const (
 	// Skills commands keys
 	SkillsPublish = "skills-publish"
 	SkillsInstall = "skills-install"
+	SkillsUpdate  = "skills-update"
 	SkillsSearch  = "skills-search"
 	SkillsDelete  = "skills-delete"
 
@@ -511,10 +512,14 @@ const (
 	signingKey          = "signing-key"
 	keyAlias            = "key-alias"
 	skillsQuiet         = "skills-" + quiet
+	skillsForce         = "force"
 	propSearch          = "prop"
 	skillsFormat        = "skills-" + Format
 	skipScan            = "skip-scan"
 	autoDeleteOnFailure = "auto-delete-on-failure"
+	skillsAgent         = "agent"
+	skillsProjectDir    = "project-dir"
+	skillsCrossAgent    = "cross-agent"
 )
 
 var commandFlags = map[string][]string{
@@ -848,6 +853,11 @@ var commandFlags = map[string][]string{
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, installPath, skillsQuiet,
 	},
+	SkillsUpdate: {
+		url, user, password, accessToken, serverId, repo, version,
+		skillsAgent, skillsProjectDir, global, skillsCrossAgent,
+		dryRun, skillsForce, skillsQuiet,
+	},
 	SkillsDelete: {
 		url, user, password, accessToken, serverId, repo, version, dryRun,
 	},
@@ -1162,7 +1172,11 @@ var flagsMap = map[string]components.Flag{
 	signingKey:          components.NewStringFlag(signingKey, "Path to PGP private key for signing evidence. Overrides EVD_SIGNING_KEY_PATH env var.", components.SetMandatoryFalse()),
 	keyAlias:            components.NewStringFlag(keyAlias, "Alias for the signing key. Overrides EVD_KEY_ALIAS env var.", components.SetMandatoryFalse()),
 	skillsQuiet:         components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip interactive prompts.", components.WithBoolDefaultValueFalse()),
+	skillsForce:         components.NewBoolFlag(skillsForce, "Re-download the skill even if it is already at the target version, overwriting any local modifications.", components.WithBoolDefaultValueFalse()),
 	skillsFormat:        components.NewStringFlag(Format, "Output format: \"table\" (default) or \"json\".", components.SetMandatoryFalse()),
+	skillsAgent:         components.NewStringFlag(skillsAgent, "Target AI agent (cursor, claude-code, github-copilot, windsurf). Mutually exclusive with --cross-agent.", components.SetMandatoryFalse()),
+	skillsProjectDir:    components.NewStringFlag(skillsProjectDir, "Path to the project root. Installs into <project-dir>/<agent-project-dir>. Defaults to current directory.", components.SetMandatoryFalse()),
+	skillsCrossAgent:    components.NewBoolFlag(skillsCrossAgent, "Install the skill into the cross-agent directory (.agents/skills). Mutually exclusive with --agent.", components.WithBoolDefaultValueFalse()),
 	propSearch:          components.NewBoolFlag(propSearch, "Use Artifactory property search (skill.name) instead of Skills API search.", components.WithBoolDefaultValueFalse()),
 	skipScan:            components.NewBoolFlag(skipScan, "Skip Xray security scan after publish. Can also be set via JFROG_CLI_SKIP_SKILLS_SCAN=true.", components.WithBoolDefaultValueFalse()),
 	autoDeleteOnFailure: components.NewBoolFlag(autoDeleteOnFailure, "Automatically delete the artifact if Xray scan identifies it as malicious.", components.WithBoolDefaultValueFalse()),

--- a/skills/cli/cli.go
+++ b/skills/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/install"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/publish"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/search"
+	skillsupdate "github.com/jfrog/jfrog-cli-artifactory/skills/commands/update"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 )
 
@@ -31,6 +32,13 @@ func GetCommands() []components.Command {
 			Description: "Search for skills across Artifactory repositories.",
 			Arguments:   getSearchArguments(),
 			Action:      search.RunSearch,
+		},
+		{
+			Name:        "update",
+			Flags:       flagkit.GetCommandFlags(flagkit.SkillsUpdate),
+			Description: "Update an installed skill to the latest (or a specific) version. Use --dry-run to preview and --force to re-download even when already up to date.",
+			Arguments:   getUpdateArguments(),
+			Action:      skillsupdate.RunUpdate,
 		},
 		{
 			Name:        "delete",
@@ -65,6 +73,15 @@ func getInstallArguments() []components.Argument {
 		{
 			Name:        "slug",
 			Description: "Skill name/slug to install.",
+		},
+	}
+}
+
+func getUpdateArguments() []components.Argument {
+	return []components.Argument{
+		{
+			Name:        "slug",
+			Description: "Skill name/slug to update (e.g. web-search).",
 		},
 	}
 }

--- a/skills/commands/install/install.go
+++ b/skills/commands/install/install.go
@@ -115,6 +115,9 @@ func (ic *InstallCommand) Run() error {
 	}
 
 	destDir := ic.getDestDir()
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("failed to remove existing skill directory: %w", err)
+	}
 	if err := copyDir(unzipDir, destDir); err != nil {
 		return fmt.Errorf("failed to copy skill files: %w", err)
 	}

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -1,0 +1,314 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/c-bata/go-prompt"
+	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/install"
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+type UpdateCommand struct {
+	serverDetails *config.ServerDetails
+	repoKey       string
+	slug          string
+	version       string
+	// Location strategy
+	agentName  string
+	projectDir string
+	global     bool
+	// Behaviour
+	dryRun bool
+	force  bool
+	quiet  bool
+}
+
+func NewUpdateCommand() *UpdateCommand {
+	return &UpdateCommand{}
+}
+
+func (uc *UpdateCommand) SetServerDetails(details *config.ServerDetails) *UpdateCommand {
+	uc.serverDetails = details
+	return uc
+}
+
+func (uc *UpdateCommand) SetRepoKey(repoKey string) *UpdateCommand {
+	uc.repoKey = repoKey
+	return uc
+}
+
+func (uc *UpdateCommand) SetSlug(slug string) *UpdateCommand {
+	uc.slug = slug
+	return uc
+}
+
+func (uc *UpdateCommand) SetVersion(version string) *UpdateCommand {
+	uc.version = version
+	return uc
+}
+
+func (uc *UpdateCommand) SetAgentName(agentName string) *UpdateCommand {
+	uc.agentName = agentName
+	return uc
+}
+
+func (uc *UpdateCommand) SetProjectDir(projectDir string) *UpdateCommand {
+	uc.projectDir = projectDir
+	return uc
+}
+
+func (uc *UpdateCommand) SetGlobal(global bool) *UpdateCommand {
+	uc.global = global
+	return uc
+}
+
+func (uc *UpdateCommand) SetDryRun(dryRun bool) *UpdateCommand {
+	uc.dryRun = dryRun
+	return uc
+}
+
+func (uc *UpdateCommand) SetForce(force bool) *UpdateCommand {
+	uc.force = force
+	return uc
+}
+
+func (uc *UpdateCommand) SetQuiet(quiet bool) *UpdateCommand {
+	uc.quiet = quiet
+	return uc
+}
+
+func (uc *UpdateCommand) ServerDetails() (*config.ServerDetails, error) {
+	return uc.serverDetails, nil
+}
+
+func (uc *UpdateCommand) CommandName() string {
+	return "skills_update"
+}
+
+func (uc *UpdateCommand) Run() error {
+	installBase, err := uc.resolveInstallBase()
+	if err != nil {
+		return err
+	}
+
+	skillDir := filepath.Join(installBase, uc.slug)
+
+	// Skill must already be installed
+	currentVersion := uc.readInstalledVersion(skillDir)
+	if currentVersion == "" {
+		return fmt.Errorf("skill '%s' is not installed at %s\n\nTo install it first, run:\n  jf skills install %s --path %s",
+			uc.slug, skillDir, uc.slug, installBase)
+	}
+
+	// Fetch available versions from Artifactory
+	versions, err := common.ListVersions(uc.serverDetails, uc.repoKey, uc.slug)
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return fmt.Errorf("skill '%s' not found in repository '%s'", uc.slug, uc.repoKey)
+		}
+		return fmt.Errorf("failed to fetch versions for '%s': %w", uc.slug, err)
+	}
+	if len(versions) == 0 {
+		return fmt.Errorf("no versions found for skill '%s' in repository '%s'", uc.slug, uc.repoKey)
+	}
+
+	versionStrs := make([]string, len(versions))
+	for i, v := range versions {
+		versionStrs[i] = v.Version
+	}
+
+	// Resolve target version
+	targetVersion, err := uc.resolveTargetVersion(versionStrs)
+	if err != nil {
+		return err
+	}
+
+	// Already on the right version
+	if currentVersion == targetVersion && !uc.force {
+		log.Info(fmt.Sprintf("Skill '%s' is already at version '%s'. Use --force to re-download.", uc.slug, currentVersion))
+		return nil
+	}
+
+	if uc.force && currentVersion == targetVersion {
+		log.Info(fmt.Sprintf("Re-downloading skill '%s' v%s (--force)", uc.slug, targetVersion))
+	} else {
+		log.Info(fmt.Sprintf("Updating skill '%s': %s → %s", uc.slug, currentVersion, targetVersion))
+	}
+
+	if uc.dryRun {
+		log.Info("[dry-run] No files were modified.")
+		return nil
+	}
+
+	// Ask for confirmation in interactive mode
+	if !uc.quiet && !common.IsNonInteractive() {
+		if !coreutils.AskYesNo(fmt.Sprintf("Update '%s' to v%s?", uc.slug, targetVersion), true) {
+			return fmt.Errorf("update aborted by user")
+		}
+	}
+
+	// Delegate download + unzip + copy + evidence verification to InstallCommand.
+	// InstallCommand installs into <installBase>/<slug>/.
+	ic := install.NewInstallCommand().
+		SetServerDetails(uc.serverDetails).
+		SetRepoKey(uc.repoKey).
+		SetSlug(uc.slug).
+		SetVersion(targetVersion).
+		SetInstallPath(installBase).
+		SetQuiet(uc.quiet)
+
+	if err := ic.Run(); err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+
+	log.Info(fmt.Sprintf("Skill '%s' updated to v%s at %s", uc.slug, targetVersion, skillDir))
+	return nil
+}
+
+// resolveInstallBase returns the parent directory in which the skill folder lives.
+func (uc *UpdateCommand) resolveInstallBase() (string, error) {
+	return common.ResolveInstallPath(uc.agentName, uc.projectDir, uc.global)
+}
+
+func (uc *UpdateCommand) resolveTargetVersion(available []string) (string, error) {
+	if uc.version == "" || uc.version == "latest" {
+		return common.LatestVersion(available)
+	}
+
+	for _, v := range available {
+		if v == uc.version {
+			return v, nil
+		}
+	}
+
+	// Version not found — offer interactive selection if possible
+	if uc.quiet || common.IsNonInteractive() {
+		return "", fmt.Errorf("version '%s' not found for skill '%s'.\nAvailable versions: %s",
+			uc.version, uc.slug, strings.Join(available, ", "))
+	}
+
+	log.Warn(fmt.Sprintf("Version '%s' not found for skill '%s'.", uc.version, uc.slug))
+	options := make([]prompt.Suggest, len(available))
+	for i, v := range available {
+		options[i] = prompt.Suggest{Text: v}
+	}
+	selected := ioutils.AskFromListWithMismatchConfirmation(
+		"Select a version:",
+		fmt.Sprintf("'%%s' is not an available version for skill '%s'.", uc.slug),
+		options,
+	)
+	return selected, nil
+}
+
+// readInstalledVersion reads the version from SKILL.md frontmatter.
+// Returns "" if not installed or version field is absent.
+func (uc *UpdateCommand) readInstalledVersion(skillDir string) string {
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		return ""
+	}
+	return parseFrontmatterVersion(string(data))
+}
+
+func parseFrontmatterVersion(content string) string {
+	lines := strings.Split(content, "\n")
+	inFrontmatter := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				continue
+			}
+			break
+		}
+		if !inFrontmatter {
+			continue
+		}
+		if kv := strings.SplitN(trimmed, ":", 2); len(kv) == 2 {
+			if strings.TrimSpace(kv[0]) == "version" {
+				return strings.Trim(strings.TrimSpace(kv[1]), `"'`)
+			}
+		}
+	}
+	return ""
+}
+
+// RunUpdate is the CLI action for `jf skills update`.
+func RunUpdate(c *components.Context) error {
+	if c.GetNumberOfArgs() < 1 {
+		return fmt.Errorf("usage: jf skills update <slug> --agent <agent> [--global | --project-dir <path>] [--cross-agent] [--version <version>] [--repo <repo>] [--dry-run] [--force]")
+	}
+
+	slug := c.GetArgumentAt(0)
+
+	serverDetails, err := common.GetServerDetails(c)
+	if err != nil {
+		return err
+	}
+
+	quiet := common.IsQuiet(c)
+
+	agentName := c.GetStringFlagValue("agent")
+	crossAgent := c.GetBoolFlagValue("cross-agent")
+	global := c.GetBoolFlagValue("global")
+
+	// Validate flags before doing any network calls.
+	if agentName != "" && crossAgent {
+		return fmt.Errorf("--agent and --cross-agent are mutually exclusive")
+	}
+	if global && c.GetStringFlagValue("project-dir") != "" {
+		return fmt.Errorf("--global and --project-dir are mutually exclusive")
+	}
+	if global && agentName == "" && !crossAgent {
+		return fmt.Errorf("--global requires --agent to be specified")
+	}
+
+	// Resolve --cross-agent into the reserved agent name so the rest of the
+	// code has a single agentName to work with.
+	if crossAgent {
+		agentName = common.CrossAgentName
+	} else if agentName == "" {
+		return fmt.Errorf("--agent is required. Supported agents: %s\n(Use --cross-agent to install into the shared .agents/skills directory.)",
+			common.SupportedAgentsList())
+	}
+
+	repoKey, err := common.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet)
+	if err != nil {
+		return err
+	}
+
+	projectDir := c.GetStringFlagValue("project-dir")
+	if projectDir != "" {
+		abs, err := filepath.Abs(projectDir)
+		if err != nil {
+			return fmt.Errorf("invalid --project-dir %q: %w", projectDir, err)
+		}
+		if _, err := os.Stat(abs); os.IsNotExist(err) {
+			return fmt.Errorf("--project-dir does not exist: %s", abs)
+		}
+		projectDir = abs
+	}
+
+	cmd := NewUpdateCommand().
+		SetServerDetails(serverDetails).
+		SetRepoKey(repoKey).
+		SetSlug(slug).
+		SetVersion(c.GetStringFlagValue("version")).
+		SetAgentName(agentName).
+		SetProjectDir(projectDir).
+		SetGlobal(global).
+		SetDryRun(c.GetBoolFlagValue("dry-run")).
+		SetForce(c.GetBoolFlagValue("force")).
+		SetQuiet(quiet)
+
+	return cmd.Run()
+}

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -1,0 +1,242 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func makeSkillDir(t *testing.T, parent, slug, version, description string) {
+	t.Helper()
+	dir := filepath.Join(parent, slug)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := "---\nname: " + slug + "\nversion: " + version + "\ndescription: " + description + "\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+}
+
+// ---------------------------------------------------------------------------
+// parseFrontmatterVersion
+// ---------------------------------------------------------------------------
+
+func TestParseFrontmatterVersion_Valid(t *testing.T) {
+	content := "---\nname: my-skill\nversion: 1.2.3\ndescription: A skill\n---\n"
+	assert.Equal(t, "1.2.3", parseFrontmatterVersion(content))
+}
+
+func TestParseFrontmatterVersion_QuotedValue(t *testing.T) {
+	content := "---\nname: my-skill\nversion: \"2.0.0\"\n---\n"
+	assert.Equal(t, "2.0.0", parseFrontmatterVersion(content))
+}
+
+func TestParseFrontmatterVersion_SingleQuotedValue(t *testing.T) {
+	content := "---\nname: my-skill\nversion: '3.1.0'\n---\n"
+	assert.Equal(t, "3.1.0", parseFrontmatterVersion(content))
+}
+
+func TestParseFrontmatterVersion_NoVersionField(t *testing.T) {
+	content := "---\nname: my-skill\ndescription: no version here\n---\n"
+	assert.Equal(t, "", parseFrontmatterVersion(content))
+}
+
+func TestParseFrontmatterVersion_NoFrontmatter(t *testing.T) {
+	content := "Just plain markdown content, no frontmatter."
+	assert.Equal(t, "", parseFrontmatterVersion(content))
+}
+
+func TestParseFrontmatterVersion_EmptyContent(t *testing.T) {
+	assert.Equal(t, "", parseFrontmatterVersion(""))
+}
+
+// ---------------------------------------------------------------------------
+// common.ResolveInstallPath
+// ---------------------------------------------------------------------------
+
+func TestResolveInstallPath_CrossAgent_NoCWD(t *testing.T) {
+	path, err := common.ResolveInstallPath(common.CrossAgentName, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, ".agents/skills", path)
+}
+
+func TestResolveInstallPath_CrossAgent_WithProjectDir(t *testing.T) {
+	path, err := common.ResolveInstallPath(common.CrossAgentName, "/my/project", false)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/my/project", ".agents/skills"), path)
+}
+
+func TestResolveInstallPath_CrossAgent_Global(t *testing.T) {
+	path, err := common.ResolveInstallPath(common.CrossAgentName, "", true)
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(path), "global cross-agent path should be absolute")
+}
+
+func TestResolveInstallPath_KnownAgent_ProjectLevel_DefaultCWD(t *testing.T) {
+	path, err := common.ResolveInstallPath("cursor", "", false)
+	require.NoError(t, err)
+	assert.Equal(t, ".cursor/skills", path)
+}
+
+func TestResolveInstallPath_KnownAgent_ProjectLevel_WithProjectDir(t *testing.T) {
+	path, err := common.ResolveInstallPath("cursor", "/my/project", false)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/my/project", ".cursor/skills"), path)
+}
+
+func TestResolveInstallPath_KnownAgent_Global(t *testing.T) {
+	path, err := common.ResolveInstallPath("claude-code", "", true)
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(path), "global path should be absolute after home expansion")
+}
+
+func TestResolveInstallPath_UnknownAgent(t *testing.T) {
+	_, err := common.ResolveInstallPath("unknown-bot", "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+	assert.Contains(t, err.Error(), "unknown-bot")
+}
+
+// ---------------------------------------------------------------------------
+// readInstalledVersion
+// ---------------------------------------------------------------------------
+
+func TestReadInstalledVersion_Exists(t *testing.T) {
+	base := t.TempDir()
+	makeSkillDir(t, base, "web-search", "1.0.0", "A web search skill")
+
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName("cursor").SetProjectDir(base)
+	skillDir := filepath.Join(base, ".cursor/skills", "web-search")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	content := "---\nname: web-search\nversion: 1.0.0\ndescription: A web search skill\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+
+	assert.Equal(t, "1.0.0", cmd.readInstalledVersion(skillDir))
+}
+
+func TestReadInstalledVersion_MissingFile(t *testing.T) {
+	base := t.TempDir()
+	skillDir := filepath.Join(base, ".cursor/skills", "web-search")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName("cursor").SetProjectDir(base)
+	assert.Equal(t, "", cmd.readInstalledVersion(skillDir))
+}
+
+func TestReadInstalledVersion_DirDoesNotExist(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName("cursor")
+	assert.Equal(t, "", cmd.readInstalledVersion("/nonexistent/path/web-search"))
+}
+
+// ---------------------------------------------------------------------------
+// resolveInstallBase
+// ---------------------------------------------------------------------------
+
+func TestResolveInstallBase_CrossAgent_ProjectLevel(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName(common.CrossAgentName)
+	base, err := cmd.resolveInstallBase()
+	require.NoError(t, err)
+	assert.Equal(t, ".agents/skills", base)
+}
+
+func TestResolveInstallBase_CrossAgent_Global(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName(common.CrossAgentName).SetGlobal(true)
+	base, err := cmd.resolveInstallBase()
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(base), "global cross-agent path should be absolute")
+}
+
+func TestResolveInstallBase_MissingAgent(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search")
+	_, err := cmd.resolveInstallBase()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+}
+
+func TestResolveInstallBase_KnownAgent_ProjectLevel(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName("cursor")
+	base, err := cmd.resolveInstallBase()
+	require.NoError(t, err)
+	assert.Equal(t, ".cursor/skills", base)
+}
+
+func TestResolveInstallBase_KnownAgent_GlobalLevel(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("web-search").SetAgentName("cursor").SetGlobal(true)
+	base, err := cmd.resolveInstallBase()
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(base), "global path should be absolute after home expansion")
+}
+
+// ---------------------------------------------------------------------------
+// resolveTargetVersion
+// ---------------------------------------------------------------------------
+
+func TestResolveTargetVersion_EmptyUsesLatest(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("my-skill").SetVersion("")
+	v, err := cmd.resolveTargetVersion([]string{"1.0.0", "1.1.0", "2.0.0"})
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", v)
+}
+
+func TestResolveTargetVersion_LatestKeyword(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("my-skill").SetVersion("latest")
+	v, err := cmd.resolveTargetVersion([]string{"1.0.0", "1.5.0", "2.3.0"})
+	require.NoError(t, err)
+	assert.Equal(t, "2.3.0", v)
+}
+
+func TestResolveTargetVersion_ExactVersionFound(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("my-skill").SetVersion("1.1.0")
+	v, err := cmd.resolveTargetVersion([]string{"1.0.0", "1.1.0", "2.0.0"})
+	require.NoError(t, err)
+	assert.Equal(t, "1.1.0", v)
+}
+
+func TestResolveTargetVersion_VersionNotFound(t *testing.T) {
+	cmd := NewUpdateCommand().SetSlug("my-skill").SetVersion("9.9.9").SetQuiet(true)
+	_, err := cmd.resolveTargetVersion([]string{"1.0.0", "1.1.0", "2.0.0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "9.9.9")
+	assert.Contains(t, err.Error(), "Available versions")
+	assert.Contains(t, err.Error(), "1.0.0")
+	assert.Contains(t, err.Error(), "2.0.0")
+}
+
+// ---------------------------------------------------------------------------
+// Run — error paths that don't need a server
+// ---------------------------------------------------------------------------
+
+func TestUpdateCommand_NotInstalled(t *testing.T) {
+	base := t.TempDir()
+	cmd := NewUpdateCommand().
+		SetSlug("missing-skill").
+		SetAgentName("cursor").
+		SetProjectDir(base).
+		SetRepoKey("repo")
+
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not installed")
+	assert.Contains(t, err.Error(), "jf skills install")
+}
+
+func TestUpdateCommand_NotInstalled_NoSKILLMd(t *testing.T) {
+	base := t.TempDir()
+	// skill dir hierarchy exists but SKILL.md is absent
+	require.NoError(t, os.MkdirAll(filepath.Join(base, ".cursor/skills", "partial-skill"), 0o755))
+
+	cmd := NewUpdateCommand().
+		SetSlug("partial-skill").
+		SetAgentName("cursor").
+		SetProjectDir(base).
+		SetRepoKey("repo")
+
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not installed")
+}

--- a/skills/common/agents.go
+++ b/skills/common/agents.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CrossAgentName is the reserved agent name for the shared cross-agent skills directory.
+const CrossAgentName = ""
+
+// AgentConfig holds the skills directory paths for an AI agent.
+type AgentConfig struct {
+	GlobalDir  string
+	ProjectDir string
+}
+
+// Agents is the single source of truth for all supported AI agents and their skill paths.
+// cross-agent is a special entry for the shared .agents/skills directory.
+var Agents = map[string]AgentConfig{
+	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},
+	"cursor":         {GlobalDir: "~/.cursor/skills-cursor", ProjectDir: ".cursor/skills"},
+	"github-copilot": {GlobalDir: "~/.github/copilot/skills", ProjectDir: ".github/copilot/skills"},
+	"windsurf":       {GlobalDir: "~/.windsurf/skills", ProjectDir: ".windsurf/skills"},
+	CrossAgentName:   {GlobalDir: "~/.agents/skills", ProjectDir: ".agents/skills"},
+}
+
+// SupportedAgentsList returns a human-readable comma-separated list of agents
+// that can be passed to --agent (excludes the internal cross-agent entry).
+func SupportedAgentsList() string {
+	names := make([]string, 0, len(Agents)-1)
+	for name := range Agents {
+		if name != CrossAgentName {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+// ExpandHome expands a leading "~/" to the user's home directory.
+func ExpandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// ResolveInstallPath determines the parent directory into which a skill should be installed.
+//
+//   - global=true  → expanded <agent.GlobalDir>
+//   - default      → <projectDir>/<agent.ProjectDir>  (or <agent.ProjectDir> relative to CWD)
+//
+// Pass CrossAgentName as agentName to target the shared .agents/skills directory.
+func ResolveInstallPath(agentName, projectDir string, global bool) (string, error) {
+	agent, ok := Agents[strings.ToLower(agentName)]
+	if !ok {
+		return "", fmt.Errorf("unknown agent %q. Supported agents: %s", agentName, SupportedAgentsList())
+	}
+
+	if global {
+		return ExpandHome(agent.GlobalDir), nil
+	}
+
+	if projectDir != "" {
+		return filepath.Join(projectDir, agent.ProjectDir), nil
+	}
+	return agent.ProjectDir, nil
+}

--- a/skills/common/agents.go
+++ b/skills/common/agents.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CrossAgentName is the reserved agent name for the shared cross-agent skills directory.
-const CrossAgentName = ""
+const CrossAgentName = "cross-agent"
 
 // AgentConfig holds the skills directory paths for an AI agent.
 type AgentConfig struct {


### PR DESCRIPTION
### Overview

Updates an installed skill to the latest or a specific version from Artifactory.

1. Implemented Flags:
--agent: Target AI agent whose skill directory to update. Supported: cursor, claude-code, github-copilot, windsurf. Mutually exclusive with --cross-agent.
--cross-agent: Update the skill in the shared cross-agent directory (.agents/skills). Mutually exclusive with --agent.
--global: Update the skill in the agent's global directory (e.g. ~/.cursor/skills-cursor). Works with both --agent and --cross-agent. Mutually exclusive with --project-dir.
--project-dir: Path to the project root. Updates the skill in <project-dir>/<agent-dir>. Defaults to current directory.
--repo: Artifactory skills repository to fetch the update from.
--version: Target version to update to (e.g. 1.2.0). Defaults to latest. If the version is not found, an interactive selector is offered.
--dry-run: Preview the update without modifying any files.
--force: Re-download and overwrite even if the skill is already at the target version.
--quiet: Skip confirmation prompts. Enabled automatically in CI environments.

2. Validates all flag combinations before network calls
3. Reuses InstallCommand for download/unzip/copy/evidence verification
4. Agent paths centralised in skills/common/agents.go

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
