### PR TITLE
Add --format flag support to artifactory commands

### DIFF
--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 
 	ioutils "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/buildinfo"
-	"github.com/jfrog/jfrog-cli-artifactory/artifactory/formats"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/curl"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/dotnet"
@@ -1898,9 +1898,10 @@ func buildPublishCmd(c *components.Context) error {
 	cmd.SetDepExcludeScopes(c.GetStringsArrFlagValue("dep-exclude-scopes"))
 
 	// When --format is set, suppress the internal logJsonOutput call so that the
-	// CLI layer can render the URL itself.
+	// CLI layer can render the URL itself, and collect sha256.
 	if outputFormat != coreformat.None {
 		cmd.SetSuppressOutput(true)
+		cmd.SetCollectSha256(true)
 	}
 
 	err = commands.Exec(cmd)
@@ -1919,25 +1920,46 @@ func buildPublishCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	return printBuildPublishResponse(cmd.GetBuildInfoUiUrl(), outputFormat, os.Stdout)
+	var sha256 string
+	if s := cmd.GetSummary(); s != nil {
+		sha256 = s.GetSha256()
+	}
+	return printBuildPublishResponse(cmd.GetBuildInfoUiUrl(), sha256, outputFormat, os.Stdout)
 }
 
 // printBuildPublishResponse renders the build-publish result in the requested output format.
-func printBuildPublishResponse(buildInfoUiUrl string, outputFormat coreformat.OutputFormat, w io.Writer) error {
+func printBuildPublishResponse(buildInfoUiUrl, sha256 string, outputFormat coreformat.OutputFormat, w io.Writer) error {
 	switch outputFormat {
 	case coreformat.Json:
-		return printBuildPublishJSON(buildInfoUiUrl)
+		return printBuildPublishJSON(buildInfoUiUrl, sha256)
 	case coreformat.Table:
-		return printBuildPublishTable(buildInfoUiUrl, w)
+		return printBuildPublishTable(buildInfoUiUrl, sha256, w)
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt build-publish. Acceptable values are: json, table", outputFormat)
 	}
 }
 
+// buildPublishFormatOutput is the structured output for --format json/table.
+// Separate from the stable formats.BuildPublishOutput API struct to allow adding fields.
+type buildPublishFormatOutput struct {
+	BuildInfoUiUrl string `json:"buildInfoUiUrl"`
+	Sha256         string `json:"sha256,omitempty"`
+}
+
+func (o *buildPublishFormatOutput) json() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(o); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // printBuildPublishJSON emits the build-publish result as indented JSON.
-func printBuildPublishJSON(buildInfoUiUrl string) error {
-	output := formats.BuildPublishOutput{BuildInfoUiUrl: buildInfoUiUrl}
-	data, err := output.JSON()
+func printBuildPublishJSON(buildInfoUiUrl, sha256 string) error {
+	output := &buildPublishFormatOutput{BuildInfoUiUrl: buildInfoUiUrl, Sha256: sha256}
+	data, err := output.json()
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
@@ -1946,10 +1968,13 @@ func printBuildPublishJSON(buildInfoUiUrl string) error {
 }
 
 // printBuildPublishTable renders the build-publish result as a two-column tabwriter table.
-func printBuildPublishTable(buildInfoUiUrl string, w io.Writer) error {
+func printBuildPublishTable(buildInfoUiUrl, sha256 string, w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
 	_, _ = fmt.Fprintf(tw, "buildInfoUiUrl\t%s\n", buildInfoUiUrl)
+	if sha256 != "" {
+		_, _ = fmt.Fprintf(tw, "sha256\t%s\n", sha256)
+	}
 	return tw.Flush()
 }
 

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1198,7 +1198,7 @@ func moveCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	moveCmd := generic.NewMoveCommand()
+	mvCmd := generic.NewMoveCommand()
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
@@ -1215,10 +1215,68 @@ func moveCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	moveCmd.SetThreads(threads).SetDryRun(c.GetBoolFlagValue("dry-run")).SetServerDetails(rtDetails).SetSpec(moveSpec).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
-	err = commands.Exec(moveCmd)
-	result := moveCmd.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	mvCmd.SetThreads(threads).SetDryRun(c.GetBoolFlagValue("dry-run")).SetServerDetails(rtDetails).SetSpec(moveSpec).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
+	err = commands.Exec(mvCmd)
+	result := mvCmd.Result()
+
+	outputFormat, fmtErr := getMoveOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printMoveResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getMoveOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getMoveOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printMoveResponse renders the move result in the requested output format.
+func printMoveResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printMoveJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printMoveTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt move. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printMoveJSON emits a JSON summary of the move operation to stdout via log.Output.
+func printMoveJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printMoveTable renders a counts table for the move operation.
+func printMoveTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func copyCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -60,6 +61,7 @@ import (
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
 	"github.com/jfrog/jfrog-cli-core/v2/common/cliutils/summary"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/common/progressbar"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/common"
@@ -70,6 +72,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/pkg/errors"
 )
@@ -1129,13 +1132,13 @@ func searchCmd(c *components.Context) (err error) {
 	if err != nil {
 		return
 	}
-	searchCmd := generic.NewSearchCommand()
-	searchCmd.SetServerDetails(artDetails).SetSpec(searchSpec).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
-	err = commands.Exec(searchCmd)
+	cmd := generic.NewSearchCommand()
+	cmd.SetServerDetails(artDetails).SetSpec(searchSpec).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
+	err = commands.Exec(cmd)
 	if err != nil {
 		return
 	}
-	reader := searchCmd.Result().Reader()
+	reader := cmd.Result().Reader()
 	defer ioutils.Close(reader, &err)
 	length, err := reader.Length()
 	if err != nil {
@@ -1145,11 +1148,66 @@ func searchCmd(c *components.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	if !c.GetBoolFlagValue("count") {
-		return utils.PrintSearchResults(reader)
+	if c.GetBoolFlagValue("count") {
+		log.Output(length)
+		return nil
 	}
-	log.Output(length)
-	return nil
+	outputFormat, err := getSearchOutputFormat(c)
+	if err != nil {
+		return err
+	}
+	return printSearchResponse(reader, outputFormat)
+}
+
+// searchTableRow is a table-printable representation of a search result item.
+type searchTableRow struct {
+	Path     string `col-name:"PATH"`
+	Type     string `col-name:"TYPE"`
+	Size     string `col-name:"SIZE"`
+	Created  string `col-name:"CREATED"`
+	Modified string `col-name:"MODIFIED"`
+	Sha256   string `col-name:"SHA256"`
+}
+
+// getSearchOutputFormat reads the --format flag and returns the resolved output format.
+// Default is json to preserve backward-compatible behaviour (the command has always emitted JSON).
+func getSearchOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.Json, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printSearchResponse renders ContentReader results in the requested output format.
+func printSearchResponse(reader *content.ContentReader, outputFormat coreformat.OutputFormat) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return utils.PrintSearchResults(reader)
+	case coreformat.Table:
+		return printSearchTable(reader)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt search. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printSearchTable prints search results as a human-readable table using coreutils.PrintTable.
+func printSearchTable(reader *content.ContentReader) error {
+	var rows []searchTableRow
+	for item := new(utils.SearchResult); reader.NextRecord(item) == nil; item = new(utils.SearchResult) {
+		rows = append(rows, searchTableRow{
+			Path:     item.Path,
+			Type:     item.Type,
+			Size:     fmt.Sprintf("%d", item.Size),
+			Created:  item.Created,
+			Modified: item.Modified,
+			Sha256:   item.Sha256,
+		})
+	}
+	if err := reader.GetError(); err != nil {
+		return err
+	}
+	reader.Reset()
+	return coreutils.PrintTable(rows, "Search Results", "No artifacts found.", false)
 }
 
 func preparePropsCmd(c *components.Context) (*generic.PropsCommand, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1424,7 +1424,65 @@ func deleteCmd(c *components.Context) error {
 	deleteCommand.SetThreads(threads).SetQuiet(common.GetQuietValue(c)).SetDryRun(c.GetBoolFlagValue("dry-run")).SetServerDetails(rtDetails).SetSpec(deleteSpec).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 	err = commands.Exec(deleteCommand)
 	result := deleteCommand.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+
+	outputFormat, fmtErr := getDeleteOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printDeleteResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getDeleteOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getDeleteOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printDeleteResponse renders the delete result in the requested output format.
+func printDeleteResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printDeleteJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printDeleteTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt delete. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printDeleteJSON emits a JSON summary of the delete operation to stdout via log.Output.
+func printDeleteJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printDeleteTable renders a counts table for the delete operation.
+func printDeleteTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func prepareSearchCommand(c *components.Context) (*spec.SpecFiles, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -644,13 +644,70 @@ func containerPullCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return err
 	}
+	outputFormat, err := getContainerPullOutputFormat(c)
+	if err != nil {
+		return err
+	}
 	dockerPullCommand := container.NewPullCommand(containerManagerType)
 	dockerPullCommand.SetCmdParams([]string{"pull", imageTag}).SetSkipLogin(skipLogin).SetImageTag(imageTag).SetRepo(sourceRepo).SetServerDetails(artDetails).SetBuildConfiguration(buildConfiguration)
 	err = commandWrappers.ShowDockerDeprecationMessageIfNeeded(containerManagerType, dockerPullCommand.IsGetRepoSupported)
 	if err != nil {
 		return err
 	}
-	return commands.Exec(dockerPullCommand)
+	if err = commands.Exec(dockerPullCommand); err != nil {
+		return err
+	}
+	if outputFormat == coreformat.None {
+		return nil
+	}
+	return printContainerPullResponse(imageTag, sourceRepo, outputFormat, os.Stdout)
+}
+
+// getContainerPullOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (no structured output beyond the native podman/docker output).
+func getContainerPullOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printContainerPullResponse renders the container pull result in the requested output format.
+func printContainerPullResponse(imageTag, sourceRepo string, outputFormat coreformat.OutputFormat, w io.Writer) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return printContainerPullJSON(imageTag, sourceRepo)
+	case coreformat.Table:
+		return printContainerPullTable(imageTag, sourceRepo, w)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt podman-pull. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printContainerPullJSON emits a JSON summary of the container pull operation to stdout via log.Output.
+func printContainerPullJSON(imageTag, sourceRepo string) error {
+	result := map[string]interface{}{
+		"status": "ok",
+		"image":  imageTag,
+		"repo":   sourceRepo,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printContainerPullTable renders a FIELD/VALUE table for the container pull operation.
+func printContainerPullTable(imageTag, sourceRepo string, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "status\t%s\n", "ok")
+	_, _ = fmt.Fprintf(tw, "image\t%s\n", imageTag)
+	_, _ = fmt.Fprintf(tw, "repo\t%s\n", sourceRepo)
+	return tw.Flush()
 }
 
 func BuildDockerCreateCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -2025,7 +2025,65 @@ func buildAddDependenciesCmd(c *components.Context) error {
 	buildAddDependenciesCmd := buildinfo.NewBuildAddDependenciesCommand().SetDryRun(c.GetBoolFlagValue("dry-run")).SetBuildConfiguration(buildConfiguration).SetDependenciesSpec(dependenciesSpec).SetServerDetails(rtDetails)
 	err = commands.Exec(buildAddDependenciesCmd)
 	result := buildAddDependenciesCmd.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+
+	outputFormat, fmtErr := getBuildAddDependenciesOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printBuildAddDependenciesResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getBuildAddDependenciesOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getBuildAddDependenciesOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printBuildAddDependenciesResponse renders the build-add-dependencies result in the requested output format.
+func printBuildAddDependenciesResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printBuildAddDependenciesJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printBuildAddDependenciesTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt build-add-dependencies. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printBuildAddDependenciesJSON emits a JSON summary of the build-add-dependencies operation to stdout via log.Output.
+func printBuildAddDependenciesJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printBuildAddDependenciesTable renders a counts table for the build-add-dependencies operation.
+func printBuildAddDependenciesTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func buildCollectEnvCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -340,6 +340,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "nuget-deps-tree",
 			Aliases:     []string{"ndt"},
+			Flags:       flagkit.GetCommandFlags(flagkit.NugetDepsTree),
 			Description: nugettree.GetDescription(),
 			Action:      nugetDepsTreeCmd,
 			Category:    otherCategory,
@@ -787,7 +788,63 @@ func nugetDepsTreeCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	return dotnet.DependencyTreeCmd()
+	content, err := dotnet.DependencyTreeCmd()
+	if err != nil {
+		return err
+	}
+	outputFormat, err := getNugetDepsTreeOutputFormat(c)
+	if err != nil {
+		return err
+	}
+	return printNugetDepsTreeResponse(content, outputFormat, os.Stdout)
+}
+
+// getNugetDepsTreeOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.Json, preserving the
+// previous behaviour (JSON tree output).
+func getNugetDepsTreeOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.Json, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printNugetDepsTreeResponse renders the dependency tree in the requested output format.
+func printNugetDepsTreeResponse(data []byte, outputFormat coreformat.OutputFormat, w io.Writer) error {
+	switch outputFormat {
+	case coreformat.Json:
+		log.Output(clientutils.IndentJson(data))
+		return nil
+	case coreformat.Table:
+		return printNugetDepsTreeTable(data, w)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt nuget-deps-tree. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// nugetDepsTreeProject is used to unmarshal the projects array from the solution JSON.
+type nugetDepsTreeProject struct {
+	Name         string                 `json:"name"`
+	Dependencies map[string]interface{} `json:"dependencies"`
+}
+
+// nugetDepsTreeSolution is the top-level structure returned by solution.Marshal().
+type nugetDepsTreeSolution struct {
+	Projects []nugetDepsTreeProject `json:"projects"`
+}
+
+// printNugetDepsTreeTable renders the dependency tree as a table with PROJECT and DEPENDENCY_COUNT columns.
+func printNugetDepsTreeTable(data []byte, w io.Writer) error {
+	var sol nugetDepsTreeSolution
+	if err := json.Unmarshal(data, &sol); err != nil {
+		return errorutils.CheckErrorf("failed to parse nuget-deps-tree response: %s", err.Error())
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "PROJECT\tDEPENDENCY_COUNT")
+	for _, p := range sol.Projects {
+		_, _ = fmt.Fprintf(tw, "%s\t%d\n", p.Name, len(p.Dependencies))
+	}
+	return tw.Flush()
 }
 
 func pingCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -12,6 +12,7 @@ import (
 
 	ioutils "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/buildinfo"
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/formats"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/curl"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/dotnet"
@@ -1704,20 +1705,83 @@ func buildPublishCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	buildPublishCmd := buildinfo.NewBuildPublishCommand().SetServerDetails(rtDetails).SetBuildConfiguration(buildConfiguration).SetConfig(buildInfoConfiguration).SetDetailedSummary(common.GetDetailedSummary(c))
-	buildPublishCmd.SetCollectEnv(c.GetBoolFlagValue("collect-env"))
-	buildPublishCmd.SetCollectGitInfo(c.GetBoolFlagValue("collect-git-info"))
-	buildPublishCmd.SetDotGitPath(c.GetStringFlagValue("dot-git-path"))
-	buildPublishCmd.SetConfigFilePath(c.GetStringFlagValue("git-config-file-path"))
-	buildPublishCmd.SetDepExcludeScopes(c.GetStringsArrFlagValue("dep-exclude-scopes"))
 
-	err = commands.Exec(buildPublishCmd)
-	if buildPublishCmd.IsDetailedSummary() {
-		if publishedSummary := buildPublishCmd.GetSummary(); publishedSummary != nil {
+	outputFormat, fmtErr := getBuildPublishOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+
+	cmd := buildinfo.NewBuildPublishCommand().SetServerDetails(rtDetails).SetBuildConfiguration(buildConfiguration).SetConfig(buildInfoConfiguration).SetDetailedSummary(common.GetDetailedSummary(c))
+	cmd.SetCollectEnv(c.GetBoolFlagValue("collect-env"))
+	cmd.SetCollectGitInfo(c.GetBoolFlagValue("collect-git-info"))
+	cmd.SetDotGitPath(c.GetStringFlagValue("dot-git-path"))
+	cmd.SetConfigFilePath(c.GetStringFlagValue("git-config-file-path"))
+	cmd.SetDepExcludeScopes(c.GetStringsArrFlagValue("dep-exclude-scopes"))
+
+	// When --format is set, suppress the internal logJsonOutput call so that the
+	// CLI layer can render the URL itself.
+	if outputFormat != coreformat.None {
+		cmd.SetSuppressOutput(true)
+	}
+
+	err = commands.Exec(cmd)
+
+	// When --detailed-summary is set and --format is NOT set, keep the
+	// existing SHA-256 summary behaviour.
+	if cmd.IsDetailedSummary() && outputFormat == coreformat.None {
+		if publishedSummary := cmd.GetSummary(); publishedSummary != nil {
 			return summary.PrintBuildInfoSummaryReport(publishedSummary.IsSucceeded(), publishedSummary.GetSha256(), err)
 		}
 	}
-	return err
+
+	if outputFormat == coreformat.None {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	return printBuildPublishResponse(cmd.GetBuildInfoUiUrl(), outputFormat, os.Stdout)
+}
+
+// getBuildPublishOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (JSON printed internally by Run()).
+func getBuildPublishOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printBuildPublishResponse renders the build-publish result in the requested output format.
+func printBuildPublishResponse(buildInfoUiUrl string, outputFormat coreformat.OutputFormat, w io.Writer) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return printBuildPublishJSON(buildInfoUiUrl)
+	case coreformat.Table:
+		return printBuildPublishTable(buildInfoUiUrl, w)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt build-publish. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printBuildPublishJSON emits the build-publish result as indented JSON.
+func printBuildPublishJSON(buildInfoUiUrl string) error {
+	output := formats.BuildPublishOutput{BuildInfoUiUrl: buildInfoUiUrl}
+	data, err := output.JSON()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printBuildPublishTable renders the build-publish result as a two-column tabwriter table.
+func printBuildPublishTable(buildInfoUiUrl string, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "buildInfoUiUrl\t%s\n", buildInfoUiUrl)
+	return tw.Flush()
 }
 
 func buildAppendCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -2379,7 +2379,60 @@ func gitLfsCleanCmd(c *components.Context) error {
 	}
 	gitLfsCmd.SetConfiguration(configuration).SetServerDetails(rtDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 
-	return commands.Exec(gitLfsCmd)
+	err = commands.Exec(gitLfsCmd)
+	succeeded, total := gitLfsCmd.Result()
+	failed := total - succeeded
+
+	outputFormat, fmtErr := getGitLfsCleanOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return err
+	}
+	return printGitLfsCleanResponse(succeeded, failed, outputFormat, os.Stdout, err)
+}
+
+// getGitLfsCleanOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (no structured output).
+func getGitLfsCleanOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printGitLfsCleanResponse renders the git-lfs-clean result in the requested output format.
+func printGitLfsCleanResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return printGitLfsCleanJSON(succeeded, failed, originalErr)
+	case coreformat.Table:
+		return printGitLfsCleanTable(succeeded, failed, w)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt git-lfs-clean. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printGitLfsCleanJSON emits a JSON summary of the git-lfs-clean operation to stdout via log.Output.
+func printGitLfsCleanJSON(succeeded, failed int, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, false, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return originalErr
+}
+
+// printGitLfsCleanTable renders a counts table for the git-lfs-clean operation.
+func printGitLfsCleanTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func curlCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1816,7 +1816,65 @@ func deletePropsCmd(c *components.Context) error {
 	propsCmd.SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+
+	outputFormat, fmtErr := getDeletePropsOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printDeletePropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getDeletePropsOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getDeletePropsOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printDeletePropsResponse renders the delete-props result in the requested output format.
+func printDeletePropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printDeletePropsJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printDeletePropsTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt delete-props. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printDeletePropsJSON emits a JSON summary of the delete-props operation to stdout via log.Output.
+func printDeletePropsJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printDeletePropsTable renders a counts table for the delete-props operation.
+func printDeletePropsTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func buildPublishCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -516,8 +516,15 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return
 	}
+	outputFormat, err := getContainerPushOutputFormat(c)
+	if err != nil {
+		return
+	}
 	printDeploymentView, detailedSummary := log.IsStdErrTerminal(), c.GetBoolFlagValue("detailed-summary")
-	dockerPushCommand.SetThreads(threads).SetDetailedSummary(detailedSummary || printDeploymentView).SetCmdParams([]string{"push", imageTag}).SetSkipLogin(skipLogin).SetBuildConfiguration(buildConfiguration).SetRepo(targetRepo).SetServerDetails(artDetails).SetImageTag(imageTag).SetValidateSha(validateSha)
+	// When a structured format is requested we need the per-layer transfer details reader,
+	// so force detailed-summary mode regardless of the explicit flag.
+	needDetailedReader := outputFormat != coreformat.None
+	dockerPushCommand.SetThreads(threads).SetDetailedSummary(detailedSummary || printDeploymentView || needDetailedReader).SetCmdParams([]string{"push", imageTag}).SetSkipLogin(skipLogin).SetBuildConfiguration(buildConfiguration).SetRepo(targetRepo).SetServerDetails(artDetails).SetImageTag(imageTag).SetValidateSha(validateSha)
 	err = commandWrappers.ShowDockerDeprecationMessageIfNeeded(containerManagerType, dockerPushCommand.IsGetRepoSupported)
 	if err != nil {
 		return
@@ -527,8 +534,70 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 
 	// Cleanup.
 	defer common.CleanupResult(result, &err)
-	err = common.PrintCommandSummary(dockerPushCommand.Result(), detailedSummary, printDeploymentView, false, err)
+	if outputFormat == coreformat.None {
+		err = common.PrintCommandSummary(dockerPushCommand.Result(), detailedSummary, printDeploymentView, false, err)
+		return
+	}
+	err = printContainerPushResponse(result, outputFormat, os.Stdout, err)
 	return
+}
+
+// getContainerPushOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (deployment view / JSON summary output via PrintCommandSummary).
+func getContainerPushOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printContainerPushResponse renders the container push result in the requested output format.
+func printContainerPushResponse(result *commandUtils.Result, outputFormat coreformat.OutputFormat, w io.Writer, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return common.PrintCommandSummary(result, true, false, false, originalErr)
+	case coreformat.Table:
+		err := printContainerPushTable(result, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, result.SuccessCount(), result.FailCount(), false)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt podman-push. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// containerPushTableRow is a table-printable representation of a pushed layer.
+type containerPushTableRow struct {
+	Target string `col-name:"TARGET"`
+	Sha256 string `col-name:"SHA256"`
+}
+
+// printContainerPushTable renders pushed layers as a human-readable table.
+func printContainerPushTable(result *commandUtils.Result, w io.Writer) error {
+	reader := result.Reader()
+	if reader == nil {
+		// No per-layer details available (e.g. no build-info collection and no detailed-summary).
+		// Fall back to a minimal counts table.
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
+		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
+		return tw.Flush()
+	}
+	var rows []containerPushTableRow
+	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
+		rows = append(rows, containerPushTableRow{
+			Target: item.RtUrl + item.TargetPath,
+			Sha256: item.Sha256,
+		})
+	}
+	if err := reader.GetError(); err != nil {
+		return err
+	}
+	reader.Reset()
+	return coreutils.PrintTable(rows, "Push Results", "No layers were pushed.", false)
 }
 
 func containerPullCmd(c *components.Context, containerManagerType containerutils.ContainerManagerType) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -2035,18 +2035,47 @@ func buildDiscardCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() > 1 {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
+
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	configuration := createBuildDiscardConfiguration(c)
 	if configuration.BuildName == "" {
 		return common.PrintHelpAndReturnError("Build name is expected as a command argument or environment variable.", c)
 	}
-	buildDiscardCmd := buildinfo.NewBuildDiscardCommand()
+	buildDiscardCommand := buildinfo.NewBuildDiscardCommand()
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
 	}
-	buildDiscardCmd.SetServerDetails(rtDetails).SetDiscardBuildsParams(configuration)
+	buildDiscardCommand.SetServerDetails(rtDetails).SetDiscardBuildsParams(configuration)
 
-	return commands.Exec(buildDiscardCmd)
+	if err = commands.Exec(buildDiscardCommand); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 204 No Content.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 204, "message": "No Content"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printBuildDiscardJSON()
+	}
+	return nil
+}
+
+// printBuildDiscardJSON emits a synthetic JSON success response for build-discard.
+// The Artifactory discard API returns 204 No Content with no body; the client layer
+// discards the response, so error == nil guarantees HTTP 204.
+func printBuildDiscardJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 204,
+		"message":     "No Content",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func gitLfsCleanCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -381,7 +381,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "repo-update",
 			Aliases:     []string{"ru"},
-			Flags:       flagkit.GetCommandFlags(flagkit.TemplateConsumer),
+			Flags:       flagkit.GetCommandFlags(flagkit.RepoUpdate),
 			Description: repoupdate.GetDescription(),
 			Arguments:   repoupdate.GetArguments(),
 			Action:      repoUpdateCmd,
@@ -2651,15 +2651,43 @@ func repoUpdateCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
 	}
 
 	// Run command.
-	repoUpdateCmd := repository.NewRepoUpdateCommand()
-	repoUpdateCmd.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
-	return commands.Exec(repoUpdateCmd)
+	repoUpdateCommand := repository.NewRepoUpdateCommand()
+	repoUpdateCommand.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
+	if err = commands.Exec(repoUpdateCommand); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 200.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 200, "message": "OK"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printRepoUpdateJSON()
+	}
+	return nil
+}
+
+// printRepoUpdateJSON emits a synthetic JSON success response for repo-update.
+// The Artifactory repo update API returns a body, but the client layer discards it;
+// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
+func printRepoUpdateJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 200,
+		"message":     "OK",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func repoDeleteCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1170,7 +1170,6 @@ func printDownloadResponse(result *commandUtils.Result, outputFormat coreformat.
 type downloadTableRow struct {
 	Source string `col-name:"SOURCE"`
 	Target string `col-name:"TARGET"`
-	Sha256 string `col-name:"SHA256"`
 }
 
 // printDownloadTable renders downloaded files as a human-readable table.
@@ -1184,7 +1183,6 @@ func printDownloadTable(result *commandUtils.Result, w io.Writer) error {
 		rows = append(rows, downloadTableRow{
 			Source: item.RtUrl + item.SourcePath,
 			Target: item.TargetPath,
-			Sha256: item.Sha256,
 		})
 	}
 	if err := reader.GetError(); err != nil {
@@ -1219,7 +1217,6 @@ func printDirectDownloadResponse(result *commandUtils.Result, outputFormat coref
 type directDownloadTableRow struct {
 	Source string `col-name:"SOURCE"`
 	Target string `col-name:"TARGET"`
-	Sha256 string `col-name:"SHA256"`
 }
 
 // printDirectDownloadTable renders directly downloaded files as a human-readable table.
@@ -1233,7 +1230,6 @@ func printDirectDownloadTable(result *commandUtils.Result, w io.Writer) error {
 		rows = append(rows, directDownloadTableRow{
 			Source: item.RtUrl + item.SourcePath,
 			Target: item.TargetPath,
-			Sha256: item.Sha256,
 		})
 	}
 	if err := reader.GetError(); err != nil {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1738,7 +1738,65 @@ func setPropsCmd(c *components.Context) error {
 	propsCmd.SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+
+	outputFormat, fmtErr := getSetPropsOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printSetPropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getSetPropsOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getSetPropsOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printSetPropsResponse renders the set-props result in the requested output format.
+func printSetPropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printSetPropsJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printSetPropsTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt set-props. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printSetPropsJSON emits a JSON summary of the set-props operation to stdout via log.Output.
+func printSetPropsJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printSetPropsTable renders a counts table for the set-props operation.
+func printSetPropsTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 func deletePropsCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -408,7 +408,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "replication-create",
 			Aliases:     []string{"rplc"},
-			Flags:       flagkit.GetCommandFlags(flagkit.TemplateConsumer),
+			Flags:       flagkit.GetCommandFlags(flagkit.ReplicationCreate),
 			Description: replicationcreate.GetDescription(),
 			Arguments:   replicationcreate.GetArguments(),
 			Action:      replicationCreateCmd,
@@ -2662,13 +2662,42 @@ func replicationCreateCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() != 1 {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
+
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
 	}
-	replicationCreateCmd := replication.NewReplicationCreateCommand()
-	replicationCreateCmd.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
-	return commands.Exec(replicationCreateCmd)
+	replicationCreateCommand := replication.NewReplicationCreateCommand()
+	replicationCreateCommand.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
+	if err = commands.Exec(replicationCreateCommand); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 200.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 200, "message": "OK"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printReplicationCreateJSON()
+	}
+	return nil
+}
+
+// printReplicationCreateJSON emits a synthetic JSON success response for replication-create.
+// The Artifactory replication create API returns a body, but the client layer discards it;
+// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
+func printReplicationCreateJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 200,
+		"message":     "OK",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func replicationDeleteCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -60,6 +60,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/commandWrappers"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	coregeneric "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/generic"
+	commandUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
@@ -998,13 +999,20 @@ func uploadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return
 	}
+	outputFormat, err := getUploadOutputFormat(c)
+	if err != nil {
+		return
+	}
 	uploadCmd := generic.NewUploadCommand()
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return
 	}
 	printDeploymentView, detailedSummary := log.IsStdErrTerminal(), common.GetDetailedSummary(c)
-	uploadCmd.SetUploadConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(uploadSpec).SetServerDetails(rtDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(detailedSummary || printDeploymentView).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
+	// When a structured format is requested we need the per-file transfer details reader,
+	// so force detailed-summary mode regardless of the explicit flag.
+	needDetailedReader := outputFormat != coreformat.None
+	uploadCmd.SetUploadConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(uploadSpec).SetServerDetails(rtDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(detailedSummary || printDeploymentView || needDetailedReader).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 
 	if uploadCmd.ShouldPrompt() && !coreutils.AskYesNo("Sync-deletes may delete some artifacts in Artifactory. Are you sure you want to continue?\n"+
 		"You can avoid this confirmation message by adding --quiet to the command.", false) {
@@ -1014,8 +1022,73 @@ func uploadCmd(c *components.Context) (err error) {
 	err = progressbar.ExecWithProgress(uploadCmd)
 	result := uploadCmd.Result()
 	defer common.CleanupResult(result, &err)
-	err = common.PrintCommandSummary(uploadCmd.Result(), detailedSummary, printDeploymentView, common.IsFailNoOp(c), err)
+	if outputFormat == coreformat.None {
+		err = common.PrintCommandSummary(uploadCmd.Result(), detailedSummary, printDeploymentView, common.IsFailNoOp(c), err)
+		return
+	}
+	err = printUploadResponse(result, outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 	return
+}
+
+// getUploadOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (JSON summary output via PrintCommandSummary).
+func getUploadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printUploadResponse renders the upload result in the requested output format.
+// It preserves the fail-no-op and error-accounting semantics of PrintCommandSummary.
+func printUploadResponse(result *commandUtils.Result, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		return common.PrintCommandSummary(result, true, false, failNoOp, originalErr)
+	case coreformat.Table:
+		err := printUploadTable(result, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, result.SuccessCount(), result.FailCount(), failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt upload. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// uploadTableRow is a table-printable representation of an uploaded file.
+type uploadTableRow struct {
+	Source string `col-name:"SOURCE"`
+	Target string `col-name:"TARGET"`
+	Sha256 string `col-name:"SHA256"`
+}
+
+// printUploadTable renders uploaded files as a human-readable table.
+func printUploadTable(result *commandUtils.Result, w io.Writer) error {
+	reader := result.Reader()
+	if reader == nil {
+		// No per-file details available (e.g. dry-run without build-info collection).
+		// Fall back to a minimal counts table.
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
+		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
+		return tw.Flush()
+	}
+	var rows []uploadTableRow
+	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
+		rows = append(rows, uploadTableRow{
+			Source: item.SourcePath,
+			Target: item.RtUrl + item.TargetPath,
+			Sha256: item.Sha256,
+		})
+	}
+	if err := reader.GetError(); err != nil {
+		return err
+	}
+	reader.Reset()
+	return coreutils.PrintTable(rows, "Upload Results", "No files were uploaded.", false)
 }
 
 func prepareCopyMoveCommand(c *components.Context) (*spec.SpecFiles, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -95,94 +95,105 @@ const (
 func GetCommands() []components.Command {
 	commands := []components.Command{
 		{
-			Name:        "upload",
-			Flags:       flagkit.GetCommandFlags(flagkit.Upload),
-			Aliases:     []string{"u"},
-			Description: upload.GetDescription(),
-			Arguments:   upload.GetArguments(),
-			Action:      uploadCmd,
-			Category:    filesCategory,
+			Name:             "upload",
+			Flags:            flagkit.GetCommandFlags(flagkit.Upload),
+			Aliases:          []string{"u"},
+			Description:      upload.GetDescription(),
+			Arguments:        upload.GetArguments(),
+			Action:           uploadCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "download",
-			Flags:       flagkit.GetCommandFlags(flagkit.Download),
-			Aliases:     []string{"dl"},
-			Description: download.GetDescription(),
-			Arguments:   download.GetArguments(),
-			Action:      downloadCmd,
-			Category:    filesCategory,
+			Name:             "download",
+			Flags:            flagkit.GetCommandFlags(flagkit.Download),
+			Aliases:          []string{"dl"},
+			Description:      download.GetDescription(),
+			Arguments:        download.GetArguments(),
+			Action:           downloadCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "direct-download",
-			Flags:       flagkit.GetCommandFlags(flagkit.DirectDownload),
-			Aliases:     []string{"ddl"},
-			Description: directdownload.GetDescription(),
-			Arguments:   directdownload.GetArguments(),
-			Action:      directDownloadCmd,
-			Category:    filesCategory,
+			Name:             "direct-download",
+			Flags:            flagkit.GetCommandFlags(flagkit.DirectDownload),
+			Aliases:          []string{"ddl"},
+			Description:      directdownload.GetDescription(),
+			Arguments:        directdownload.GetArguments(),
+			Action:           directDownloadCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "move",
-			Flags:       flagkit.GetCommandFlags(flagkit.Move),
-			Aliases:     []string{"mv"},
-			Description: move.GetDescription(),
-			Arguments:   move.GetArguments(),
-			Action:      moveCmd,
-			Category:    filesCategory,
+			Name:             "move",
+			Flags:            flagkit.GetCommandFlags(flagkit.Move),
+			Aliases:          []string{"mv"},
+			Description:      move.GetDescription(),
+			Arguments:        move.GetArguments(),
+			Action:           moveCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "copy",
-			Flags:       flagkit.GetCommandFlags(flagkit.Copy),
-			Aliases:     []string{"cp"},
-			Description: copydocs.GetDescription(),
-			Arguments:   copydocs.GetArguments(),
-			Action:      copyCmd,
-			Category:    filesCategory,
+			Name:             "copy",
+			Flags:            flagkit.GetCommandFlags(flagkit.Copy),
+			Aliases:          []string{"cp"},
+			Description:      copydocs.GetDescription(),
+			Arguments:        copydocs.GetArguments(),
+			Action:           copyCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "delete",
-			Flags:       flagkit.GetCommandFlags(flagkit.Delete),
-			Aliases:     []string{"del"},
-			Description: delete.GetDescription(),
-			Arguments:   delete.GetArguments(),
-			Action:      deleteCmd,
-			Category:    filesCategory,
+			Name:             "delete",
+			Flags:            flagkit.GetCommandFlags(flagkit.Delete),
+			Aliases:          []string{"del"},
+			Description:      delete.GetDescription(),
+			Arguments:        delete.GetArguments(),
+			Action:           deleteCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "search",
-			Flags:       flagkit.GetCommandFlags(flagkit.Search),
-			Aliases:     []string{"s"},
-			Description: search.GetDescription(),
-			Arguments:   search.GetArguments(),
-			Action:      searchCmd,
-			Category:    filesCategory,
+			Name:             "search",
+			Flags:            flagkit.GetCommandFlags(flagkit.Search),
+			Aliases:          []string{"s"},
+			Description:      search.GetDescription(),
+			Arguments:        search.GetArguments(),
+			Action:           searchCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
+			DefaultFormat:    coreformat.Json,
 		},
 		{
-			Name:        "set-props",
-			Flags:       flagkit.GetCommandFlags(flagkit.Properties),
-			Aliases:     []string{"sp"},
-			Description: setprops.GetDescription(),
-			Arguments:   setprops.GetArguments(),
-			Action:      setPropsCmd,
-			Category:    filesCategory,
+			Name:             "set-props",
+			Flags:            flagkit.GetCommandFlags(flagkit.Properties),
+			Aliases:          []string{"sp"},
+			Description:      setprops.GetDescription(),
+			Arguments:        setprops.GetArguments(),
+			Action:           setPropsCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "delete-props",
-			Flags:       flagkit.GetCommandFlags(flagkit.Properties),
-			Aliases:     []string{"delp"},
-			Description: deleteprops.GetDescription(),
-			Arguments:   deleteprops.GetArguments(),
-			Action:      deletePropsCmd,
-			Category:    filesCategory,
+			Name:             "delete-props",
+			Flags:            flagkit.GetCommandFlags(flagkit.Properties),
+			Aliases:          []string{"delp"},
+			Description:      deleteprops.GetDescription(),
+			Arguments:        deleteprops.GetArguments(),
+			Action:           deletePropsCmd,
+			Category:         filesCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "build-publish",
-			Flags:       flagkit.GetCommandFlags(flagkit.BuildPublish),
-			Aliases:     []string{"bp"},
-			Description: buildpublish.GetDescription(),
-			Arguments:   buildpublish.GetArguments(),
-			Action:      buildPublishCmd,
-			Category:    buildCategory,
+			Name:             "build-publish",
+			Flags:            flagkit.GetCommandFlags(flagkit.BuildPublish),
+			Aliases:          []string{"bp"},
+			Description:      buildpublish.GetDescription(),
+			Arguments:        buildpublish.GetArguments(),
+			Action:           buildPublishCmd,
+			Category:         buildCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
 			Name:        "build-collect-env",
@@ -203,13 +214,14 @@ func GetCommands() []components.Command {
 			Category:    buildCategory,
 		},
 		{
-			Name:        "build-add-dependencies",
-			Flags:       flagkit.GetCommandFlags(flagkit.BuildAddDependencies),
-			Aliases:     []string{"bad"},
-			Description: buildadddependencies.GetDescription(),
-			Arguments:   buildadddependencies.GetArguments(),
-			Action:      buildAddDependenciesCmd,
-			Category:    buildCategory,
+			Name:             "build-add-dependencies",
+			Flags:            flagkit.GetCommandFlags(flagkit.BuildAddDependencies),
+			Aliases:          []string{"bad"},
+			Description:      buildadddependencies.GetDescription(),
+			Arguments:        buildadddependencies.GetArguments(),
+			Action:           buildAddDependenciesCmd,
+			Category:         buildCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
 			Name:        "build-add-git",
@@ -240,80 +252,88 @@ func GetCommands() []components.Command {
 			Category:    buildCategory,
 		},
 		{
-			Name:        "build-promote",
-			Flags:       flagkit.GetCommandFlags(flagkit.BuildPromote),
-			Aliases:     []string{"bpr"},
-			Description: buildpromote.GetDescription(),
-			Arguments:   buildpromote.GetArguments(),
-			Action:      buildPromoteCmd,
-			Category:    buildCategory,
+			Name:             "build-promote",
+			Flags:            flagkit.GetCommandFlags(flagkit.BuildPromote),
+			Aliases:          []string{"bpr"},
+			Description:      buildpromote.GetDescription(),
+			Arguments:        buildpromote.GetArguments(),
+			Action:           buildPromoteCmd,
+			Category:         buildCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
-			Name:        "build-discard",
-			Flags:       flagkit.GetCommandFlags(flagkit.BuildDiscard),
-			Aliases:     []string{"bdi"},
-			Description: builddiscard.GetDescription(),
-			Arguments:   builddiscard.GetArguments(),
-			Action:      buildDiscardCmd,
-			Category:    buildCategory,
+			Name:             "build-discard",
+			Flags:            flagkit.GetCommandFlags(flagkit.BuildDiscard),
+			Aliases:          []string{"bdi"},
+			Description:      builddiscard.GetDescription(),
+			Arguments:        builddiscard.GetArguments(),
+			Action:           buildDiscardCmd,
+			Category:         buildCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
-			Name:        "git-lfs-clean",
-			Flags:       flagkit.GetCommandFlags(flagkit.GitLfsClean),
-			Aliases:     []string{"glc"},
-			Description: gitlfsclean.GetDescription(),
-			Arguments:   gitlfsclean.GetArguments(),
-			Action:      gitLfsCleanCmd,
-			Category:    otherCategory,
+			Name:             "git-lfs-clean",
+			Flags:            flagkit.GetCommandFlags(flagkit.GitLfsClean),
+			Aliases:          []string{"glc"},
+			Description:      gitlfsclean.GetDescription(),
+			Arguments:        gitlfsclean.GetArguments(),
+			Action:           gitLfsCleanCmd,
+			Category:         otherCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:        "docker-promote",
-			Flags:       flagkit.GetCommandFlags(flagkit.DockerPromote),
-			Aliases:     []string{"dpr"},
-			Description: dockerpromote.GetDescription(),
-			Arguments:   dockerpromote.GetArguments(),
-			Action:      dockerPromoteCmd,
-			Category:    buildCategory,
+			Name:             "docker-promote",
+			Flags:            flagkit.GetCommandFlags(flagkit.DockerPromote),
+			Aliases:          []string{"dpr"},
+			Description:      dockerpromote.GetDescription(),
+			Arguments:        dockerpromote.GetArguments(),
+			Action:           dockerPromoteCmd,
+			Category:         buildCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
-			Name:        "docker-push",
-			Hidden:      true,
-			Flags:       flagkit.GetCommandFlags(flagkit.ContainerPush),
-			Aliases:     []string{"dp"},
-			Description: dockerpush.GetDescription(),
-			Arguments:   dockerpush.GetArguments(),
+			Name:             "docker-push",
+			Hidden:           true,
+			Flags:            flagkit.GetCommandFlags(flagkit.ContainerPush),
+			Aliases:          []string{"dp"},
+			Description:      dockerpush.GetDescription(),
+			Arguments:        dockerpush.GetArguments(),
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 			Action: func(c *components.Context) error {
 				return containerPushCmd(c, containerutils.DockerClient)
 			},
 		},
 		{
-			Name:        "docker-pull",
-			Hidden:      true,
-			Flags:       flagkit.GetCommandFlags(flagkit.ContainerPull),
-			Aliases:     []string{"dpl"},
-			Description: dockerpull.GetDescription(),
-			Arguments:   dockerpull.GetArguments(),
+			Name:             "docker-pull",
+			Hidden:           true,
+			Flags:            flagkit.GetCommandFlags(flagkit.ContainerPull),
+			Aliases:          []string{"dpl"},
+			Description:      dockerpull.GetDescription(),
+			Arguments:        dockerpull.GetArguments(),
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 			Action: func(c *components.Context) error {
 				return containerPullCmd(c, containerutils.DockerClient)
 			},
 		},
 		{
-			Name:        "podman-push",
-			Flags:       flagkit.GetCommandFlags(flagkit.ContainerPush),
-			Aliases:     []string{"pp"},
-			Description: podmanpush.GetDescription(),
-			Arguments:   podmanpush.GetArguments(),
+			Name:             "podman-push",
+			Flags:            flagkit.GetCommandFlags(flagkit.ContainerPush),
+			Aliases:          []string{"pp"},
+			Description:      podmanpush.GetDescription(),
+			Arguments:        podmanpush.GetArguments(),
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 			Action: func(c *components.Context) error {
 				return containerPushCmd(c, containerutils.Podman)
 			},
 			Category: otherCategory,
 		},
 		{
-			Name:        "podman-pull",
-			Flags:       flagkit.GetCommandFlags(flagkit.ContainerPull),
-			Aliases:     []string{"ppl"},
-			Description: podmanpull.GetDescription(),
-			Arguments:   podmanpull.GetArguments(),
+			Name:             "podman-pull",
+			Flags:            flagkit.GetCommandFlags(flagkit.ContainerPull),
+			Aliases:          []string{"ppl"},
+			Description:      podmanpull.GetDescription(),
+			Arguments:        podmanpull.GetArguments(),
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 			Action: func(c *components.Context) error {
 				return containerPullCmd(c, containerutils.Podman)
 			},
@@ -338,19 +358,22 @@ func GetCommands() []components.Command {
 			Category:        otherCategory,
 		},
 		{
-			Name:        "nuget-deps-tree",
-			Aliases:     []string{"ndt"},
-			Flags:       flagkit.GetCommandFlags(flagkit.NugetDepsTree),
-			Description: nugettree.GetDescription(),
-			Action:      nugetDepsTreeCmd,
-			Category:    otherCategory,
+			Name:             "nuget-deps-tree",
+			Aliases:          []string{"ndt"},
+			Flags:            flagkit.GetCommandFlags(flagkit.NugetDepsTree),
+			Description:      nugettree.GetDescription(),
+			Action:           nugetDepsTreeCmd,
+			Category:         otherCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
+			DefaultFormat:    coreformat.Json,
 		},
 		{
-			Name:        "ping",
-			Flags:       flagkit.GetCommandFlags(flagkit.Ping),
-			Aliases:     []string{"p"},
-			Description: ping.GetDescription(),
-			Action:      pingCmd,
+			Name:             "ping",
+			Flags:            flagkit.GetCommandFlags(flagkit.Ping),
+			Aliases:          []string{"p"},
+			Description:      ping.GetDescription(),
+			Action:           pingCmd,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
 			Name:            "curl",
@@ -370,22 +393,24 @@ func GetCommands() []components.Command {
 			Category:    repoCategory,
 		},
 		{
-			Name:        "repo-create",
-			Aliases:     []string{"rc"},
-			Flags:       flagkit.GetCommandFlags(flagkit.RepoCreate),
-			Description: repocreate.GetDescription(),
-			Arguments:   repocreate.GetArguments(),
-			Action:      repoCreateCmd,
-			Category:    repoCategory,
+			Name:             "repo-create",
+			Aliases:          []string{"rc"},
+			Flags:            flagkit.GetCommandFlags(flagkit.RepoCreate),
+			Description:      repocreate.GetDescription(),
+			Arguments:        repocreate.GetArguments(),
+			Action:           repoCreateCmd,
+			Category:         repoCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
-			Name:        "repo-update",
-			Aliases:     []string{"ru"},
-			Flags:       flagkit.GetCommandFlags(flagkit.RepoUpdate),
-			Description: repoupdate.GetDescription(),
-			Arguments:   repoupdate.GetArguments(),
-			Action:      repoUpdateCmd,
-			Category:    repoCategory,
+			Name:             "repo-update",
+			Aliases:          []string{"ru"},
+			Flags:            flagkit.GetCommandFlags(flagkit.RepoUpdate),
+			Description:      repoupdate.GetDescription(),
+			Arguments:        repoupdate.GetArguments(),
+			Action:           repoUpdateCmd,
+			Category:         repoCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
 			Name:        "repo-delete",
@@ -406,13 +431,14 @@ func GetCommands() []components.Command {
 			Category:    replicCategory,
 		},
 		{
-			Name:        "replication-create",
-			Aliases:     []string{"rplc"},
-			Flags:       flagkit.GetCommandFlags(flagkit.ReplicationCreate),
-			Description: replicationcreate.GetDescription(),
-			Arguments:   replicationcreate.GetArguments(),
-			Action:      replicationCreateCmd,
-			Category:    replicCategory,
+			Name:             "replication-create",
+			Aliases:          []string{"rplc"},
+			Flags:            flagkit.GetCommandFlags(flagkit.ReplicationCreate),
+			Description:      replicationcreate.GetDescription(),
+			Arguments:        replicationcreate.GetArguments(),
+			Action:           replicationCreateCmd,
+			Category:         replicCategory,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
 			Name:        "replication-delete",
@@ -476,26 +502,14 @@ func getRetryWaitTimeVerificationError() error {
 	return errorutils.CheckError(errors.New("The '--retry-wait-time' option should have a numeric value with 's'/'ms' suffix. " + common.GetDocumentationMessage()))
 }
 
-// getOutputFormatWithDefault reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns defaultFormat, preserving the caller's
-// previous behaviour.  Callers that previously emitted JSON by default pass coreformat.Json;
-// callers that previously produced non-structured output pass coreformat.None.
-func getOutputFormatWithDefault(c *components.Context, defaultFormat coreformat.OutputFormat) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return defaultFormat, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
-}
-
 func dockerPromoteCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() != 3 {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	artDetails, err := common.CreateArtifactoryDetailsByFlags(c)
@@ -517,7 +531,7 @@ func dockerPromoteCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 200.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(200, "OK")
 	}
 	return nil
@@ -572,7 +586,7 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return
 	}
@@ -655,7 +669,7 @@ func containerPullCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return err
 	}
@@ -792,7 +806,7 @@ func nugetDepsTreeCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.Json)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return err
 	}
@@ -853,7 +867,7 @@ func pingCmd(c *components.Context) error {
 	if err != nil {
 		return errors.New(err.Error() + "\n" + resString)
 	}
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1040,7 +1054,7 @@ func directDownloadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return err
 	}
@@ -1100,7 +1114,7 @@ func downloadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return err
 	}
@@ -1315,7 +1329,7 @@ func uploadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return
 	}
@@ -1442,7 +1456,7 @@ func moveCmd(c *components.Context) error {
 	err = commands.Exec(mvCmd)
 	result := mvCmd.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1499,7 +1513,7 @@ func copyCmd(c *components.Context) error {
 	err = commands.Exec(copyCommand)
 	result := copyCommand.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1588,7 +1602,7 @@ func deleteCmd(c *components.Context) error {
 	err = commands.Exec(deleteCommand)
 	result := deleteCommand.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1680,7 +1694,7 @@ func searchCmd(c *components.Context) (err error) {
 		log.Output(length)
 		return nil
 	}
-	outputFormat, err := getOutputFormatWithDefault(c, coreformat.Json)
+	outputFormat, err := c.GetOutputFormat()
 	if err != nil {
 		return err
 	}
@@ -1793,7 +1807,7 @@ func setPropsCmd(c *components.Context) error {
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1841,7 +1855,7 @@ func deletePropsCmd(c *components.Context) error {
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1885,7 +1899,7 @@ func buildPublishCmd(c *components.Context) error {
 		return err
 	}
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2035,7 +2049,7 @@ func buildAddDependenciesCmd(c *components.Context) error {
 	err = commands.Exec(buildAddDependenciesCmd)
 	result := buildAddDependenciesCmd.Result()
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2143,10 +2157,9 @@ func buildPromoteCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	configuration := createBuildPromoteConfiguration(c)
@@ -2166,7 +2179,7 @@ func buildPromoteCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 200.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(200, "OK")
 	}
 	return nil
@@ -2177,10 +2190,9 @@ func buildDiscardCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	configuration := createBuildDiscardConfiguration(c)
@@ -2201,7 +2213,7 @@ func buildDiscardCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 204 No Content.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 204, "message": "No Content"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(204, "No Content")
 	}
 	return nil
@@ -2231,7 +2243,7 @@ func gitLfsCleanCmd(c *components.Context) error {
 	succeeded, total := gitLfsCmd.Result()
 	failed := total - succeeded
 
-	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
+	outputFormat, fmtErr := c.GetOutputFormat()
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2314,10 +2326,9 @@ func repoCreateCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
@@ -2335,7 +2346,7 @@ func repoCreateCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 200.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(200, "OK")
 	}
 	return nil
@@ -2346,10 +2357,9 @@ func repoUpdateCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
@@ -2367,7 +2377,7 @@ func repoUpdateCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 200.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(200, "OK")
 	}
 	return nil
@@ -2402,10 +2412,9 @@ func replicationCreateCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
-	if c.IsFlagSet(flagkit.Format) {
-		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
-			return fmtErr
-		}
+	outputFormat, fmtErr := c.GetOutputFormat()
+	if fmtErr != nil {
+		return fmtErr
 	}
 
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
@@ -2421,7 +2430,7 @@ func replicationCreateCmd(c *components.Context) error {
 	// error == nil guarantees the server responded with 200.
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
-	if c.IsFlagSet(flagkit.Format) {
+	if outputFormat != coreformat.None {
 		printStatusJSON(200, "OK")
 	}
 	return nil

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -518,22 +518,37 @@ func dockerPromoteCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printDockerPromoteJSON()
+		printStatusJSON(200, "OK")
 	}
 	return nil
 }
 
-// printDockerPromoteJSON emits a synthetic JSON success response for docker-promote.
-// The Artifactory docker promote API returns a body, but the client layer discards it;
-// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
-func printDockerPromoteJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 200,
-		"message":     "OK",
-	}
-	data, _ := json.Marshal(synthetic)
+// printStatusJSON emits a synthetic JSON response with the given HTTP status code and message.
+func printStatusJSON(statusCode int, message string) {
+	data, _ := json.Marshal(map[string]interface{}{"status_code": statusCode, "message": message})
 	log.Output(clientutils.IndentJson(data))
 }
+
+// printCountsTable writes a two-row FIELD/VALUE tabwriter table with success and failure counts.
+func printCountsTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
+}
+
+// printSummaryJSON marshals a summary report to indented JSON and writes it to the log output.
+func printSummaryJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
 
 func containerPushCmd(c *components.Context, containerManagerType containerutils.ContainerManagerType) (err error) {
 	if c.GetNumberOfArgs() != 2 {
@@ -609,13 +624,7 @@ type containerPushTableRow struct {
 func printContainerPushTable(result *commandUtils.Result, w io.Writer) error {
 	reader := result.Reader()
 	if reader == nil {
-		// No per-layer details available (e.g. no build-info collection and no detailed-summary).
-		// Fall back to a minimal counts table.
-		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
-		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
-		return tw.Flush()
+		return printCountsTable(result.SuccessCount(), result.FailCount(), w)
 	}
 	var rows []containerPushTableRow
 	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
@@ -1154,13 +1163,7 @@ type downloadTableRow struct {
 func printDownloadTable(result *commandUtils.Result, w io.Writer) error {
 	reader := result.Reader()
 	if reader == nil {
-		// No per-file details available (e.g. dry-run without build-info collection).
-		// Fall back to a minimal counts table.
-		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
-		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
-		return tw.Flush()
+		return printCountsTable(result.SuccessCount(), result.FailCount(), w)
 	}
 	var rows []downloadTableRow
 	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
@@ -1209,13 +1212,7 @@ type directDownloadTableRow struct {
 func printDirectDownloadTable(result *commandUtils.Result, w io.Writer) error {
 	reader := result.Reader()
 	if reader == nil {
-		// No per-file details available (e.g. dry-run without build-info collection).
-		// Fall back to a minimal counts table.
-		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
-		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
-		return tw.Flush()
+		return printCountsTable(result.SuccessCount(), result.FailCount(), w)
 	}
 	var rows []directDownloadTableRow
 	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
@@ -1377,13 +1374,7 @@ type uploadTableRow struct {
 func printUploadTable(result *commandUtils.Result, w io.Writer) error {
 	reader := result.Reader()
 	if reader == nil {
-		// No per-file details available (e.g. dry-run without build-info collection).
-		// Fall back to a minimal counts table.
-		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
-		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
-		return tw.Flush()
+		return printCountsTable(result.SuccessCount(), result.FailCount(), w)
 	}
 	var rows []uploadTableRow
 	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
@@ -1465,13 +1456,13 @@ func moveCmd(c *components.Context) error {
 func printMoveResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printMoveJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printMoveTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -1479,26 +1470,6 @@ func printMoveResponse(succeeded, failed int, outputFormat coreformat.OutputForm
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt move. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printMoveJSON emits a JSON summary of the move operation to stdout via log.Output.
-func printMoveJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printMoveTable renders a counts table for the move operation.
-func printMoveTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func copyCmd(c *components.Context) error {
@@ -1542,13 +1513,13 @@ func copyCmd(c *components.Context) error {
 func printCopyResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printCopyJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printCopyTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -1556,26 +1527,6 @@ func printCopyResponse(succeeded, failed int, outputFormat coreformat.OutputForm
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt copy. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printCopyJSON emits a JSON summary of the copy operation to stdout via log.Output.
-func printCopyJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printCopyTable renders a counts table for the copy operation.
-func printCopyTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 // Prints a 'brief' (not detailed) summary and returns the appropriate exit error.
@@ -1651,13 +1602,13 @@ func deleteCmd(c *components.Context) error {
 func printDeleteResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printDeleteJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printDeleteTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -1665,26 +1616,6 @@ func printDeleteResponse(succeeded, failed int, outputFormat coreformat.OutputFo
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt delete. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printDeleteJSON emits a JSON summary of the delete operation to stdout via log.Output.
-func printDeleteJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printDeleteTable renders a counts table for the delete operation.
-func printDeleteTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func prepareSearchCommand(c *components.Context) (*spec.SpecFiles, error) {
@@ -1876,13 +1807,13 @@ func setPropsCmd(c *components.Context) error {
 func printSetPropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printSetPropsJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printSetPropsTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -1890,26 +1821,6 @@ func printSetPropsResponse(succeeded, failed int, outputFormat coreformat.Output
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt set-props. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printSetPropsJSON emits a JSON summary of the set-props operation to stdout via log.Output.
-func printSetPropsJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printSetPropsTable renders a counts table for the set-props operation.
-func printSetPropsTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func deletePropsCmd(c *components.Context) error {
@@ -1944,13 +1855,13 @@ func deletePropsCmd(c *components.Context) error {
 func printDeletePropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printDeletePropsJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printDeletePropsTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -1958,26 +1869,6 @@ func printDeletePropsResponse(succeeded, failed int, outputFormat coreformat.Out
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt delete-props. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printDeletePropsJSON emits a JSON summary of the delete-props operation to stdout via log.Output.
-func printDeletePropsJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printDeletePropsTable renders a counts table for the delete-props operation.
-func printDeletePropsTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func buildPublishCmd(c *components.Context) error {
@@ -2133,13 +2024,13 @@ func buildAddDependenciesCmd(c *components.Context) error {
 func printBuildAddDependenciesResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		err := printBuildAddDependenciesJSON(succeeded, failed, failNoOp, originalErr)
+		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
 		if err != nil {
 			return err
 		}
 		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
 	case coreformat.Table:
-		err := printBuildAddDependenciesTable(succeeded, failed, w)
+		err := printCountsTable(succeeded, failed, w)
 		if err != nil {
 			return err
 		}
@@ -2147,26 +2038,6 @@ func printBuildAddDependenciesResponse(succeeded, failed int, outputFormat coref
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt build-add-dependencies. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printBuildAddDependenciesJSON emits a JSON summary of the build-add-dependencies operation to stdout via log.Output.
-func printBuildAddDependenciesJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return nil
-}
-
-// printBuildAddDependenciesTable renders a counts table for the build-add-dependencies operation.
-func printBuildAddDependenciesTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func buildCollectEnvCmd(c *components.Context) error {
@@ -2271,21 +2142,9 @@ func buildPromoteCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printBuildPromoteJSON()
+		printStatusJSON(200, "OK")
 	}
 	return nil
-}
-
-// printBuildPromoteJSON emits a synthetic JSON success response for build-promote.
-// The Artifactory promote API returns a body, but the client layer discards it;
-// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
-func printBuildPromoteJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 200,
-		"message":     "OK",
-	}
-	data, _ := json.Marshal(synthetic)
-	log.Output(clientutils.IndentJson(data))
 }
 
 func buildDiscardCmd(c *components.Context) error {
@@ -2318,21 +2177,9 @@ func buildDiscardCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 204, "message": "No Content"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printBuildDiscardJSON()
+		printStatusJSON(204, "No Content")
 	}
 	return nil
-}
-
-// printBuildDiscardJSON emits a synthetic JSON success response for build-discard.
-// The Artifactory discard API returns 204 No Content with no body; the client layer
-// discards the response, so error == nil guarantees HTTP 204.
-func printBuildDiscardJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 204,
-		"message":     "No Content",
-	}
-	data, _ := json.Marshal(synthetic)
-	log.Output(clientutils.IndentJson(data))
 }
 
 func gitLfsCleanCmd(c *components.Context) error {
@@ -2373,32 +2220,15 @@ func gitLfsCleanCmd(c *components.Context) error {
 func printGitLfsCleanResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, originalErr error) error {
 	switch outputFormat {
 	case coreformat.Json:
-		return printGitLfsCleanJSON(succeeded, failed, originalErr)
+		if err := printSummaryJSON(succeeded, failed, false, originalErr); err != nil {
+			return err
+		}
+		return originalErr
 	case coreformat.Table:
-		return printGitLfsCleanTable(succeeded, failed, w)
+		return printCountsTable(succeeded, failed, w)
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt git-lfs-clean. Acceptable values are: json, table", outputFormat)
 	}
-}
-
-// printGitLfsCleanJSON emits a JSON summary of the git-lfs-clean operation to stdout via log.Output.
-func printGitLfsCleanJSON(succeeded, failed int, originalErr error) error {
-	summaryReport := summary.GetSummaryReport(succeeded, failed, false, originalErr)
-	data, err := summaryReport.Marshal()
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	log.Output(clientutils.IndentJson(data))
-	return originalErr
-}
-
-// printGitLfsCleanTable renders a counts table for the git-lfs-clean operation.
-func printGitLfsCleanTable(succeeded, failed int, w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
-	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
-	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
-	return tw.Flush()
 }
 
 func curlCmd(c *components.Context) error {
@@ -2481,21 +2311,9 @@ func repoCreateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printRepoCreateJSON()
+		printStatusJSON(200, "OK")
 	}
 	return nil
-}
-
-// printRepoCreateJSON emits a synthetic JSON success response for repo-create.
-// The Artifactory repo create API returns a body, but the client layer discards it;
-// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
-func printRepoCreateJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 200,
-		"message":     "OK",
-	}
-	data, _ := json.Marshal(synthetic)
-	log.Output(clientutils.IndentJson(data))
 }
 
 func repoUpdateCmd(c *components.Context) error {
@@ -2525,21 +2343,9 @@ func repoUpdateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printRepoUpdateJSON()
+		printStatusJSON(200, "OK")
 	}
 	return nil
-}
-
-// printRepoUpdateJSON emits a synthetic JSON success response for repo-update.
-// The Artifactory repo update API returns a body, but the client layer discards it;
-// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
-func printRepoUpdateJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 200,
-		"message":     "OK",
-	}
-	data, _ := json.Marshal(synthetic)
-	log.Output(clientutils.IndentJson(data))
 }
 
 func repoDeleteCmd(c *components.Context) error {
@@ -2591,21 +2397,9 @@ func replicationCreateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if c.IsFlagSet(flagkit.Format) {
-		printReplicationCreateJSON()
+		printStatusJSON(200, "OK")
 	}
 	return nil
-}
-
-// printReplicationCreateJSON emits a synthetic JSON success response for replication-create.
-// The Artifactory replication create API returns a body, but the client layer discards it;
-// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
-func printReplicationCreateJSON() {
-	synthetic := map[string]interface{}{
-		"status_code": 200,
-		"message":     "OK",
-	}
-	data, _ := json.Marshal(synthetic)
-	log.Output(clientutils.IndentJson(data))
 }
 
 func replicationDeleteCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -867,7 +867,7 @@ func directDownloadCmd(c *components.Context) error {
 	return common.GetCliError(err, result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c))
 }
 
-func downloadCmd(c *components.Context) error {
+func downloadCmd(c *components.Context) (err error) {
 	downloadSpec, err := prepareDownloadCommand(c)
 	if err != nil {
 		return err
@@ -894,8 +894,16 @@ func downloadCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
+	outputFormat, err := getDownloadOutputFormat(c)
+	if err != nil {
+		return err
+	}
+	detailedSummary := common.GetDetailedSummary(c)
+	// When a structured format is requested we need the per-file transfer details reader,
+	// so force detailed-summary mode regardless of the explicit flag.
+	needDetailedReader := outputFormat != coreformat.None
 	downloadCommand := generic.NewDownloadCommand()
-	downloadCommand.SetConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(downloadSpec).SetServerDetails(serverDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(c.GetBoolFlagValue("detailed-summary")).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
+	downloadCommand.SetConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(downloadSpec).SetServerDetails(serverDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(detailedSummary || needDetailedReader).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 
 	if downloadCommand.ShouldPrompt() && !coreutils.AskYesNo("Sync-deletes may delete some files in your local file system. Are you sure you want to continue?\n"+
 		"You can avoid this confirmation message by adding --quiet to the command.", false) {
@@ -905,12 +913,81 @@ func downloadCmd(c *components.Context) error {
 	err = progressbar.ExecWithProgress(downloadCommand)
 	result := downloadCommand.Result()
 	defer common.CleanupResult(result, &err)
-	basicSummary, err := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
-	if err != nil {
+	if outputFormat == coreformat.None {
+		basicSummary, sErr := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+		if sErr != nil {
+			return sErr
+		}
+		err = common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, err)
+		return common.GetCliError(err, result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c))
+	}
+	err = printDownloadResponse(result, outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+	return
+}
+
+// getDownloadOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (JSON summary output via PrintDetailedSummaryReport).
+func getDownloadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printDownloadResponse renders the download result in the requested output format.
+// It preserves the fail-no-op and error-accounting semantics of PrintDetailedSummaryReport.
+func printDownloadResponse(result *commandUtils.Result, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		basicSummary, err := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, originalErr)
+	case coreformat.Table:
+		err := printDownloadTable(result, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, result.SuccessCount(), result.FailCount(), failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt download. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// downloadTableRow is a table-printable representation of a downloaded file.
+type downloadTableRow struct {
+	Source string `col-name:"SOURCE"`
+	Target string `col-name:"TARGET"`
+	Sha256 string `col-name:"SHA256"`
+}
+
+// printDownloadTable renders downloaded files as a human-readable table.
+func printDownloadTable(result *commandUtils.Result, w io.Writer) error {
+	reader := result.Reader()
+	if reader == nil {
+		// No per-file details available (e.g. dry-run without build-info collection).
+		// Fall back to a minimal counts table.
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
+		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
+		return tw.Flush()
+	}
+	var rows []downloadTableRow
+	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
+		rows = append(rows, downloadTableRow{
+			Source: item.RtUrl + item.SourcePath,
+			Target: item.TargetPath,
+			Sha256: item.Sha256,
+		})
+	}
+	if err := reader.GetError(); err != nil {
 		return err
 	}
-	err = common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, err)
-	return common.GetCliError(err, result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c))
+	reader.Reset()
+	return coreutils.PrintTable(rows, "Download Results", "No files were downloaded.", false)
 }
 
 func checkRbExistenceInV2(c *components.Context) (bool, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1989,6 +1989,13 @@ func buildPromoteCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() > 3 {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
+
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	configuration := createBuildPromoteConfiguration(c)
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
@@ -1999,7 +2006,29 @@ func buildPromoteCmd(c *components.Context) error {
 		return err
 	}
 	buildPromotionCmd := buildinfo.NewBuildPromotionCommand().SetDryRun(c.GetBoolFlagValue("dry-run")).SetServerDetails(rtDetails).SetPromotionParams(configuration).SetBuildConfiguration(buildConfiguration)
-	return commands.Exec(buildPromotionCmd)
+	if err = commands.Exec(buildPromotionCmd); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 200.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 200, "message": "OK"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printBuildPromoteJSON()
+	}
+	return nil
+}
+
+// printBuildPromoteJSON emits a synthetic JSON success response for build-promote.
+// The Artifactory promote API returns a body, but the client layer discards it;
+// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
+func printBuildPromoteJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 200,
+		"message":     "OK",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func buildDiscardCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -479,6 +479,13 @@ func dockerPromoteCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() != 3 {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
+
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	artDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
@@ -491,7 +498,29 @@ func dockerPromoteCmd(c *components.Context) error {
 	dockerPromoteCommand := container.NewDockerPromoteCommand()
 	dockerPromoteCommand.SetParams(params).SetServerDetails(artDetails)
 
-	return commands.Exec(dockerPromoteCommand)
+	if err = commands.Exec(dockerPromoteCommand); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 200.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 200, "message": "OK"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printDockerPromoteJSON()
+	}
+	return nil
+}
+
+// printDockerPromoteJSON emits a synthetic JSON success response for docker-promote.
+// The Artifactory docker promote API returns a body, but the client layer discards it;
+// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
+func printDockerPromoteJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 200,
+		"message":     "OK",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func containerPushCmd(c *components.Context, containerManagerType containerutils.ContainerManagerType) (err error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -891,7 +891,7 @@ func parseStringToBool(value string) (bool, error) {
 	return boolValue, nil
 }
 
-func directDownloadCmd(c *components.Context) error {
+func directDownloadCmd(c *components.Context) (err error) {
 	downloadSpec, err := prepareDirectDownloadCommand(c)
 	if err != nil {
 		return err
@@ -917,24 +917,37 @@ func directDownloadCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
+	outputFormat, err := getDirectDownloadOutputFormat(c)
+	if err != nil {
+		return err
+	}
+	detailedSummary := common.GetDetailedSummary(c)
+	// When a structured format is requested we need the per-file transfer details reader,
+	// so force detailed-summary mode regardless of the explicit flag.
+	needDetailedReader := outputFormat != coreformat.None
 
 	directDownloadCommand := generic.NewDirectDownloadCommand()
-	directDownloadCommand.SetConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(downloadSpec).SetServerDetails(serverDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(c.GetBoolFlagValue("detailed-summary")).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
+	directDownloadCommand.SetConfiguration(configuration).SetBuildConfiguration(buildConfiguration).SetSpec(downloadSpec).SetServerDetails(serverDetails).SetDryRun(c.GetBoolFlagValue("dry-run")).SetSyncDeletesPath(c.GetStringFlagValue("sync-deletes")).SetQuiet(common.GetQuietValue(c)).SetDetailedSummary(detailedSummary || needDetailedReader).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 
 	if directDownloadCommand.ShouldPrompt() && !coreutils.AskYesNo("Sync-deletes may delete some files in your local file system. Are you sure you want to continue?\n"+
 		"You can avoid this confirmation message by adding --quiet to the command.", false) {
 		return nil
 	}
 
+	// This error is being checked later on because we need to generate summary report before return.
 	err = progressbar.ExecWithProgress(directDownloadCommand)
 	result := directDownloadCommand.Result()
 	defer common.CleanupResult(result, &err)
-	basicSummary, err := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
-	if err != nil {
-		return err
+	if outputFormat == coreformat.None {
+		basicSummary, sErr := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+		if sErr != nil {
+			return sErr
+		}
+		err = common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, err)
+		return common.GetCliError(err, result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c))
 	}
-	err = common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, err)
-	return common.GetCliError(err, result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c))
+	err = printDirectDownloadResponse(result, outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+	return
 }
 
 func downloadCmd(c *components.Context) (err error) {
@@ -1058,6 +1071,71 @@ func printDownloadTable(result *commandUtils.Result, w io.Writer) error {
 	}
 	reader.Reset()
 	return coreutils.PrintTable(rows, "Download Results", "No files were downloaded.", false)
+}
+
+// getDirectDownloadOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (JSON summary output via PrintDetailedSummaryReport).
+func getDirectDownloadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printDirectDownloadResponse renders the direct-download result in the requested output format.
+// It preserves the fail-no-op and error-accounting semantics of PrintDetailedSummaryReport.
+func printDirectDownloadResponse(result *commandUtils.Result, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		basicSummary, err := common.CreateSummaryReportString(result.SuccessCount(), result.FailCount(), failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.PrintDetailedSummaryReport(basicSummary, result.Reader(), false, originalErr)
+	case coreformat.Table:
+		err := printDirectDownloadTable(result, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, result.SuccessCount(), result.FailCount(), failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt direct-download. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// directDownloadTableRow is a table-printable representation of a directly downloaded file.
+type directDownloadTableRow struct {
+	Source string `col-name:"SOURCE"`
+	Target string `col-name:"TARGET"`
+	Sha256 string `col-name:"SHA256"`
+}
+
+// printDirectDownloadTable renders directly downloaded files as a human-readable table.
+func printDirectDownloadTable(result *commandUtils.Result, w io.Writer) error {
+	reader := result.Reader()
+	if reader == nil {
+		// No per-file details available (e.g. dry-run without build-info collection).
+		// Fall back to a minimal counts table.
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+		_, _ = fmt.Fprintf(tw, "success\t%d\n", result.SuccessCount())
+		_, _ = fmt.Fprintf(tw, "failure\t%d\n", result.FailCount())
+		return tw.Flush()
+	}
+	var rows []directDownloadTableRow
+	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
+		rows = append(rows, directDownloadTableRow{
+			Source: item.RtUrl + item.SourcePath,
+			Target: item.TargetPath,
+			Sha256: item.Sha256,
+		})
+	}
+	if err := reader.GetError(); err != nil {
+		return err
+	}
+	reader.Reset()
+	return coreutils.PrintTable(rows, "Direct Download Results", "No files were downloaded.", false)
 }
 
 func checkRbExistenceInV2(c *components.Context) (bool, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1305,7 +1305,65 @@ func copyCmd(c *components.Context) error {
 	copyCommand.SetThreads(threads).SetSpec(copySpec).SetDryRun(c.GetBoolFlagValue("dry-run")).SetServerDetails(rtDetails).SetRetries(retries).SetRetryWaitMilliSecs(retryWaitTime)
 	err = commands.Exec(copyCommand)
 	result := copyCommand.Result()
-	return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+
+	outputFormat, fmtErr := getCopyOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	if outputFormat == coreformat.None {
+		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
+	}
+	return printCopyResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+}
+
+// getCopyOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (brief summary output via printBriefSummaryAndGetError).
+func getCopyOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printCopyResponse renders the copy result in the requested output format.
+func printCopyResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		err := printCopyJSON(succeeded, failed, failNoOp, originalErr)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		err := printCopyTable(succeeded, failed, w)
+		if err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt copy. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// printCopyJSON emits a JSON summary of the copy operation to stdout via log.Output.
+func printCopyJSON(succeeded, failed int, failNoOp bool, originalErr error) error {
+	summaryReport := summary.GetSummaryReport(succeeded, failed, failNoOp, originalErr)
+	data, err := summaryReport.Marshal()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printCopyTable renders a counts table for the copy operation.
+func printCopyTable(succeeded, failed int, w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
+	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
+	return tw.Flush()
 }
 
 // Prints a 'brief' (not detailed) summary and returns the appropriate exit error.

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -476,6 +476,17 @@ func getRetryWaitTimeVerificationError() error {
 	return errorutils.CheckError(errors.New("The '--retry-wait-time' option should have a numeric value with 's'/'ms' suffix. " + common.GetDocumentationMessage()))
 }
 
+// getOutputFormatWithDefault reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns defaultFormat, preserving the caller's
+// previous behaviour.  Callers that previously emitted JSON by default pass coreformat.Json;
+// callers that previously produced non-structured output pass coreformat.None.
+func getOutputFormatWithDefault(c *components.Context, defaultFormat coreformat.OutputFormat) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return defaultFormat, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
 func dockerPromoteCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() != 3 {
 		return common.WrongNumberOfArgumentsHandler(c)
@@ -546,7 +557,7 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return
 	}
-	outputFormat, err := getContainerPushOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
 	if err != nil {
 		return
 	}
@@ -570,16 +581,6 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 	}
 	err = printContainerPushResponse(result, outputFormat, os.Stdout, err)
 	return
-}
-
-// getContainerPushOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (deployment view / JSON summary output via PrintCommandSummary).
-func getContainerPushOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printContainerPushResponse renders the container push result in the requested output format.
@@ -645,7 +646,7 @@ func containerPullCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getContainerPullOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
 	if err != nil {
 		return err
 	}
@@ -662,16 +663,6 @@ func containerPullCmd(c *components.Context, containerManagerType containerutils
 		return nil
 	}
 	return printContainerPullResponse(imageTag, sourceRepo, outputFormat, os.Stdout)
-}
-
-// getContainerPullOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (no structured output beyond the native podman/docker output).
-func getContainerPullOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printContainerPullResponse renders the container pull result in the requested output format.
@@ -792,21 +783,11 @@ func nugetDepsTreeCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getNugetDepsTreeOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.Json)
 	if err != nil {
 		return err
 	}
 	return printNugetDepsTreeResponse(content, outputFormat, os.Stdout)
-}
-
-// getNugetDepsTreeOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.Json, preserving the
-// previous behaviour (JSON tree output).
-func getNugetDepsTreeOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.Json, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printNugetDepsTreeResponse renders the dependency tree in the requested output format.
@@ -863,21 +844,11 @@ func pingCmd(c *components.Context) error {
 	if err != nil {
 		return errors.New(err.Error() + "\n" + resString)
 	}
-	outputFormat, fmtErr := getPingOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
 	return printPingResponse(resBody, outputFormat, os.Stdout)
-}
-
-// getPingOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (plain-text "OK" output).
-func getPingOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printPingResponse renders the raw ping body in the requested output format.
@@ -1060,7 +1031,7 @@ func directDownloadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getDirectDownloadOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
 	if err != nil {
 		return err
 	}
@@ -1120,7 +1091,7 @@ func downloadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	outputFormat, err := getDownloadOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
 	if err != nil {
 		return err
 	}
@@ -1149,16 +1120,6 @@ func downloadCmd(c *components.Context) (err error) {
 	}
 	err = printDownloadResponse(result, outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 	return
-}
-
-// getDownloadOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (JSON summary output via PrintDetailedSummaryReport).
-func getDownloadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printDownloadResponse renders the download result in the requested output format.
@@ -1214,16 +1175,6 @@ func printDownloadTable(result *commandUtils.Result, w io.Writer) error {
 	}
 	reader.Reset()
 	return coreutils.PrintTable(rows, "Download Results", "No files were downloaded.", false)
-}
-
-// getDirectDownloadOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (JSON summary output via PrintDetailedSummaryReport).
-func getDirectDownloadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printDirectDownloadResponse renders the direct-download result in the requested output format.
@@ -1367,7 +1318,7 @@ func uploadCmd(c *components.Context) (err error) {
 	if err != nil {
 		return
 	}
-	outputFormat, err := getUploadOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.None)
 	if err != nil {
 		return
 	}
@@ -1396,16 +1347,6 @@ func uploadCmd(c *components.Context) (err error) {
 	}
 	err = printUploadResponse(result, outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 	return
-}
-
-// getUploadOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (JSON summary output via PrintCommandSummary).
-func getUploadOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printUploadResponse renders the upload result in the requested output format.
@@ -1510,7 +1451,7 @@ func moveCmd(c *components.Context) error {
 	err = commands.Exec(mvCmd)
 	result := mvCmd.Result()
 
-	outputFormat, fmtErr := getMoveOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1518,16 +1459,6 @@ func moveCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printMoveResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getMoveOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getMoveOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printMoveResponse renders the move result in the requested output format.
@@ -1597,7 +1528,7 @@ func copyCmd(c *components.Context) error {
 	err = commands.Exec(copyCommand)
 	result := copyCommand.Result()
 
-	outputFormat, fmtErr := getCopyOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1605,16 +1536,6 @@ func copyCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printCopyResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getCopyOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getCopyOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printCopyResponse renders the copy result in the requested output format.
@@ -1716,7 +1637,7 @@ func deleteCmd(c *components.Context) error {
 	err = commands.Exec(deleteCommand)
 	result := deleteCommand.Result()
 
-	outputFormat, fmtErr := getDeleteOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1724,16 +1645,6 @@ func deleteCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printDeleteResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getDeleteOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getDeleteOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printDeleteResponse renders the delete result in the requested output format.
@@ -1838,7 +1749,7 @@ func searchCmd(c *components.Context) (err error) {
 		log.Output(length)
 		return nil
 	}
-	outputFormat, err := getSearchOutputFormat(c)
+	outputFormat, err := getOutputFormatWithDefault(c, coreformat.Json)
 	if err != nil {
 		return err
 	}
@@ -1853,15 +1764,6 @@ type searchTableRow struct {
 	Created  string `col-name:"CREATED"`
 	Modified string `col-name:"MODIFIED"`
 	Sha256   string `col-name:"SHA256"`
-}
-
-// getSearchOutputFormat reads the --format flag and returns the resolved output format.
-// Default is json to preserve backward-compatible behaviour (the command has always emitted JSON).
-func getSearchOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.Json, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printSearchResponse renders ContentReader results in the requested output format.
@@ -1960,7 +1862,7 @@ func setPropsCmd(c *components.Context) error {
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
 
-	outputFormat, fmtErr := getSetPropsOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -1968,16 +1870,6 @@ func setPropsCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printSetPropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getSetPropsOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getSetPropsOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printSetPropsResponse renders the set-props result in the requested output format.
@@ -2038,7 +1930,7 @@ func deletePropsCmd(c *components.Context) error {
 	err = commands.Exec(propsCmd)
 	result := propsCmd.Result()
 
-	outputFormat, fmtErr := getDeletePropsOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2046,16 +1938,6 @@ func deletePropsCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printDeletePropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getDeletePropsOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getDeletePropsOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printDeletePropsResponse renders the delete-props result in the requested output format.
@@ -2112,7 +1994,7 @@ func buildPublishCmd(c *components.Context) error {
 		return err
 	}
 
-	outputFormat, fmtErr := getBuildPublishOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2147,16 +2029,6 @@ func buildPublishCmd(c *components.Context) error {
 		return err
 	}
 	return printBuildPublishResponse(cmd.GetBuildInfoUiUrl(), outputFormat, os.Stdout)
-}
-
-// getBuildPublishOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (JSON printed internally by Run()).
-func getBuildPublishOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printBuildPublishResponse renders the build-publish result in the requested output format.
@@ -2247,7 +2119,7 @@ func buildAddDependenciesCmd(c *components.Context) error {
 	err = commands.Exec(buildAddDependenciesCmd)
 	result := buildAddDependenciesCmd.Result()
 
-	outputFormat, fmtErr := getBuildAddDependenciesOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2255,16 +2127,6 @@ func buildAddDependenciesCmd(c *components.Context) error {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
 	return printBuildAddDependenciesResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// getBuildAddDependenciesOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (brief summary output via printBriefSummaryAndGetError).
-func getBuildAddDependenciesOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printBuildAddDependenciesResponse renders the build-add-dependencies result in the requested output format.
@@ -2497,7 +2359,7 @@ func gitLfsCleanCmd(c *components.Context) error {
 	succeeded, total := gitLfsCmd.Result()
 	failed := total - succeeded
 
-	outputFormat, fmtErr := getGitLfsCleanOutputFormat(c)
+	outputFormat, fmtErr := getOutputFormatWithDefault(c, coreformat.None)
 	if fmtErr != nil {
 		return fmtErr
 	}
@@ -2505,16 +2367,6 @@ func gitLfsCleanCmd(c *components.Context) error {
 		return err
 	}
 	return printGitLfsCleanResponse(succeeded, failed, outputFormat, os.Stdout, err)
-}
-
-// getGitLfsCleanOutputFormat reads the --format flag and returns the resolved output format.
-// When the flag is not set the function returns coreformat.None, preserving the
-// previous behaviour (no structured output).
-func getGitLfsCleanOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
-	if !c.IsFlagSet(flagkit.Format) {
-		return coreformat.None, nil
-	}
-	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
 }
 
 // printGitLfsCleanResponse renders the git-lfs-clean result in the requested output format.

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 
 	ioutils "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/buildinfo"
@@ -637,16 +641,83 @@ func pingCmd(c *components.Context) error {
 	if err != nil {
 		return err
 	}
-	pingCmd := coregeneric.NewPingCommand()
-	pingCmd.SetServerDetails(artDetails)
-	err = commands.Exec(pingCmd)
-	resString := clientutils.IndentJson(pingCmd.Response())
+	cmd := coregeneric.NewPingCommand()
+	cmd.SetServerDetails(artDetails)
+	err = commands.Exec(cmd)
+	resBody := cmd.Response()
+	resString := clientutils.IndentJson(resBody)
 	if err != nil {
 		return errors.New(err.Error() + "\n" + resString)
 	}
-	log.Output(resString)
+	outputFormat, fmtErr := getPingOutputFormat(c)
+	if fmtErr != nil {
+		return fmtErr
+	}
+	return printPingResponse(resBody, outputFormat, os.Stdout)
+}
 
-	return err
+// getPingOutputFormat reads the --format flag and returns the resolved output format.
+// When the flag is not set the function returns coreformat.None, preserving the
+// previous behaviour (plain-text "OK" output).
+func getPingOutputFormat(c *components.Context) (coreformat.OutputFormat, error) {
+	if !c.IsFlagSet(flagkit.Format) {
+		return coreformat.None, nil
+	}
+	return common.ExtractOutputFormat(c, []coreformat.OutputFormat{coreformat.Json, coreformat.Table})
+}
+
+// printPingResponse renders the raw ping body in the requested output format.
+func printPingResponse(body []byte, outputFormat coreformat.OutputFormat, w io.Writer) error {
+	switch outputFormat {
+	case coreformat.None:
+		// Backward-compatible: print the raw (or indented) response as before.
+		log.Output(clientutils.IndentJson(body))
+		return nil
+	case coreformat.Json:
+		return printPingJSON(body)
+	case coreformat.Table:
+		return printPingTable(body, w)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt ping. Acceptable values are: json, table", outputFormat)
+	}
+}
+
+// pingResponse is the structured representation emitted for --format json / table.
+type pingResponse struct {
+	StatusCode int    `json:"status_code"`
+	Message    string `json:"message"`
+}
+
+// pingResponseFromBody builds a pingResponse from the raw HTTP body.
+// The body is expected to be plain text (e.g. "OK"). A 200 status is assumed
+// because error responses are handled before this function is called.
+func pingResponseFromBody(body []byte) pingResponse {
+	msg := http.StatusText(http.StatusOK)
+	if len(body) > 0 {
+		msg = strings.TrimSpace(string(body))
+	}
+	return pingResponse{StatusCode: http.StatusOK, Message: msg}
+}
+
+// printPingJSON emits the ping result as indented JSON.
+func printPingJSON(body []byte) error {
+	resp := pingResponseFromBody(body)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	log.Output(clientutils.IndentJson(data))
+	return nil
+}
+
+// printPingTable renders the ping result as a two-column tabwriter table.
+func printPingTable(body []byte, w io.Writer) error {
+	resp := pingResponseFromBody(body)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "status_code\t%d\n", resp.StatusCode)
+	_, _ = fmt.Fprintf(tw, "message\t%s\n", resp.Message)
+	return tw.Flush()
 }
 
 func prepareDownloadCommand(c *components.Context) (*spec.SpecFiles, error) {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -372,7 +372,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "repo-create",
 			Aliases:     []string{"rc"},
-			Flags:       flagkit.GetCommandFlags(flagkit.TemplateConsumer),
+			Flags:       flagkit.GetCommandFlags(flagkit.RepoCreate),
 			Description: repocreate.GetDescription(),
 			Arguments:   repocreate.GetArguments(),
 			Action:      repoCreateCmd,
@@ -2607,15 +2607,43 @@ func repoCreateCmd(c *components.Context) error {
 		return common.WrongNumberOfArgumentsHandler(c)
 	}
 
+	if c.IsFlagSet(flagkit.Format) {
+		if _, fmtErr := coreformat.ParseOutputFormat(c.GetStringFlagValue(flagkit.Format), []coreformat.OutputFormat{coreformat.Json}); fmtErr != nil {
+			return fmtErr
+		}
+	}
+
 	rtDetails, err := common.CreateArtifactoryDetailsByFlags(c)
 	if err != nil {
 		return err
 	}
 
 	// Run command.
-	repoCreateCmd := repository.NewRepoCreateCommand()
-	repoCreateCmd.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
-	return commands.Exec(repoCreateCmd)
+	repoCreateCommand := repository.NewRepoCreateCommand()
+	repoCreateCommand.SetTemplatePath(c.GetArgumentAt(0)).SetServerDetails(rtDetails).SetVars(c.GetStringFlagValue("vars"))
+	if err = commands.Exec(repoCreateCommand); err != nil {
+		return err
+	}
+
+	// error == nil guarantees the server responded with 200.
+	// The client layer discards the body, so we pass nil and let the helper
+	// synthesize {"status_code": 200, "message": "OK"}.
+	if c.IsFlagSet(flagkit.Format) {
+		printRepoCreateJSON()
+	}
+	return nil
+}
+
+// printRepoCreateJSON emits a synthetic JSON success response for repo-create.
+// The Artifactory repo create API returns a body, but the client layer discards it;
+// error == nil guarantees HTTP 200, so we synthesise {"status_code":200,"message":"OK"}.
+func printRepoCreateJSON() {
+	synthetic := map[string]interface{}{
+		"status_code": 200,
+		"message":     "OK",
+	}
+	data, _ := json.Marshal(synthetic)
+	log.Output(clientutils.IndentJson(data))
 }
 
 func repoUpdateCmd(c *components.Context) error {

--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -532,15 +532,22 @@ func dockerPromoteCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(200, "OK")
+		return printStatusJSON(200, "OK")
 	}
 	return nil
 }
 
 // printStatusJSON emits a synthetic JSON response with the given HTTP status code and message.
-func printStatusJSON(statusCode int, message string) {
-	data, _ := json.Marshal(map[string]interface{}{"status_code": statusCode, "message": message})
+func printStatusJSON(statusCode int, message string) error {
+	data, err := json.Marshal(struct {
+		StatusCode int    `json:"status_code"`
+		Message    string `json:"message"`
+	}{StatusCode: statusCode, Message: message})
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
 	log.Output(clientutils.IndentJson(data))
+	return nil
 }
 
 // printCountsTable writes a two-row FIELD/VALUE tabwriter table with success and failure counts.
@@ -550,6 +557,24 @@ func printCountsTable(succeeded, failed int, w io.Writer) error {
 	_, _ = fmt.Fprintf(tw, "success\t%d\n", succeeded)
 	_, _ = fmt.Fprintf(tw, "failure\t%d\n", failed)
 	return tw.Flush()
+}
+
+// printCountBasedResponse renders a succeeded/failed count result in the requested output format.
+func printCountBasedResponse(cmdName string, succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
+	switch outputFormat {
+	case coreformat.Json:
+		if err := printSummaryJSON(succeeded, failed, failNoOp, originalErr); err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	case coreformat.Table:
+		if err := printCountsTable(succeeded, failed, w); err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
+	default:
+		return errorutils.CheckErrorf("unsupported format '%s' for rt %s. Acceptable values are: json, table", outputFormat, cmdName)
+	}
 }
 
 // printSummaryJSON marshals a summary report to indented JSON and writes it to the log output.
@@ -1213,21 +1238,15 @@ func printDirectDownloadResponse(result *commandUtils.Result, outputFormat coref
 	}
 }
 
-// directDownloadTableRow is a table-printable representation of a directly downloaded file.
-type directDownloadTableRow struct {
-	Source string `col-name:"SOURCE"`
-	Target string `col-name:"TARGET"`
-}
-
 // printDirectDownloadTable renders directly downloaded files as a human-readable table.
 func printDirectDownloadTable(result *commandUtils.Result, w io.Writer) error {
 	reader := result.Reader()
 	if reader == nil {
 		return printCountsTable(result.SuccessCount(), result.FailCount(), w)
 	}
-	var rows []directDownloadTableRow
+	var rows []downloadTableRow
 	for item := new(clientutils.FileTransferDetails); reader.NextRecord(item) == nil; item = new(clientutils.FileTransferDetails) {
-		rows = append(rows, directDownloadTableRow{
+		rows = append(rows, downloadTableRow{
 			Source: item.RtUrl + item.SourcePath,
 			Target: item.TargetPath,
 		})
@@ -1459,27 +1478,7 @@ func moveCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printMoveResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// printMoveResponse renders the move result in the requested output format.
-func printMoveResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt move. Acceptable values are: json, table", outputFormat)
-	}
+	return printCountBasedResponse("move", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 func copyCmd(c *components.Context) error {
@@ -1516,27 +1515,7 @@ func copyCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printCopyResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// printCopyResponse renders the copy result in the requested output format.
-func printCopyResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt copy. Acceptable values are: json, table", outputFormat)
-	}
+	return printCountBasedResponse("copy", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 // Prints a 'brief' (not detailed) summary and returns the appropriate exit error.
@@ -1605,27 +1584,7 @@ func deleteCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printDeleteResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// printDeleteResponse renders the delete result in the requested output format.
-func printDeleteResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt delete. Acceptable values are: json, table", outputFormat)
-	}
+	return printCountBasedResponse("delete", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 func prepareSearchCommand(c *components.Context) (*spec.SpecFiles, error) {
@@ -1810,27 +1769,7 @@ func setPropsCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printSetPropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// printSetPropsResponse renders the set-props result in the requested output format.
-func printSetPropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt set-props. Acceptable values are: json, table", outputFormat)
-	}
+	return printCountBasedResponse("set-props", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 func deletePropsCmd(c *components.Context) error {
@@ -1858,27 +1797,7 @@ func deletePropsCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printDeletePropsResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
-}
-
-// printDeletePropsResponse renders the delete-props result in the requested output format.
-func printDeletePropsResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt delete-props. Acceptable values are: json, table", outputFormat)
-	}
+	return printCountBasedResponse("delete-props", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 func buildPublishCmd(c *components.Context) error {
@@ -2052,29 +1971,10 @@ func buildAddDependenciesCmd(c *components.Context) error {
 	if outputFormat == coreformat.None {
 		return printBriefSummaryAndGetError(result.SuccessCount(), result.FailCount(), common.IsFailNoOp(c), err)
 	}
-	return printBuildAddDependenciesResponse(result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
+	return printCountBasedResponse("build-add-dependencies", result.SuccessCount(), result.FailCount(), outputFormat, os.Stdout, common.IsFailNoOp(c), err)
 }
 
 // printBuildAddDependenciesResponse renders the build-add-dependencies result in the requested output format.
-func printBuildAddDependenciesResponse(succeeded, failed int, outputFormat coreformat.OutputFormat, w io.Writer, failNoOp bool, originalErr error) error {
-	switch outputFormat {
-	case coreformat.Json:
-		err := printSummaryJSON(succeeded, failed, failNoOp, originalErr)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	case coreformat.Table:
-		err := printCountsTable(succeeded, failed, w)
-		if err != nil {
-			return err
-		}
-		return common.GetCliError(originalErr, succeeded, failed, failNoOp)
-	default:
-		return errorutils.CheckErrorf("unsupported format '%s' for rt build-add-dependencies. Acceptable values are: json, table", outputFormat)
-	}
-}
-
 func buildCollectEnvCmd(c *components.Context) error {
 	if c.GetNumberOfArgs() > 2 {
 		return common.WrongNumberOfArgumentsHandler(c)
@@ -2176,7 +2076,7 @@ func buildPromoteCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(200, "OK")
+		return printStatusJSON(200, "OK")
 	}
 	return nil
 }
@@ -2210,7 +2110,7 @@ func buildDiscardCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 204, "message": "No Content"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(204, "No Content")
+		return printStatusJSON(204, "No Content")
 	}
 	return nil
 }
@@ -2258,7 +2158,10 @@ func printGitLfsCleanResponse(succeeded, failed int, outputFormat coreformat.Out
 		}
 		return originalErr
 	case coreformat.Table:
-		return printCountsTable(succeeded, failed, w)
+		if err := printCountsTable(succeeded, failed, w); err != nil {
+			return err
+		}
+		return common.GetCliError(originalErr, succeeded, failed, false)
 	default:
 		return errorutils.CheckErrorf("unsupported format '%s' for rt git-lfs-clean. Acceptable values are: json, table", outputFormat)
 	}
@@ -2343,7 +2246,7 @@ func repoCreateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(200, "OK")
+		return printStatusJSON(200, "OK")
 	}
 	return nil
 }
@@ -2374,7 +2277,7 @@ func repoUpdateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(200, "OK")
+		return printStatusJSON(200, "OK")
 	}
 	return nil
 }
@@ -2427,7 +2330,7 @@ func replicationCreateCmd(c *components.Context) error {
 	// The client layer discards the body, so we pass nil and let the helper
 	// synthesize {"status_code": 200, "message": "OK"}.
 	if outputFormat != coreformat.None {
-		printStatusJSON(200, "OK")
+		return printStatusJSON(200, "OK")
 	}
 	return nil
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1828,3 +1828,117 @@ func TestPrintGitLfsCleanJSON_FailureStatus(t *testing.T) {
 	err := printGitLfsCleanJSON(3, 2, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getContainerPullOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetContainerPullOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getContainerPullOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetContainerPullOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getContainerPullOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetContainerPullOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getContainerPullOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetContainerPullOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getContainerPullOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printContainerPullResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintContainerPullResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printContainerPullJSON writes to log.Output (stdout); we only check no error is returned.
+	err := printContainerPullResponse("myrepo.example.com/myimage:latest", "docker-local", coreformat.Json, &buf)
+	require.NoError(t, err)
+}
+
+func TestPrintContainerPullResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printContainerPullResponse("myrepo.example.com/myimage:latest", "docker-local", coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "status")
+	assert.Contains(t, out, "ok")
+	assert.Contains(t, out, "image")
+	assert.Contains(t, out, "myrepo.example.com/myimage:latest")
+	assert.Contains(t, out, "repo")
+	assert.Contains(t, out, "docker-local")
+}
+
+func TestPrintContainerPullResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printContainerPullResponse("myimage:latest", "docker-local", coreformat.Sarif, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt podman-pull")
+}
+
+// ---------------------------------------------------------------------------
+// printContainerPullTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintContainerPullTable_WithValues(t *testing.T) {
+	var buf bytes.Buffer
+	err := printContainerPullTable("registry.example.com/my-image:v1.2.3", "docker-local", &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 4, "expected header + 3 data rows (status, image, repo)")
+	assert.Contains(t, lines[0], "FIELD")
+	assert.Contains(t, lines[0], "VALUE")
+	assert.Contains(t, out, "status")
+	assert.Contains(t, out, "ok")
+	assert.Contains(t, out, "image")
+	assert.Contains(t, out, "registry.example.com/my-image:v1.2.3")
+	assert.Contains(t, out, "repo")
+	assert.Contains(t, out, "docker-local")
+}
+
+func TestPrintContainerPullTable_EmptyValues(t *testing.T) {
+	var buf bytes.Buffer
+	err := printContainerPullTable("", "", &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "status")
+	assert.Contains(t, out, "ok")
+}
+
+// ---------------------------------------------------------------------------
+// printContainerPullJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintContainerPullJSON_Success(t *testing.T) {
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printContainerPullJSON("registry.example.com/myimage:latest", "docker-local")
+	require.NoError(t, err)
+}
+
+func TestPrintContainerPullJSON_EmptyValues(t *testing.T) {
+	// Even with empty image/repo the function should not error.
+	err := printContainerPullJSON("", "")
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1533,3 +1533,133 @@ func TestPrintBuildAddDependenciesJSON_FailureStatus(t *testing.T) {
 	err := printBuildAddDependenciesJSON(3, 2, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// direct-download test helpers
+// ---------------------------------------------------------------------------
+
+// createDirectDownloadResult builds a *commandUtils.Result with the given counts and an optional
+// per-file transfer-details ContentReader (keyed "files", matching Artifactory's convention).
+func createDirectDownloadResult(t *testing.T, success, failed int, transfers []clientutils.FileTransferDetails) *commandUtils.Result {
+	t.Helper()
+	r := new(commandUtils.Result)
+	r.SetSuccessCount(success)
+	r.SetFailCount(failed)
+	if transfers != nil {
+		type filesWrapper struct {
+			Files []clientutils.FileTransferDetails `json:"files"`
+		}
+		data, err := json.Marshal(filesWrapper{Files: transfers})
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp("", "direct-download-details-*.json")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r.SetReader(content.NewContentReader(f.Name(), "files"))
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// getDirectDownloadOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetDirectDownloadOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getDirectDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetDirectDownloadOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getDirectDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetDirectDownloadOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getDirectDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetDirectDownloadOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getDirectDownloadOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printDirectDownloadTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDirectDownloadTable_WithResults(t *testing.T) {
+	transfers := []clientutils.FileTransferDetails{
+		{SourcePath: "repo/a.jar", TargetPath: "/local/a.jar", RtUrl: "https://myrt.example.com/", Sha256: "abc123"},
+		{SourcePath: "repo/b.zip", TargetPath: "/local/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
+	}
+	result := createDirectDownloadResult(t, 2, 0, transfers)
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printDirectDownloadTable(result, &buf)
+	require.NoError(t, err)
+	// When a reader is present, PrintTable is used (writes to stdout); we only
+	// check that the function does not error and the reader state is consistent.
+}
+
+func TestPrintDirectDownloadTable_NoReader_FallsBackToCountsTable(t *testing.T) {
+	result := createDirectDownloadResult(t, 3, 1, nil)
+
+	var buf bytes.Buffer
+	err := printDirectDownloadTable(result, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintDirectDownloadTable_EmptyReader(t *testing.T) {
+	result := createDirectDownloadResult(t, 0, 0, []clientutils.FileTransferDetails{})
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printDirectDownloadTable(result, &buf)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// printDirectDownloadResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDirectDownloadResponse_Table_NoReader(t *testing.T) {
+	result := createDirectDownloadResult(t, 2, 0, nil)
+
+	var buf bytes.Buffer
+	err := printDirectDownloadResponse(result, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintDirectDownloadResponse_UnsupportedFormat(t *testing.T) {
+	result := createDirectDownloadResult(t, 1, 0, nil)
+
+	var buf bytes.Buffer
+	err := printDirectDownloadResponse(result, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt direct-download")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -2081,3 +2081,59 @@ func TestPrintNugetDepsTreeTable_InvalidJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse nuget-deps-tree response")
 }
+
+// ---------------------------------------------------------------------------
+// replication-create --format tests (Pattern B — json-only)
+// ---------------------------------------------------------------------------
+
+// TestReplicationCreateFormat_ValidJSON verifies that printReplicationCreateJSON does not panic.
+func TestReplicationCreateFormat_ValidJSON(t *testing.T) {
+	require.NotPanics(t, func() {
+		printReplicationCreateJSON()
+	})
+}
+
+// TestReplicationCreateFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (the common case: client discards body).
+func TestReplicationCreateFormat_EmptyBody(t *testing.T) {
+	// printReplicationCreateJSON always produces {"message":"OK","status_code":200}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printReplicationCreateJSON()
+	})
+}
+
+// TestReplicationCreateFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestReplicationCreateFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestReplicationCreateFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestReplicationCreateFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestReplicationCreateFormat_SarifRejected verifies that --format sarif is rejected.
+func TestReplicationCreateFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestReplicationCreateFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestReplicationCreateFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -48,26 +48,26 @@ func newTestContext(flags map[string]string) *components.Context {
 }
 
 // ---------------------------------------------------------------------------
-// getSearchOutputFormat tests
+// getOutputFormatWithDefault tests (search — default Json)
 // ---------------------------------------------------------------------------
 
 func TestGetSearchOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getSearchOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format, "default format should be json (backward-compatible)")
 }
 
 func TestGetSearchOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getSearchOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetSearchOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getSearchOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
@@ -76,7 +76,7 @@ func TestGetSearchOutputFormat_CaseInsensitive(t *testing.T) {
 	for _, val := range []string{"JSON", "Json", "TABLE", "Table"} {
 		t.Run(val, func(t *testing.T) {
 			ctx := newTestContext(map[string]string{"format": val})
-			_, err := getSearchOutputFormat(ctx)
+			_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 			require.NoError(t, err)
 		})
 	}
@@ -84,21 +84,21 @@ func TestGetSearchOutputFormat_CaseInsensitive(t *testing.T) {
 
 func TestGetSearchOutputFormat_UnsupportedFormat_Sarif(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "sarif"})
-	_, err := getSearchOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 func TestGetSearchOutputFormat_UnsupportedFormat_SimpleJson(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "simple-json"})
-	_, err := getSearchOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 func TestGetSearchOutputFormat_UnsupportedFormat_XML(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getSearchOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -164,33 +164,33 @@ func TestPrintSearchTable_EmptyResults(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getPingOutputFormat tests
+// getOutputFormatWithDefault tests (ping — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetPingOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getPingOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetPingOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getPingOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetPingOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getPingOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetPingOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getPingOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -318,33 +318,33 @@ func createUploadResult(t *testing.T, success, failed int, transfers []clientuti
 }
 
 // ---------------------------------------------------------------------------
-// getUploadOutputFormat tests
+// getOutputFormatWithDefault tests (upload — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetUploadOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getUploadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetUploadOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getUploadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetUploadOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getUploadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetUploadOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getUploadOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -449,33 +449,33 @@ func createDownloadResult(t *testing.T, success, failed int, transfers []clientu
 }
 
 // ---------------------------------------------------------------------------
-// getDownloadOutputFormat tests
+// getOutputFormatWithDefault tests (download — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetDownloadOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetDownloadOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetDownloadOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetDownloadOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getDownloadOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -549,33 +549,33 @@ func TestPrintDownloadResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getMoveOutputFormat tests
+// getOutputFormatWithDefault tests (move — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetMoveOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getMoveOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetMoveOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getMoveOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetMoveOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getMoveOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetMoveOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getMoveOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -656,33 +656,33 @@ func TestPrintMoveJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getCopyOutputFormat tests
+// getOutputFormatWithDefault tests (copy — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetCopyOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getCopyOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetCopyOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getCopyOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetCopyOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getCopyOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetCopyOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getCopyOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -763,33 +763,33 @@ func TestPrintCopyJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getDeleteOutputFormat tests
+// getOutputFormatWithDefault tests (delete — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetDeleteOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getDeleteOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetDeleteOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getDeleteOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetDeleteOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getDeleteOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetDeleteOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getDeleteOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -870,33 +870,33 @@ func TestPrintDeleteJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getBuildPublishOutputFormat tests
+// getOutputFormatWithDefault tests (build-publish — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetBuildPublishOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getBuildPublishOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default should be None (backward-compatible: Run() prints JSON internally)")
 }
 
 func TestGetBuildPublishOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getBuildPublishOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetBuildPublishOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getBuildPublishOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetBuildPublishOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getBuildPublishOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "only the following output formats are supported")
 }
@@ -999,33 +999,33 @@ func createContainerPushResult(t *testing.T, success, failed int, transfers []cl
 }
 
 // ---------------------------------------------------------------------------
-// getContainerPushOutputFormat tests
+// getOutputFormatWithDefault tests (container-push — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetContainerPushOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getContainerPushOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetContainerPushOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getContainerPushOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetContainerPushOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getContainerPushOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetContainerPushOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getContainerPushOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1213,33 +1213,33 @@ func TestBuildDiscardFormat_XMLRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getSetPropsOutputFormat tests
+// getOutputFormatWithDefault tests (set-props — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetSetPropsOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getSetPropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetSetPropsOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getSetPropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetSetPropsOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getSetPropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetSetPropsOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getSetPropsOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1320,33 +1320,33 @@ func TestPrintSetPropsJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getDeletePropsOutputFormat tests
+// getOutputFormatWithDefault tests (delete-props — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetDeletePropsOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getDeletePropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetDeletePropsOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getDeletePropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetDeletePropsOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getDeletePropsOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetDeletePropsOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getDeletePropsOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1426,33 +1426,33 @@ func TestPrintDeletePropsJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getBuildAddDependenciesOutputFormat tests
+// getOutputFormatWithDefault tests (build-add-dependencies — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetBuildAddDependenciesOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetBuildAddDependenciesOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetBuildAddDependenciesOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetBuildAddDependenciesOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getBuildAddDependenciesOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1565,33 +1565,33 @@ func createDirectDownloadResult(t *testing.T, success, failed int, transfers []c
 }
 
 // ---------------------------------------------------------------------------
-// getDirectDownloadOutputFormat tests
+// getOutputFormatWithDefault tests (direct-download — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetDirectDownloadOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getDirectDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetDirectDownloadOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getDirectDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetDirectDownloadOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getDirectDownloadOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetDirectDownloadOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getDirectDownloadOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1721,33 +1721,33 @@ func TestDockerPromoteFormat_XMLRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getGitLfsCleanOutputFormat tests
+// getOutputFormatWithDefault tests (git-lfs-clean — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetGitLfsCleanOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getGitLfsCleanOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetGitLfsCleanOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getGitLfsCleanOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetGitLfsCleanOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getGitLfsCleanOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetGitLfsCleanOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getGitLfsCleanOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1830,33 +1830,33 @@ func TestPrintGitLfsCleanJSON_FailureStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getContainerPullOutputFormat tests
+// getOutputFormatWithDefault tests (container-pull — default None)
 // ---------------------------------------------------------------------------
 
 func TestGetContainerPullOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getContainerPullOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
 }
 
 func TestGetContainerPullOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getContainerPullOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetContainerPullOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getContainerPullOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetContainerPullOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getContainerPullOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
@@ -1944,33 +1944,33 @@ func TestPrintContainerPullJSON_EmptyValues(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getNugetDepsTreeOutputFormat tests
+// getOutputFormatWithDefault tests (nuget-deps-tree — default Json)
 // ---------------------------------------------------------------------------
 
 func TestGetNugetDepsTreeOutputFormat_Default(t *testing.T) {
 	ctx := newTestContext(nil)
-	format, err := getNugetDepsTreeOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format, "default (no flag) should be Json to preserve backward-compatible JSON tree output")
 }
 
 func TestGetNugetDepsTreeOutputFormat_ExplicitJSON(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getNugetDepsTreeOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Json, format)
 }
 
 func TestGetNugetDepsTreeOutputFormat_ExplicitTable(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getNugetDepsTreeOutputFormat(ctx)
+	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.NoError(t, err)
 	assert.Equal(t, coreformat.Table, format)
 }
 
 func TestGetNugetDepsTreeOutputFormat_Invalid(t *testing.T) {
 	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getNugetDepsTreeOutputFormat(ctx)
+	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	commandUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
 	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -283,4 +285,135 @@ func TestPingResponseFromBody_WhitespaceBody(t *testing.T) {
 	resp := pingResponseFromBody([]byte("  OK  "))
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "OK", resp.Message)
+}
+
+// ---------------------------------------------------------------------------
+// upload test helpers
+// ---------------------------------------------------------------------------
+
+// createUploadResult builds a *commandUtils.Result with the given counts and an optional
+// per-file transfer-details ContentReader (keyed "files", matching Artifactory's convention).
+func createUploadResult(t *testing.T, success, failed int, transfers []clientutils.FileTransferDetails) *commandUtils.Result {
+	t.Helper()
+	r := new(commandUtils.Result)
+	r.SetSuccessCount(success)
+	r.SetFailCount(failed)
+	if transfers != nil {
+		type filesWrapper struct {
+			Files []clientutils.FileTransferDetails `json:"files"`
+		}
+		data, err := json.Marshal(filesWrapper{Files: transfers})
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp("", "upload-details-*.json")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r.SetReader(content.NewContentReader(f.Name(), "files"))
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// getUploadOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetUploadOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getUploadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetUploadOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getUploadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetUploadOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getUploadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetUploadOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getUploadOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printUploadTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintUploadTable_WithResults(t *testing.T) {
+	transfers := []clientutils.FileTransferDetails{
+		{SourcePath: "/local/a.jar", TargetPath: "repo/a.jar", RtUrl: "https://myrt.example.com/", Sha256: "abc123"},
+		{SourcePath: "/local/b.zip", TargetPath: "repo/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
+	}
+	result := createUploadResult(t, 2, 0, transfers)
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printUploadTable(result, &buf)
+	require.NoError(t, err)
+	// The table should not contain raw tabwriter output from the fallback path.
+	// When a reader is present, PrintTable is used (writes to stdout), so we only
+	// check that the function does not error and the reader state is consistent.
+}
+
+func TestPrintUploadTable_NoReader_FallsBackToCountsTable(t *testing.T) {
+	result := createUploadResult(t, 3, 1, nil)
+
+	var buf bytes.Buffer
+	err := printUploadTable(result, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintUploadTable_EmptyReader(t *testing.T) {
+	result := createUploadResult(t, 0, 0, []clientutils.FileTransferDetails{})
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printUploadTable(result, &buf)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// printUploadResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintUploadResponse_Table_NoReader(t *testing.T) {
+	result := createUploadResult(t, 2, 0, nil)
+
+	var buf bytes.Buffer
+	err := printUploadResponse(result, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintUploadResponse_UnsupportedFormat(t *testing.T) {
+	result := createUploadResult(t, 1, 0, nil)
+
+	var buf bytes.Buffer
+	err := printUploadResponse(result, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt upload")
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -2193,3 +2193,59 @@ func TestRepoCreateFormat_XMLRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
+
+// ---------------------------------------------------------------------------
+// repo-update --format tests (Pattern B — json-only)
+// ---------------------------------------------------------------------------
+
+// TestRepoUpdateFormat_ValidJSON verifies that printRepoUpdateJSON does not panic.
+func TestRepoUpdateFormat_ValidJSON(t *testing.T) {
+	require.NotPanics(t, func() {
+		printRepoUpdateJSON()
+	})
+}
+
+// TestRepoUpdateFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (client discards body).
+func TestRepoUpdateFormat_EmptyBody(t *testing.T) {
+	// printRepoUpdateJSON always produces {"message":"OK","status_code":200}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printRepoUpdateJSON()
+	})
+}
+
+// TestRepoUpdateFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestRepoUpdateFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestRepoUpdateFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestRepoUpdateFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestRepoUpdateFormat_SarifRejected verifies that --format sarif is rejected.
+func TestRepoUpdateFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestRepoUpdateFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestRepoUpdateFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -48,62 +48,6 @@ func newTestContext(flags map[string]string) *components.Context {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (search — default Json)
-// ---------------------------------------------------------------------------
-
-func TestGetSearchOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format, "default format should be json (backward-compatible)")
-}
-
-func TestGetSearchOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetSearchOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetSearchOutputFormat_CaseInsensitive(t *testing.T) {
-	for _, val := range []string{"JSON", "Json", "TABLE", "Table"} {
-		t.Run(val, func(t *testing.T) {
-			ctx := newTestContext(map[string]string{"format": val})
-			_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-			require.NoError(t, err)
-		})
-	}
-}
-
-func TestGetSearchOutputFormat_UnsupportedFormat_Sarif(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "sarif"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-func TestGetSearchOutputFormat_UnsupportedFormat_SimpleJson(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "simple-json"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-func TestGetSearchOutputFormat_UnsupportedFormat_XML(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printSearchResponse tests
 // ---------------------------------------------------------------------------
 
@@ -161,38 +105,6 @@ func TestPrintSearchTable_EmptyResults(t *testing.T) {
 
 	err := printSearchTable(reader)
 	assert.NoError(t, err)
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (ping — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetPingOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetPingOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetPingOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetPingOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -318,38 +230,6 @@ func createUploadResult(t *testing.T, success, failed int, transfers []clientuti
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (upload — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetUploadOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetUploadOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetUploadOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetUploadOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printUploadTable tests
 // ---------------------------------------------------------------------------
 
@@ -449,38 +329,6 @@ func createDownloadResult(t *testing.T, success, failed int, transfers []clientu
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (download — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetDownloadOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetDownloadOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetDownloadOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetDownloadOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printDownloadTable tests
 // ---------------------------------------------------------------------------
 
@@ -549,38 +397,6 @@ func TestPrintDownloadResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (move — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetMoveOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetMoveOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetMoveOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetMoveOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printCountsTable tests
 // ---------------------------------------------------------------------------
 
@@ -639,38 +455,6 @@ func TestPrintMoveResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (copy — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetCopyOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetCopyOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetCopyOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetCopyOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printCopyResponse tests
 // ---------------------------------------------------------------------------
 
@@ -701,38 +485,6 @@ func TestPrintCopyResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (delete — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetDeleteOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetDeleteOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetDeleteOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetDeleteOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printDeleteResponse tests
 // ---------------------------------------------------------------------------
 
@@ -760,38 +512,6 @@ func TestPrintDeleteResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt delete")
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (build-publish — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetBuildPublishOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default should be None (backward-compatible: Run() prints JSON internally)")
-}
-
-func TestGetBuildPublishOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetBuildPublishOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetBuildPublishOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, strings.ToLower(err.Error()), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -929,38 +649,6 @@ func createContainerPushResult(t *testing.T, success, failed int, transfers []cl
 		r.SetReader(content.NewContentReader(f.Name(), "files"))
 	}
 	return r
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (container-push — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetContainerPushOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetContainerPushOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetContainerPushOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetContainerPushOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -1110,38 +798,6 @@ func TestBuildDiscardFormat_XMLRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (set-props — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetSetPropsOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetSetPropsOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetSetPropsOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetSetPropsOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printSetPropsResponse tests
 // ---------------------------------------------------------------------------
 
@@ -1172,38 +828,6 @@ func TestPrintSetPropsResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (delete-props — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetDeletePropsOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetDeletePropsOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetDeletePropsOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetDeletePropsOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printDeletePropsResponse tests
 // ---------------------------------------------------------------------------
 
@@ -1231,38 +855,6 @@ func TestPrintDeletePropsResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt delete-props")
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (build-add-dependencies — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetBuildAddDependenciesOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetBuildAddDependenciesOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetBuildAddDependenciesOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetBuildAddDependenciesOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -1325,38 +917,6 @@ func createDirectDownloadResult(t *testing.T, success, failed int, transfers []c
 		r.SetReader(content.NewContentReader(f.Name(), "files"))
 	}
 	return r
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (direct-download — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetDirectDownloadOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetDirectDownloadOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetDirectDownloadOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetDirectDownloadOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -1467,38 +1027,6 @@ func TestDockerPromoteFormat_XMLRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (git-lfs-clean — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetGitLfsCleanOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetGitLfsCleanOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetGitLfsCleanOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetGitLfsCleanOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
-}
-
-// ---------------------------------------------------------------------------
 // printGitLfsCleanResponse tests
 // ---------------------------------------------------------------------------
 
@@ -1528,38 +1056,6 @@ func TestPrintGitLfsCleanResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt git-lfs-clean")
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (container-pull — default None)
-// ---------------------------------------------------------------------------
-
-func TestGetContainerPullOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
-}
-
-func TestGetContainerPullOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetContainerPullOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetContainerPullOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.None)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------
@@ -1642,38 +1138,6 @@ func TestPrintContainerPullJSON_EmptyValues(t *testing.T) {
 	// Even with empty image/repo the function should not error.
 	err := printContainerPullJSON("", "")
 	require.NoError(t, err)
-}
-
-// ---------------------------------------------------------------------------
-// getOutputFormatWithDefault tests (nuget-deps-tree — default Json)
-// ---------------------------------------------------------------------------
-
-func TestGetNugetDepsTreeOutputFormat_Default(t *testing.T) {
-	ctx := newTestContext(nil)
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format, "default (no flag) should be Json to preserve backward-compatible JSON tree output")
-}
-
-func TestGetNugetDepsTreeOutputFormat_ExplicitJSON(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "json"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Json, format)
-}
-
-func TestGetNugetDepsTreeOutputFormat_ExplicitTable(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "table"})
-	format, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.NoError(t, err)
-	assert.Equal(t, coreformat.Table, format)
-}
-
-func TestGetNugetDepsTreeOutputFormat_Invalid(t *testing.T) {
-	ctx := newTestContext(map[string]string{"format": "xml"})
-	_, err := getOutputFormatWithDefault(ctx, coreformat.Json)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
 
 // ---------------------------------------------------------------------------

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1663,3 +1663,59 @@ func TestPrintDirectDownloadResponse_UnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt direct-download")
 }
+
+// ---------------------------------------------------------------------------
+// docker-promote --format tests
+// ---------------------------------------------------------------------------
+
+// TestDockerPromoteFormat_ValidJSON verifies that printDockerPromoteJSON does not panic.
+func TestDockerPromoteFormat_ValidJSON(t *testing.T) {
+	require.NotPanics(t, func() {
+		printDockerPromoteJSON()
+	})
+}
+
+// TestDockerPromoteFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (the common case: client discards body).
+func TestDockerPromoteFormat_EmptyBody(t *testing.T) {
+	// printDockerPromoteJSON always produces {"message":"OK","status_code":200}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printDockerPromoteJSON()
+	})
+}
+
+// TestDockerPromoteFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestDockerPromoteFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestDockerPromoteFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestDockerPromoteFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestDockerPromoteFormat_SarifRejected verifies that --format sarif is rejected.
+func TestDockerPromoteFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestDockerPromoteFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestDockerPromoteFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -417,3 +417,133 @@ func TestPrintUploadResponse_UnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt upload")
 }
+
+// ---------------------------------------------------------------------------
+// download test helpers
+// ---------------------------------------------------------------------------
+
+// createDownloadResult builds a *commandUtils.Result with the given counts and an optional
+// per-file transfer-details ContentReader (keyed "files", matching Artifactory's convention).
+func createDownloadResult(t *testing.T, success, failed int, transfers []clientutils.FileTransferDetails) *commandUtils.Result {
+	t.Helper()
+	r := new(commandUtils.Result)
+	r.SetSuccessCount(success)
+	r.SetFailCount(failed)
+	if transfers != nil {
+		type filesWrapper struct {
+			Files []clientutils.FileTransferDetails `json:"files"`
+		}
+		data, err := json.Marshal(filesWrapper{Files: transfers})
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp("", "download-details-*.json")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r.SetReader(content.NewContentReader(f.Name(), "files"))
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// getDownloadOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetDownloadOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetDownloadOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetDownloadOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getDownloadOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetDownloadOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getDownloadOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printDownloadTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDownloadTable_WithResults(t *testing.T) {
+	transfers := []clientutils.FileTransferDetails{
+		{SourcePath: "repo/a.jar", TargetPath: "/local/a.jar", RtUrl: "https://myrt.example.com/", Sha256: "abc123"},
+		{SourcePath: "repo/b.zip", TargetPath: "/local/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
+	}
+	result := createDownloadResult(t, 2, 0, transfers)
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printDownloadTable(result, &buf)
+	require.NoError(t, err)
+	// When a reader is present, PrintTable is used (writes to stdout), so we only
+	// check that the function does not error and the reader state is consistent.
+}
+
+func TestPrintDownloadTable_NoReader_FallsBackToCountsTable(t *testing.T) {
+	result := createDownloadResult(t, 3, 1, nil)
+
+	var buf bytes.Buffer
+	err := printDownloadTable(result, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintDownloadTable_EmptyReader(t *testing.T) {
+	result := createDownloadResult(t, 0, 0, []clientutils.FileTransferDetails{})
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printDownloadTable(result, &buf)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// printDownloadResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDownloadResponse_Table_NoReader(t *testing.T) {
+	result := createDownloadResult(t, 2, 0, nil)
+
+	var buf bytes.Buffer
+	err := printDownloadResponse(result, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintDownloadResponse_UnsupportedFormat(t *testing.T) {
+	result := createDownloadResult(t, 1, 0, nil)
+
+	var buf bytes.Buffer
+	err := printDownloadResponse(result, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt download")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -581,12 +581,12 @@ func TestGetMoveOutputFormat_Invalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printMoveTable tests
+// printCountsTable tests
 // ---------------------------------------------------------------------------
 
-func TestPrintMoveTable_SuccessAndFailure(t *testing.T) {
+func TestPrintCountsTableSuccessAndFailure(t *testing.T) {
 	var buf bytes.Buffer
-	err := printMoveTable(5, 2, &buf)
+	err := printCountsTable(5, 2, &buf)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "FIELD")
@@ -597,9 +597,9 @@ func TestPrintMoveTable_SuccessAndFailure(t *testing.T) {
 	assert.Contains(t, out, "2")
 }
 
-func TestPrintMoveTable_ZeroCounts(t *testing.T) {
+func TestPrintCountsTableZeroCounts(t *testing.T) {
 	var buf bytes.Buffer
-	err := printMoveTable(0, 0, &buf)
+	err := printCountsTable(0, 0, &buf)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "FIELD")
@@ -639,23 +639,6 @@ func TestPrintMoveResponse_UnsupportedFormat(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printMoveJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintMoveJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printMoveJSON(3, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintMoveJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should be "failure".
-	err := printMoveJSON(2, 1, false, nil)
-	require.NoError(t, err)
-}
-
-// ---------------------------------------------------------------------------
 // getOutputFormatWithDefault tests (copy — default None)
 // ---------------------------------------------------------------------------
 
@@ -688,34 +671,6 @@ func TestGetCopyOutputFormat_Invalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printCopyTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintCopyTable_SuccessAndFailure(t *testing.T) {
-	var buf bytes.Buffer
-	err := printCopyTable(5, 2, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "5")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "2")
-}
-
-func TestPrintCopyTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printCopyTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-}
-
-// ---------------------------------------------------------------------------
 // printCopyResponse tests
 // ---------------------------------------------------------------------------
 
@@ -743,23 +698,6 @@ func TestPrintCopyResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt copy")
-}
-
-// ---------------------------------------------------------------------------
-// printCopyJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintCopyJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printCopyJSON(3, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintCopyJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should be "failure".
-	err := printCopyJSON(2, 1, false, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -795,34 +733,6 @@ func TestGetDeleteOutputFormat_Invalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printDeleteTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeleteTable_SuccessAndFailure(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeleteTable(5, 2, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "5")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "2")
-}
-
-func TestPrintDeleteTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeleteTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-}
-
-// ---------------------------------------------------------------------------
 // printDeleteResponse tests
 // ---------------------------------------------------------------------------
 
@@ -850,23 +760,6 @@ func TestPrintDeleteResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt delete")
-}
-
-// ---------------------------------------------------------------------------
-// printDeleteJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeleteJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printDeleteJSON(3, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintDeleteJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should be "failure".
-	err := printDeleteJSON(2, 1, false, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -1102,25 +995,6 @@ func TestPrintContainerPushResponse_UnsupportedFormat(t *testing.T) {
 // build-promote (Pattern B — json-only) tests
 // ---------------------------------------------------------------------------
 
-// TestBuildPromoteFormat_ValidJSON verifies that --format json is accepted and
-// printBuildPromoteJSON does not panic or error.
-func TestBuildPromoteFormat_ValidJSON(t *testing.T) {
-	// printBuildPromoteJSON writes to log.Output (stdout); we just verify it does not panic.
-	require.NotPanics(t, func() {
-		printBuildPromoteJSON()
-	})
-}
-
-// TestBuildPromoteFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (the common case: client discards body).
-func TestBuildPromoteFormat_EmptyBody(t *testing.T) {
-	// printBuildPromoteJSON always produces {"message":"OK","status_code":200}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printBuildPromoteJSON()
-	})
-}
-
 // TestBuildPromoteFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
 func TestBuildPromoteFormat_InvalidFormatRejected(t *testing.T) {
@@ -1159,23 +1033,6 @@ func TestBuildPromoteFormat_XMLRejected(t *testing.T) {
 // ---------------------------------------------------------------------------
 // build-discard --format tests
 // ---------------------------------------------------------------------------
-
-// TestBuildDiscardFormat_ValidJSON verifies that printBuildDiscardJSON does not panic.
-func TestBuildDiscardFormat_ValidJSON(t *testing.T) {
-	require.NotPanics(t, func() {
-		printBuildDiscardJSON()
-	})
-}
-
-// TestBuildDiscardFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (204 No Content; client discards body).
-func TestBuildDiscardFormat_EmptyBody(t *testing.T) {
-	// printBuildDiscardJSON always produces {"message":"No Content","status_code":204}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printBuildDiscardJSON()
-	})
-}
 
 // TestBuildDiscardFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
@@ -1245,34 +1102,6 @@ func TestGetSetPropsOutputFormat_Invalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printSetPropsTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintSetPropsTable_SuccessAndFailure(t *testing.T) {
-	var buf bytes.Buffer
-	err := printSetPropsTable(7, 3, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "7")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "3")
-}
-
-func TestPrintSetPropsTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printSetPropsTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-}
-
-// ---------------------------------------------------------------------------
 // printSetPropsResponse tests
 // ---------------------------------------------------------------------------
 
@@ -1300,23 +1129,6 @@ func TestPrintSetPropsResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt set-props")
-}
-
-// ---------------------------------------------------------------------------
-// printSetPropsJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintSetPropsJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printSetPropsJSON(3, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintSetPropsJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should be "failure".
-	err := printSetPropsJSON(2, 1, false, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -1352,33 +1164,6 @@ func TestGetDeletePropsOutputFormat_Invalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printDeletePropsTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeletePropsTable_SuccessAndFailure(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeletePropsTable(7, 3, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "7")
-	assert.Contains(t, out, "3")
-}
-
-func TestPrintDeletePropsTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeletePropsTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "0")
-}
-
-// ---------------------------------------------------------------------------
 // printDeletePropsResponse tests
 // ---------------------------------------------------------------------------
 
@@ -1406,23 +1191,6 @@ func TestPrintDeletePropsResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt delete-props")
-}
-
-// ---------------------------------------------------------------------------
-// printDeletePropsJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeletePropsJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printDeletePropsJSON(3, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintDeletePropsJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should be "failure".
-	err := printDeletePropsJSON(2, 1, false, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -1487,51 +1255,6 @@ func TestPrintBuildAddDependenciesResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt build-add-dependencies")
-}
-
-// ---------------------------------------------------------------------------
-// printBuildAddDependenciesTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintBuildAddDependenciesTable_WithCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printBuildAddDependenciesTable(10, 3, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 data rows")
-	assert.Contains(t, lines[0], "FIELD")
-	assert.Contains(t, lines[0], "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "10")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "3")
-}
-
-func TestPrintBuildAddDependenciesTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printBuildAddDependenciesTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-}
-
-// ---------------------------------------------------------------------------
-// printBuildAddDependenciesJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintBuildAddDependenciesJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printBuildAddDependenciesJSON(8, 0, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintBuildAddDependenciesJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should reflect failure.
-	err := printBuildAddDependenciesJSON(3, 2, false, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -1668,23 +1391,6 @@ func TestPrintDirectDownloadResponse_UnsupportedFormat(t *testing.T) {
 // docker-promote --format tests
 // ---------------------------------------------------------------------------
 
-// TestDockerPromoteFormat_ValidJSON verifies that printDockerPromoteJSON does not panic.
-func TestDockerPromoteFormat_ValidJSON(t *testing.T) {
-	require.NotPanics(t, func() {
-		printDockerPromoteJSON()
-	})
-}
-
-// TestDockerPromoteFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (the common case: client discards body).
-func TestDockerPromoteFormat_EmptyBody(t *testing.T) {
-	// printDockerPromoteJSON always produces {"message":"OK","status_code":200}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printDockerPromoteJSON()
-	})
-}
-
 // TestDockerPromoteFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
 func TestDockerPromoteFormat_InvalidFormatRejected(t *testing.T) {
@@ -1782,51 +1488,6 @@ func TestPrintGitLfsCleanResponse_UnsupportedFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt git-lfs-clean")
-}
-
-// ---------------------------------------------------------------------------
-// printGitLfsCleanTable tests
-// ---------------------------------------------------------------------------
-
-func TestPrintGitLfsCleanTable_WithCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printGitLfsCleanTable(10, 3, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 data rows")
-	assert.Contains(t, lines[0], "FIELD")
-	assert.Contains(t, lines[0], "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "10")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "3")
-}
-
-func TestPrintGitLfsCleanTable_ZeroCounts(t *testing.T) {
-	var buf bytes.Buffer
-	err := printGitLfsCleanTable(0, 0, &buf)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-}
-
-// ---------------------------------------------------------------------------
-// printGitLfsCleanJSON tests
-// ---------------------------------------------------------------------------
-
-func TestPrintGitLfsCleanJSON_SuccessStatus(t *testing.T) {
-	// No error, no failures → status should be "success".
-	// Output goes to log.Output (stdout); we just verify no error is returned.
-	err := printGitLfsCleanJSON(8, 0, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintGitLfsCleanJSON_FailureStatus(t *testing.T) {
-	// Has failures → status should reflect failure; we verify no error is returned.
-	err := printGitLfsCleanJSON(3, 2, nil)
-	require.NoError(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -2086,23 +1747,6 @@ func TestPrintNugetDepsTreeTable_InvalidJSON(t *testing.T) {
 // replication-create --format tests (Pattern B — json-only)
 // ---------------------------------------------------------------------------
 
-// TestReplicationCreateFormat_ValidJSON verifies that printReplicationCreateJSON does not panic.
-func TestReplicationCreateFormat_ValidJSON(t *testing.T) {
-	require.NotPanics(t, func() {
-		printReplicationCreateJSON()
-	})
-}
-
-// TestReplicationCreateFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (the common case: client discards body).
-func TestReplicationCreateFormat_EmptyBody(t *testing.T) {
-	// printReplicationCreateJSON always produces {"message":"OK","status_code":200}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printReplicationCreateJSON()
-	})
-}
-
 // TestReplicationCreateFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
 func TestReplicationCreateFormat_InvalidFormatRejected(t *testing.T) {
@@ -2141,23 +1785,6 @@ func TestReplicationCreateFormat_XMLRejected(t *testing.T) {
 // ---------------------------------------------------------------------------
 // repo-create --format tests (Pattern B — json-only)
 // ---------------------------------------------------------------------------
-
-// TestRepoCreateFormat_ValidJSON verifies that printRepoCreateJSON does not panic.
-func TestRepoCreateFormat_ValidJSON(t *testing.T) {
-	require.NotPanics(t, func() {
-		printRepoCreateJSON()
-	})
-}
-
-// TestRepoCreateFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (the common case: client discards body).
-func TestRepoCreateFormat_EmptyBody(t *testing.T) {
-	// printRepoCreateJSON always produces {"message":"OK","status_code":200}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printRepoCreateJSON()
-	})
-}
 
 // TestRepoCreateFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
@@ -2198,23 +1825,6 @@ func TestRepoCreateFormat_XMLRejected(t *testing.T) {
 // repo-update --format tests (Pattern B — json-only)
 // ---------------------------------------------------------------------------
 
-// TestRepoUpdateFormat_ValidJSON verifies that printRepoUpdateJSON does not panic.
-func TestRepoUpdateFormat_ValidJSON(t *testing.T) {
-	require.NotPanics(t, func() {
-		printRepoUpdateJSON()
-	})
-}
-
-// TestRepoUpdateFormat_EmptyBody verifies that the synthetic JSON object is
-// well-formed when the body is nil (client discards body).
-func TestRepoUpdateFormat_EmptyBody(t *testing.T) {
-	// printRepoUpdateJSON always produces {"message":"OK","status_code":200}.
-	// We verify the function runs without error (output goes to log.Output, not a writer).
-	require.NotPanics(t, func() {
-		printRepoUpdateJSON()
-	})
-}
-
 // TestRepoUpdateFormat_InvalidFormatRejected verifies that --format table (and
 // any other unsupported format) is rejected before the HTTP call is made.
 func TestRepoUpdateFormat_InvalidFormatRejected(t *testing.T) {
@@ -2248,4 +1858,22 @@ func TestRepoUpdateFormat_XMLRejected(t *testing.T) {
 	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+func TestPrintSummaryJSONSuccessStatus(t *testing.T) {
+	err := printSummaryJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintSummaryJSONFailureStatus(t *testing.T) {
+	err := printSummaryJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintStatusJSONOK(t *testing.T) {
+	require.NotPanics(t, func() { printStatusJSON(200, "OK") })
+}
+
+func TestPrintStatusJSONNoContent(t *testing.T) {
+	require.NotPanics(t, func() { printStatusJSON(204, "No Content") })
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1719,3 +1719,112 @@ func TestDockerPromoteFormat_XMLRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
+
+// ---------------------------------------------------------------------------
+// getGitLfsCleanOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetGitLfsCleanOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getGitLfsCleanOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetGitLfsCleanOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getGitLfsCleanOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetGitLfsCleanOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getGitLfsCleanOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetGitLfsCleanOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getGitLfsCleanOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printGitLfsCleanResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintGitLfsCleanResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printGitLfsCleanResponse(5, 1, coreformat.Table, &buf, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintGitLfsCleanResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printGitLfsCleanJSON writes to log.Output (stdout); we only check no error is returned.
+	err := printGitLfsCleanResponse(3, 0, coreformat.Json, &buf, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintGitLfsCleanResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printGitLfsCleanResponse(1, 0, coreformat.Sarif, &buf, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt git-lfs-clean")
+}
+
+// ---------------------------------------------------------------------------
+// printGitLfsCleanTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintGitLfsCleanTable_WithCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printGitLfsCleanTable(10, 3, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 data rows")
+	assert.Contains(t, lines[0], "FIELD")
+	assert.Contains(t, lines[0], "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "10")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "3")
+}
+
+func TestPrintGitLfsCleanTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printGitLfsCleanTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printGitLfsCleanJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintGitLfsCleanJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printGitLfsCleanJSON(8, 0, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintGitLfsCleanJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should reflect failure; we verify no error is returned.
+	err := printGitLfsCleanJSON(3, 2, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1424,3 +1424,112 @@ func TestPrintDeletePropsJSON_FailureStatus(t *testing.T) {
 	err := printDeletePropsJSON(2, 1, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getBuildAddDependenciesOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetBuildAddDependenciesOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetBuildAddDependenciesOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetBuildAddDependenciesOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getBuildAddDependenciesOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetBuildAddDependenciesOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getBuildAddDependenciesOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printBuildAddDependenciesResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildAddDependenciesResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildAddDependenciesResponse(7, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "7")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintBuildAddDependenciesResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printBuildAddDependenciesJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printBuildAddDependenciesResponse(5, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintBuildAddDependenciesResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildAddDependenciesResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt build-add-dependencies")
+}
+
+// ---------------------------------------------------------------------------
+// printBuildAddDependenciesTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildAddDependenciesTable_WithCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildAddDependenciesTable(10, 3, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 data rows")
+	assert.Contains(t, lines[0], "FIELD")
+	assert.Contains(t, lines[0], "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "10")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "3")
+}
+
+func TestPrintBuildAddDependenciesTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildAddDependenciesTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printBuildAddDependenciesJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildAddDependenciesJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printBuildAddDependenciesJSON(8, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintBuildAddDependenciesJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should reflect failure.
+	err := printBuildAddDependenciesJSON(3, 2, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -967,3 +967,133 @@ func TestPrintBuildPublishJSON_ValidURL(t *testing.T) {
 	err := printBuildPublishJSON("https://example.jfrog.io/ui/builds/myapp/1/123/published")
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// container-push test helpers
+// ---------------------------------------------------------------------------
+
+// createContainerPushResult builds a *commandUtils.Result with the given counts and an optional
+// per-layer transfer-details ContentReader (keyed "files", matching the push command convention).
+func createContainerPushResult(t *testing.T, success, failed int, transfers []clientutils.FileTransferDetails) *commandUtils.Result {
+	t.Helper()
+	r := new(commandUtils.Result)
+	r.SetSuccessCount(success)
+	r.SetFailCount(failed)
+	if transfers != nil {
+		type filesWrapper struct {
+			Files []clientutils.FileTransferDetails `json:"files"`
+		}
+		data, err := json.Marshal(filesWrapper{Files: transfers})
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp("", "container-push-details-*.json")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+		_, err = f.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r.SetReader(content.NewContentReader(f.Name(), "files"))
+	}
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// getContainerPushOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetContainerPushOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getContainerPushOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetContainerPushOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getContainerPushOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetContainerPushOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getContainerPushOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetContainerPushOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getContainerPushOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printContainerPushTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintContainerPushTable_WithResults(t *testing.T) {
+	transfers := []clientutils.FileTransferDetails{
+		{TargetPath: "myrepo/sha256:aabbcc", RtUrl: "https://myrt.example.com/", Sha256: "aabbcc"},
+		{TargetPath: "myrepo/sha256:ddeeff", RtUrl: "https://myrt.example.com/", Sha256: "ddeeff"},
+	}
+	result := createContainerPushResult(t, 2, 0, transfers)
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printContainerPushTable(result, &buf)
+	require.NoError(t, err)
+	// When a reader is present, PrintTable is used (writes to stdout); we only
+	// check that the function does not error and the reader state is consistent.
+}
+
+func TestPrintContainerPushTable_NoReader_FallsBackToCountsTable(t *testing.T) {
+	result := createContainerPushResult(t, 3, 1, nil)
+
+	var buf bytes.Buffer
+	err := printContainerPushTable(result, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintContainerPushTable_EmptyReader(t *testing.T) {
+	result := createContainerPushResult(t, 0, 0, []clientutils.FileTransferDetails{})
+	defer result.Reader().Close()
+
+	var buf bytes.Buffer
+	err := printContainerPushTable(result, &buf)
+	require.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// printContainerPushResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintContainerPushResponse_Table_NoReader(t *testing.T) {
+	result := createContainerPushResult(t, 2, 0, nil)
+
+	var buf bytes.Buffer
+	err := printContainerPushResponse(result, coreformat.Table, &buf, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintContainerPushResponse_UnsupportedFormat(t *testing.T) {
+	result := createContainerPushResult(t, 1, 0, nil)
+
+	var buf bytes.Buffer
+	err := printContainerPushResponse(result, coreformat.Sarif, &buf, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt podman-push")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -654,3 +654,110 @@ func TestPrintMoveJSON_FailureStatus(t *testing.T) {
 	err := printMoveJSON(2, 1, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getCopyOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetCopyOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getCopyOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetCopyOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getCopyOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetCopyOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getCopyOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetCopyOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getCopyOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printCopyTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintCopyTable_SuccessAndFailure(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCopyTable(5, 2, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintCopyTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCopyTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printCopyResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintCopyResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCopyResponse(3, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintCopyResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printCopyJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printCopyResponse(4, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintCopyResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printCopyResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt copy")
+}
+
+// ---------------------------------------------------------------------------
+// printCopyJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintCopyJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printCopyJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintCopyJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should be "failure".
+	err := printCopyJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1318,3 +1318,109 @@ func TestPrintSetPropsJSON_FailureStatus(t *testing.T) {
 	err := printSetPropsJSON(2, 1, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getDeletePropsOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetDeletePropsOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getDeletePropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetDeletePropsOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getDeletePropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetDeletePropsOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getDeletePropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetDeletePropsOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getDeletePropsOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printDeletePropsTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeletePropsTable_SuccessAndFailure(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeletePropsTable(7, 3, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "7")
+	assert.Contains(t, out, "3")
+}
+
+func TestPrintDeletePropsTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeletePropsTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "0")
+}
+
+// ---------------------------------------------------------------------------
+// printDeletePropsResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeletePropsResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeletePropsResponse(5, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintDeletePropsResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printDeletePropsJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printDeletePropsResponse(4, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintDeletePropsResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeletePropsResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt delete-props")
+}
+
+// ---------------------------------------------------------------------------
+// printDeletePropsJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeletePropsJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printDeletePropsJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintDeletePropsJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should be "failure".
+	err := printDeletePropsJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1211,3 +1211,110 @@ func TestBuildDiscardFormat_XMLRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
+
+// ---------------------------------------------------------------------------
+// getSetPropsOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetSetPropsOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getSetPropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetSetPropsOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getSetPropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetSetPropsOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getSetPropsOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetSetPropsOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getSetPropsOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printSetPropsTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintSetPropsTable_SuccessAndFailure(t *testing.T) {
+	var buf bytes.Buffer
+	err := printSetPropsTable(7, 3, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "7")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "3")
+}
+
+func TestPrintSetPropsTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printSetPropsTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printSetPropsResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintSetPropsResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printSetPropsResponse(5, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintSetPropsResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printSetPropsJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printSetPropsResponse(4, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintSetPropsResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printSetPropsResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt set-props")
+}
+
+// ---------------------------------------------------------------------------
+// printSetPropsJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintSetPropsJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printSetPropsJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintSetPropsJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should be "failure".
+	err := printSetPropsJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -2137,3 +2137,59 @@ func TestReplicationCreateFormat_XMLRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
+
+// ---------------------------------------------------------------------------
+// repo-create --format tests (Pattern B — json-only)
+// ---------------------------------------------------------------------------
+
+// TestRepoCreateFormat_ValidJSON verifies that printRepoCreateJSON does not panic.
+func TestRepoCreateFormat_ValidJSON(t *testing.T) {
+	require.NotPanics(t, func() {
+		printRepoCreateJSON()
+	})
+}
+
+// TestRepoCreateFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (the common case: client discards body).
+func TestRepoCreateFormat_EmptyBody(t *testing.T) {
+	// printRepoCreateJSON always produces {"message":"OK","status_code":200}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printRepoCreateJSON()
+	})
+}
+
+// TestRepoCreateFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestRepoCreateFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestRepoCreateFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestRepoCreateFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestRepoCreateFormat_SarifRejected verifies that --format sarif is rejected.
+func TestRepoCreateFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestRepoCreateFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestRepoCreateFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
@@ -157,4 +159,128 @@ func TestPrintSearchTable_EmptyResults(t *testing.T) {
 
 	err := printSearchTable(reader)
 	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// getPingOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetPingOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getPingOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetPingOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getPingOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetPingOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getPingOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetPingOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getPingOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printPingResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintPingResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingResponse([]byte("OK"), coreformat.Json, &buf)
+	require.NoError(t, err)
+	// Verify the output is valid JSON with the expected fields.
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(`{"message":"OK","status_code":200}`), &result))
+}
+
+func TestPrintPingResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingResponse([]byte("OK"), coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "status_code")
+	assert.Contains(t, out, "200")
+	assert.Contains(t, out, "message")
+	assert.Contains(t, out, "OK")
+}
+
+func TestPrintPingResponse_None_BackwardCompat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingResponse([]byte("OK"), coreformat.None, &buf)
+	require.NoError(t, err)
+	// None format uses log.Output (not the writer), so buf stays empty.
+	// Just verify no error is returned.
+}
+
+func TestPrintPingResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingResponse([]byte("OK"), coreformat.Sarif, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt ping")
+}
+
+// ---------------------------------------------------------------------------
+// printPingTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintPingTable_OKBody(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingTable([]byte("OK"), &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 data rows")
+	assert.Contains(t, lines[0], "FIELD")
+	assert.Contains(t, lines[0], "VALUE")
+	assert.Contains(t, out, "status_code")
+	assert.Contains(t, out, "200")
+	assert.Contains(t, out, "message")
+	assert.Contains(t, out, "OK")
+}
+
+func TestPrintPingTable_EmptyBody(t *testing.T) {
+	var buf bytes.Buffer
+	err := printPingTable(nil, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	// Empty body falls back to HTTP status phrase "OK".
+	assert.Contains(t, out, "OK")
+}
+
+// ---------------------------------------------------------------------------
+// pingResponseFromBody tests
+// ---------------------------------------------------------------------------
+
+func TestPingResponseFromBody_PlainText(t *testing.T) {
+	resp := pingResponseFromBody([]byte("OK"))
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "OK", resp.Message)
+}
+
+func TestPingResponseFromBody_EmptyBody(t *testing.T) {
+	resp := pingResponseFromBody(nil)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "OK", resp.Message) // http.StatusText(200) == "OK"
+}
+
+func TestPingResponseFromBody_WhitespaceBody(t *testing.T) {
+	resp := pingResponseFromBody([]byte("  OK  "))
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "OK", resp.Message)
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -801,25 +801,47 @@ func TestGetBuildPublishOutputFormat_Invalid(t *testing.T) {
 func TestPrintBuildPublishResponse_JSON(t *testing.T) {
 	var buf bytes.Buffer
 	// printBuildPublishJSON writes to log.Output (stdout); we verify no error.
-	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1/123/published", coreformat.Json, &buf)
+	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1/123/published", "", coreformat.Json, &buf)
+	require.NoError(t, err)
+}
+
+func TestPrintBuildPublishResponse_JSON_WithSha256(t *testing.T) {
+	var buf bytes.Buffer
+	const testURL = "https://example.jfrog.io/ui/builds/myapp/1/123/published"
+	const testSha256 = "abc123def456"
+	err := printBuildPublishResponse(testURL, testSha256, coreformat.Json, &buf)
 	require.NoError(t, err)
 }
 
 func TestPrintBuildPublishResponse_Table(t *testing.T) {
 	var buf bytes.Buffer
 	const testURL = "https://example.jfrog.io/ui/builds/myapp/1/123/published"
-	err := printBuildPublishResponse(testURL, coreformat.Table, &buf)
+	err := printBuildPublishResponse(testURL, "", coreformat.Table, &buf)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "FIELD")
 	assert.Contains(t, out, "VALUE")
 	assert.Contains(t, out, "buildInfoUiUrl")
 	assert.Contains(t, out, testURL)
+	assert.NotContains(t, out, "sha256")
+}
+
+func TestPrintBuildPublishResponse_Table_WithSha256(t *testing.T) {
+	var buf bytes.Buffer
+	const testURL = "https://example.jfrog.io/ui/builds/myapp/1/123/published"
+	const testSha256 = "deadbeef1234"
+	err := printBuildPublishResponse(testURL, testSha256, coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "buildInfoUiUrl")
+	assert.Contains(t, out, testURL)
+	assert.Contains(t, out, "sha256")
+	assert.Contains(t, out, testSha256)
 }
 
 func TestPrintBuildPublishResponse_Table_EmptyURL(t *testing.T) {
 	var buf bytes.Buffer
-	err := printBuildPublishResponse("", coreformat.Table, &buf)
+	err := printBuildPublishResponse("", "", coreformat.Table, &buf)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "FIELD")
@@ -828,7 +850,7 @@ func TestPrintBuildPublishResponse_Table_EmptyURL(t *testing.T) {
 
 func TestPrintBuildPublishResponse_UnsupportedFormat(t *testing.T) {
 	var buf bytes.Buffer
-	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1", coreformat.Sarif, &buf)
+	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1", "", coreformat.Sarif, &buf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt build-publish")
@@ -841,7 +863,7 @@ func TestPrintBuildPublishResponse_UnsupportedFormat(t *testing.T) {
 func TestPrintBuildPublishTable_ContainsHeaderAndURL(t *testing.T) {
 	var buf bytes.Buffer
 	const testURL = "https://myrt.example.com/ui/builds/my-build/42/1234/published"
-	err := printBuildPublishTable(testURL, &buf)
+	err := printBuildPublishTable(testURL, "", &buf)
 	require.NoError(t, err)
 	out := buf.String()
 	// tabwriter replaces tabs with spaces; check for rendered tokens
@@ -849,6 +871,19 @@ func TestPrintBuildPublishTable_ContainsHeaderAndURL(t *testing.T) {
 	assert.Contains(t, out, "VALUE")
 	assert.Contains(t, out, "buildInfoUiUrl")
 	assert.Contains(t, out, testURL)
+	assert.NotContains(t, out, "sha256")
+}
+
+func TestPrintBuildPublishTable_WithSha256(t *testing.T) {
+	var buf bytes.Buffer
+	const testURL = "https://myrt.example.com/ui/builds/my-build/42/1234/published"
+	const testSha256 = "cafebabe5678"
+	err := printBuildPublishTable(testURL, testSha256, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "buildInfoUiUrl")
+	assert.Contains(t, out, "sha256")
+	assert.Contains(t, out, testSha256)
 }
 
 // ---------------------------------------------------------------------------
@@ -857,7 +892,12 @@ func TestPrintBuildPublishTable_ContainsHeaderAndURL(t *testing.T) {
 
 func TestPrintBuildPublishJSON_ValidURL(t *testing.T) {
 	// Output goes to log.Output; we just verify no error is returned.
-	err := printBuildPublishJSON("https://example.jfrog.io/ui/builds/myapp/1/123/published")
+	err := printBuildPublishJSON("https://example.jfrog.io/ui/builds/myapp/1/123/published", "")
+	require.NoError(t, err)
+}
+
+func TestPrintBuildPublishJSON_WithSha256(t *testing.T) {
+	err := printBuildPublishJSON("https://example.jfrog.io/ui/builds/myapp/1/123/published", "abc123")
 	require.NoError(t, err)
 }
 

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -868,3 +868,102 @@ func TestPrintDeleteJSON_FailureStatus(t *testing.T) {
 	err := printDeleteJSON(2, 1, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getBuildPublishOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetBuildPublishOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getBuildPublishOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default should be None (backward-compatible: Run() prints JSON internally)")
+}
+
+func TestGetBuildPublishOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getBuildPublishOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetBuildPublishOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getBuildPublishOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetBuildPublishOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getBuildPublishOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printBuildPublishResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildPublishResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printBuildPublishJSON writes to log.Output (stdout); we verify no error.
+	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1/123/published", coreformat.Json, &buf)
+	require.NoError(t, err)
+}
+
+func TestPrintBuildPublishResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	const testURL = "https://example.jfrog.io/ui/builds/myapp/1/123/published"
+	err := printBuildPublishResponse(testURL, coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "buildInfoUiUrl")
+	assert.Contains(t, out, testURL)
+}
+
+func TestPrintBuildPublishResponse_Table_EmptyURL(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildPublishResponse("", coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "buildInfoUiUrl")
+}
+
+func TestPrintBuildPublishResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printBuildPublishResponse("https://example.jfrog.io/ui/builds/myapp/1", coreformat.Sarif, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt build-publish")
+}
+
+// ---------------------------------------------------------------------------
+// printBuildPublishTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildPublishTable_ContainsHeaderAndURL(t *testing.T) {
+	var buf bytes.Buffer
+	const testURL = "https://myrt.example.com/ui/builds/my-build/42/1234/published"
+	err := printBuildPublishTable(testURL, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	// tabwriter replaces tabs with spaces; check for rendered tokens
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "buildInfoUiUrl")
+	assert.Contains(t, out, testURL)
+}
+
+// ---------------------------------------------------------------------------
+// printBuildPublishJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintBuildPublishJSON_ValidURL(t *testing.T) {
+	// Output goes to log.Output; we just verify no error is returned.
+	err := printBuildPublishJSON("https://example.jfrog.io/ui/builds/myapp/1/123/published")
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1097,3 +1097,61 @@ func TestPrintContainerPushResponse_UnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt podman-push")
 }
+
+// ---------------------------------------------------------------------------
+// build-promote (Pattern B — json-only) tests
+// ---------------------------------------------------------------------------
+
+// TestBuildPromoteFormat_ValidJSON verifies that --format json is accepted and
+// printBuildPromoteJSON does not panic or error.
+func TestBuildPromoteFormat_ValidJSON(t *testing.T) {
+	// printBuildPromoteJSON writes to log.Output (stdout); we just verify it does not panic.
+	require.NotPanics(t, func() {
+		printBuildPromoteJSON()
+	})
+}
+
+// TestBuildPromoteFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (the common case: client discards body).
+func TestBuildPromoteFormat_EmptyBody(t *testing.T) {
+	// printBuildPromoteJSON always produces {"message":"OK","status_code":200}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printBuildPromoteJSON()
+	})
+}
+
+// TestBuildPromoteFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestBuildPromoteFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestBuildPromoteFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestBuildPromoteFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestBuildPromoteFormat_SarifRejected verifies that --format sarif is rejected.
+func TestBuildPromoteFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestBuildPromoteFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestBuildPromoteFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1155,3 +1155,59 @@ func TestBuildPromoteFormat_XMLRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only the following output formats are supported")
 }
+
+// ---------------------------------------------------------------------------
+// build-discard --format tests
+// ---------------------------------------------------------------------------
+
+// TestBuildDiscardFormat_ValidJSON verifies that printBuildDiscardJSON does not panic.
+func TestBuildDiscardFormat_ValidJSON(t *testing.T) {
+	require.NotPanics(t, func() {
+		printBuildDiscardJSON()
+	})
+}
+
+// TestBuildDiscardFormat_EmptyBody verifies that the synthetic JSON object is
+// well-formed when the body is nil (204 No Content; client discards body).
+func TestBuildDiscardFormat_EmptyBody(t *testing.T) {
+	// printBuildDiscardJSON always produces {"message":"No Content","status_code":204}.
+	// We verify the function runs without error (output goes to log.Output, not a writer).
+	require.NotPanics(t, func() {
+		printBuildDiscardJSON()
+	})
+}
+
+// TestBuildDiscardFormat_InvalidFormatRejected verifies that --format table (and
+// any other unsupported format) is rejected before the HTTP call is made.
+func TestBuildDiscardFormat_InvalidFormatRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestBuildDiscardFormat_JSONFormatAccepted verifies that --format json passes
+// ParseOutputFormat validation without error.
+func TestBuildDiscardFormat_JSONFormatAccepted(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	outputFormat, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, outputFormat)
+}
+
+// TestBuildDiscardFormat_SarifRejected verifies that --format sarif is rejected.
+func TestBuildDiscardFormat_SarifRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// TestBuildDiscardFormat_XMLRejected verifies that an arbitrary unsupported format
+// value is rejected.
+func TestBuildDiscardFormat_XMLRejected(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := coreformat.ParseOutputFormat(ctx.GetStringFlagValue("format"), []coreformat.OutputFormat{coreformat.Json})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1942,3 +1942,142 @@ func TestPrintContainerPullJSON_EmptyValues(t *testing.T) {
 	err := printContainerPullJSON("", "")
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getNugetDepsTreeOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetNugetDepsTreeOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getNugetDepsTreeOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format, "default (no flag) should be Json to preserve backward-compatible JSON tree output")
+}
+
+func TestGetNugetDepsTreeOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getNugetDepsTreeOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetNugetDepsTreeOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getNugetDepsTreeOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetNugetDepsTreeOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getNugetDepsTreeOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printNugetDepsTreeResponse tests
+// ---------------------------------------------------------------------------
+
+// sampleNugetDepsTreeJSON returns a minimal solution JSON matching the structure
+// returned by solution.Marshal() — used as test input.
+func sampleNugetDepsTreeJSON(projects []nugetDepsTreeProject) []byte {
+	sol := nugetDepsTreeSolution{Projects: projects}
+	data, _ := json.Marshal(sol)
+	return data
+}
+
+func TestPrintNugetDepsTreeResponse_JSON(t *testing.T) {
+	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+		{Name: "MyProject", Dependencies: map[string]interface{}{"Newtonsoft.Json:13.0.1": nil}},
+	})
+	var buf bytes.Buffer
+	err := printNugetDepsTreeResponse(data, coreformat.Json, &buf)
+	require.NoError(t, err)
+	// JSON output goes to log.Output (stdout), not to buf; just verify no error.
+}
+
+func TestPrintNugetDepsTreeResponse_Table(t *testing.T) {
+	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+		{Name: "MyProject", Dependencies: map[string]interface{}{
+			"Newtonsoft.Json:13.0.1": nil,
+			"Serilog:3.0.0":          nil,
+		}},
+	})
+	var buf bytes.Buffer
+	err := printNugetDepsTreeResponse(data, coreformat.Table, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "DEPENDENCY_COUNT")
+	assert.Contains(t, out, "MyProject")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintNugetDepsTreeResponse_UnsupportedFormat(t *testing.T) {
+	data := sampleNugetDepsTreeJSON(nil)
+	var buf bytes.Buffer
+	err := printNugetDepsTreeResponse(data, coreformat.Sarif, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt nuget-deps-tree")
+}
+
+// ---------------------------------------------------------------------------
+// printNugetDepsTreeTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintNugetDepsTreeTable_MultipleProjects(t *testing.T) {
+	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+		{Name: "ProjectA", Dependencies: map[string]interface{}{
+			"Newtonsoft.Json:13.0.1": nil,
+			"Serilog:3.0.0":          nil,
+			"AutoMapper:12.0.0":      nil,
+		}},
+		{Name: "ProjectB", Dependencies: map[string]interface{}{
+			"Dapper:2.0.0": nil,
+		}},
+	})
+	var buf bytes.Buffer
+	err := printNugetDepsTreeTable(data, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "expected header + 2 project rows")
+	assert.Contains(t, lines[0], "PROJECT")
+	assert.Contains(t, lines[0], "DEPENDENCY_COUNT")
+	assert.Contains(t, out, "ProjectA")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "ProjectB")
+	assert.Contains(t, out, "1")
+}
+
+func TestPrintNugetDepsTreeTable_EmptyProjects(t *testing.T) {
+	data := sampleNugetDepsTreeJSON(nil)
+	var buf bytes.Buffer
+	err := printNugetDepsTreeTable(data, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	// Should still have the header even with no projects.
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "DEPENDENCY_COUNT")
+}
+
+func TestPrintNugetDepsTreeTable_ProjectWithNoDependencies(t *testing.T) {
+	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+		{Name: "EmptyProject", Dependencies: map[string]interface{}{}},
+	})
+	var buf bytes.Buffer
+	err := printNugetDepsTreeTable(data, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "EmptyProject")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintNugetDepsTreeTable_InvalidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := printNugetDepsTreeTable([]byte("not-valid-json"), &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse nuget-deps-tree response")
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -761,3 +761,110 @@ func TestPrintCopyJSON_FailureStatus(t *testing.T) {
 	err := printCopyJSON(2, 1, false, nil)
 	require.NoError(t, err)
 }
+
+// ---------------------------------------------------------------------------
+// getDeleteOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetDeleteOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getDeleteOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetDeleteOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getDeleteOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetDeleteOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getDeleteOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetDeleteOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getDeleteOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printDeleteTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeleteTable_SuccessAndFailure(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeleteTable(5, 2, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintDeleteTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeleteTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printDeleteResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeleteResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeleteResponse(3, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintDeleteResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printDeleteJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printDeleteResponse(4, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintDeleteResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printDeleteResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt delete")
+}
+
+// ---------------------------------------------------------------------------
+// printDeleteJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintDeleteJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printDeleteJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintDeleteJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should be "failure".
+	err := printDeleteJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createSearchContentReader writes SearchResult-compatible JSON to a temp file and
+// returns a *content.ContentReader backed by that file.
+func createSearchContentReader(t *testing.T, items []map[string]interface{}) *content.ContentReader {
+	t.Helper()
+	type resultFile struct {
+		Results []map[string]interface{} `json:"results"`
+	}
+	rf := resultFile{Results: items}
+	data, err := json.Marshal(rf)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "search-results-*.json")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	return content.NewContentReader(f.Name(), content.DefaultKey)
+}
+
+// newTestContext constructs a minimal *components.Context with the given string flags set.
+func newTestContext(flags map[string]string) *components.Context {
+	ctx := &components.Context{}
+	for k, v := range flags {
+		ctx.AddStringFlag(k, v)
+	}
+	ctx.PrintCommandHelp = func(string) error { return nil }
+	return ctx
+}
+
+// ---------------------------------------------------------------------------
+// getSearchOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetSearchOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getSearchOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format, "default format should be json (backward-compatible)")
+}
+
+func TestGetSearchOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getSearchOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetSearchOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getSearchOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetSearchOutputFormat_CaseInsensitive(t *testing.T) {
+	for _, val := range []string{"JSON", "Json", "TABLE", "Table"} {
+		t.Run(val, func(t *testing.T) {
+			ctx := newTestContext(map[string]string{"format": val})
+			_, err := getSearchOutputFormat(ctx)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetSearchOutputFormat_UnsupportedFormat_Sarif(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "sarif"})
+	_, err := getSearchOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+func TestGetSearchOutputFormat_UnsupportedFormat_SimpleJson(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "simple-json"})
+	_, err := getSearchOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+func TestGetSearchOutputFormat_UnsupportedFormat_XML(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getSearchOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printSearchResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintSearchResponse_JSON(t *testing.T) {
+	items := []map[string]interface{}{
+		{"path": "repo/path/file.txt", "type": "file", "size": 1234, "sha256": "abc123"},
+	}
+	reader := createSearchContentReader(t, items)
+	defer reader.Close()
+
+	err := printSearchResponse(reader, coreformat.Json)
+	assert.NoError(t, err)
+}
+
+func TestPrintSearchResponse_Table(t *testing.T) {
+	items := []map[string]interface{}{
+		{"path": "repo/path/file.jar", "type": "file", "size": 5678, "sha256": "deadbeef"},
+	}
+	reader := createSearchContentReader(t, items)
+	defer reader.Close()
+
+	err := printSearchResponse(reader, coreformat.Table)
+	assert.NoError(t, err)
+}
+
+func TestPrintSearchResponse_UnsupportedFormat(t *testing.T) {
+	reader := createSearchContentReader(t, nil)
+	defer reader.Close()
+
+	err := printSearchResponse(reader, coreformat.Sarif)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt search")
+}
+
+// ---------------------------------------------------------------------------
+// printSearchTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintSearchTable_WithResults(t *testing.T) {
+	items := []map[string]interface{}{
+		{"path": "my-repo/a/b/file.jar", "type": "file", "size": 5678, "sha256": "deadbeef"},
+		{"path": "my-repo/a/c/other.zip", "type": "file", "size": 999, "sha256": "cafebabe"},
+	}
+	reader := createSearchContentReader(t, items)
+	defer reader.Close()
+
+	err := printSearchTable(reader)
+	assert.NoError(t, err)
+}
+
+func TestPrintSearchTable_EmptyResults(t *testing.T) {
+	reader := createSearchContentReader(t, nil)
+	defer reader.Close()
+
+	err := printSearchTable(reader)
+	assert.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -547,3 +547,110 @@ func TestPrintDownloadResponse_UnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt download")
 }
+
+// ---------------------------------------------------------------------------
+// getMoveOutputFormat tests
+// ---------------------------------------------------------------------------
+
+func TestGetMoveOutputFormat_Default(t *testing.T) {
+	ctx := newTestContext(nil)
+	format, err := getMoveOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.None, format, "default (no flag) should be None to preserve backward-compatible output")
+}
+
+func TestGetMoveOutputFormat_ExplicitJSON(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "json"})
+	format, err := getMoveOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Json, format)
+}
+
+func TestGetMoveOutputFormat_ExplicitTable(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "table"})
+	format, err := getMoveOutputFormat(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, coreformat.Table, format)
+}
+
+func TestGetMoveOutputFormat_Invalid(t *testing.T) {
+	ctx := newTestContext(map[string]string{"format": "xml"})
+	_, err := getMoveOutputFormat(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the following output formats are supported")
+}
+
+// ---------------------------------------------------------------------------
+// printMoveTable tests
+// ---------------------------------------------------------------------------
+
+func TestPrintMoveTable_SuccessAndFailure(t *testing.T) {
+	var buf bytes.Buffer
+	err := printMoveTable(5, 2, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "5")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "2")
+}
+
+func TestPrintMoveTable_ZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	err := printMoveTable(0, 0, &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FIELD")
+	assert.Contains(t, out, "VALUE")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "failure")
+}
+
+// ---------------------------------------------------------------------------
+// printMoveResponse tests
+// ---------------------------------------------------------------------------
+
+func TestPrintMoveResponse_Table(t *testing.T) {
+	var buf bytes.Buffer
+	err := printMoveResponse(3, 0, coreformat.Table, &buf, false, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "failure")
+	assert.Contains(t, out, "0")
+}
+
+func TestPrintMoveResponse_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	// printMoveJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
+	err := printMoveResponse(4, 0, coreformat.Json, &buf, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintMoveResponse_UnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := printMoveResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+	assert.Contains(t, err.Error(), "rt move")
+}
+
+// ---------------------------------------------------------------------------
+// printMoveJSON tests
+// ---------------------------------------------------------------------------
+
+func TestPrintMoveJSON_SuccessStatus(t *testing.T) {
+	// No error, no failures → status should be "success".
+	// Output goes to log.Output (stdout); we just verify no error is returned.
+	err := printMoveJSON(3, 0, false, nil)
+	require.NoError(t, err)
+}
+
+func TestPrintMoveJSON_FailureStatus(t *testing.T) {
+	// Has failures → status should be "failure".
+	err := printMoveJSON(2, 1, false, nil)
+	require.NoError(t, err)
+}

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -823,7 +823,11 @@ func TestPrintDirectDownloadTable_WithResults(t *testing.T) {
 		{SourcePath: "repo/b.zip", TargetPath: "/local/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
 	}
 	result := createDirectDownloadResult(t, 2, 0, transfers)
-	defer result.Reader().Close()
+	defer func() {
+		if err := result.Reader().Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printDirectDownloadTable(result, &buf)
@@ -849,7 +853,11 @@ func TestPrintDirectDownloadTable_NoReader_FallsBackToCountsTable(t *testing.T) 
 
 func TestPrintDirectDownloadTable_EmptyReader(t *testing.T) {
 	result := createDirectDownloadResult(t, 0, 0, []clientutils.FileTransferDetails{})
-	defer result.Reader().Close()
+	defer func() {
+		if err := result.Reader().Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printDirectDownloadTable(result, &buf)

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -105,7 +105,11 @@ func TestPrintSearchTable_WithResults(t *testing.T) {
 		{"path": "my-repo/a/c/other.zip", "type": "file", "size": 999, "sha256": "cafebabe"},
 	}
 	reader := createSearchContentReader(t, items)
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Logf("reader.Close() error: %v", err)
+		}
+	}()
 
 	err := printSearchTable(reader)
 	assert.NoError(t, err)
@@ -113,7 +117,11 @@ func TestPrintSearchTable_WithResults(t *testing.T) {
 
 func TestPrintSearchTable_EmptyResults(t *testing.T) {
 	reader := createSearchContentReader(t, nil)
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Logf("reader.Close() error: %v", err)
+		}
+	}()
 
 	err := printSearchTable(reader)
 	assert.NoError(t, err)
@@ -388,7 +396,12 @@ func TestPrintDownloadTable_NoReader_FallsBackToCountsTable(t *testing.T) {
 
 func TestPrintDownloadTable_EmptyReader(t *testing.T) {
 	result := createDownloadResult(t, 0, 0, []clientutils.FileTransferDetails{})
-	defer result.Reader().Close()
+	r := result.Reader()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Logf("reader.Close() error: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printDownloadTable(result, &buf)
@@ -624,7 +637,12 @@ func TestPrintContainerPushTable_WithResults(t *testing.T) {
 		{TargetPath: "myrepo/sha256:ddeeff", RtUrl: "https://myrt.example.com/", Sha256: "ddeeff"},
 	}
 	result := createContainerPushResult(t, 2, 0, transfers)
-	defer result.Reader().Close()
+	r := result.Reader()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Logf("reader.Close() error: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printContainerPushTable(result, &buf)
@@ -650,7 +668,12 @@ func TestPrintContainerPushTable_NoReader_FallsBackToCountsTable(t *testing.T) {
 
 func TestPrintContainerPushTable_EmptyReader(t *testing.T) {
 	result := createContainerPushResult(t, 0, 0, []clientutils.FileTransferDetails{})
-	defer result.Reader().Close()
+	r := result.Reader()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Logf("reader.Close() error: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printContainerPushTable(result, &buf)
@@ -1249,9 +1272,15 @@ func TestPrintSummaryJSONFailureStatus(t *testing.T) {
 }
 
 func TestPrintStatusJSONOK(t *testing.T) {
-	require.NotPanics(t, func() { printStatusJSON(200, "OK") })
+	require.NotPanics(t, func() {
+		err := printStatusJSON(200, "OK")
+		assert.NoError(t, err)
+	})
 }
 
 func TestPrintStatusJSONNoContent(t *testing.T) {
-	require.NotPanics(t, func() { printStatusJSON(204, "No Content") })
+	require.NotPanics(t, func() {
+		err := printStatusJSON(204, "No Content")
+		assert.NoError(t, err)
+	})
 }

--- a/artifactory/cli/cli_test.go
+++ b/artifactory/cli/cli_test.go
@@ -56,7 +56,11 @@ func TestPrintSearchResponse_JSON(t *testing.T) {
 		{"path": "repo/path/file.txt", "type": "file", "size": 1234, "sha256": "abc123"},
 	}
 	reader := createSearchContentReader(t, items)
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	err := printSearchResponse(reader, coreformat.Json)
 	assert.NoError(t, err)
@@ -67,7 +71,11 @@ func TestPrintSearchResponse_Table(t *testing.T) {
 		{"path": "repo/path/file.jar", "type": "file", "size": 5678, "sha256": "deadbeef"},
 	}
 	reader := createSearchContentReader(t, items)
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	err := printSearchResponse(reader, coreformat.Table)
 	assert.NoError(t, err)
@@ -75,7 +83,11 @@ func TestPrintSearchResponse_Table(t *testing.T) {
 
 func TestPrintSearchResponse_UnsupportedFormat(t *testing.T) {
 	reader := createSearchContentReader(t, nil)
-	defer reader.Close()
+	defer func() {
+		if err := reader.Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	err := printSearchResponse(reader, coreformat.Sarif)
 	require.Error(t, err)
@@ -239,7 +251,11 @@ func TestPrintUploadTable_WithResults(t *testing.T) {
 		{SourcePath: "/local/b.zip", TargetPath: "repo/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
 	}
 	result := createUploadResult(t, 2, 0, transfers)
-	defer result.Reader().Close()
+	defer func() {
+		if err := result.Reader().Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printUploadTable(result, &buf)
@@ -266,7 +282,11 @@ func TestPrintUploadTable_NoReader_FallsBackToCountsTable(t *testing.T) {
 
 func TestPrintUploadTable_EmptyReader(t *testing.T) {
 	result := createUploadResult(t, 0, 0, []clientutils.FileTransferDetails{})
-	defer result.Reader().Close()
+	defer func() {
+		if err := result.Reader().Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printUploadTable(result, &buf)
@@ -338,7 +358,11 @@ func TestPrintDownloadTable_WithResults(t *testing.T) {
 		{SourcePath: "repo/b.zip", TargetPath: "/local/b.zip", RtUrl: "https://myrt.example.com/", Sha256: "def456"},
 	}
 	result := createDownloadResult(t, 2, 0, transfers)
-	defer result.Reader().Close()
+	defer func() {
+		if err := result.Reader().Close(); err != nil {
+			t.Logf("failed to close reader: %v", err)
+		}
+	}()
 
 	var buf bytes.Buffer
 	err := printDownloadTable(result, &buf)
@@ -425,12 +449,12 @@ func TestPrintCountsTableZeroCounts(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printMoveResponse tests
+// printCountBasedResponse tests
 // ---------------------------------------------------------------------------
 
-func TestPrintMoveResponse_Table(t *testing.T) {
+func TestPrintCountBasedResponse_Table(t *testing.T) {
 	var buf bytes.Buffer
-	err := printMoveResponse(3, 0, coreformat.Table, &buf, false, nil)
+	err := printCountBasedResponse("move", 3, 0, coreformat.Table, &buf, false, nil)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "success")
@@ -439,79 +463,18 @@ func TestPrintMoveResponse_Table(t *testing.T) {
 	assert.Contains(t, out, "0")
 }
 
-func TestPrintMoveResponse_JSON(t *testing.T) {
+func TestPrintCountBasedResponse_JSON(t *testing.T) {
 	var buf bytes.Buffer
-	// printMoveJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printMoveResponse(4, 0, coreformat.Json, &buf, false, nil)
+	err := printCountBasedResponse("move", 4, 0, coreformat.Json, &buf, false, nil)
 	require.NoError(t, err)
 }
 
-func TestPrintMoveResponse_UnsupportedFormat(t *testing.T) {
+func TestPrintCountBasedResponse_UnsupportedFormat(t *testing.T) {
 	var buf bytes.Buffer
-	err := printMoveResponse(1, 0, coreformat.Sarif, &buf, false, nil)
+	err := printCountBasedResponse("move", 1, 0, coreformat.Sarif, &buf, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 	assert.Contains(t, err.Error(), "rt move")
-}
-
-// ---------------------------------------------------------------------------
-// printCopyResponse tests
-// ---------------------------------------------------------------------------
-
-func TestPrintCopyResponse_Table(t *testing.T) {
-	var buf bytes.Buffer
-	err := printCopyResponse(3, 0, coreformat.Table, &buf, false, nil)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "3")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "0")
-}
-
-func TestPrintCopyResponse_JSON(t *testing.T) {
-	var buf bytes.Buffer
-	// printCopyJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printCopyResponse(4, 0, coreformat.Json, &buf, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintCopyResponse_UnsupportedFormat(t *testing.T) {
-	var buf bytes.Buffer
-	err := printCopyResponse(1, 0, coreformat.Sarif, &buf, false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "rt copy")
-}
-
-// ---------------------------------------------------------------------------
-// printDeleteResponse tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeleteResponse_Table(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeleteResponse(3, 0, coreformat.Table, &buf, false, nil)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "3")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "0")
-}
-
-func TestPrintDeleteResponse_JSON(t *testing.T) {
-	var buf bytes.Buffer
-	// printDeleteJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printDeleteResponse(4, 0, coreformat.Json, &buf, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintDeleteResponse_UnsupportedFormat(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeleteResponse(1, 0, coreformat.Sarif, &buf, false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "rt delete")
 }
 
 // ---------------------------------------------------------------------------
@@ -798,98 +761,6 @@ func TestBuildDiscardFormat_XMLRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printSetPropsResponse tests
-// ---------------------------------------------------------------------------
-
-func TestPrintSetPropsResponse_Table(t *testing.T) {
-	var buf bytes.Buffer
-	err := printSetPropsResponse(5, 0, coreformat.Table, &buf, false, nil)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "5")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "0")
-}
-
-func TestPrintSetPropsResponse_JSON(t *testing.T) {
-	var buf bytes.Buffer
-	// printSetPropsJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printSetPropsResponse(4, 0, coreformat.Json, &buf, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintSetPropsResponse_UnsupportedFormat(t *testing.T) {
-	var buf bytes.Buffer
-	err := printSetPropsResponse(1, 0, coreformat.Sarif, &buf, false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "rt set-props")
-}
-
-// ---------------------------------------------------------------------------
-// printDeletePropsResponse tests
-// ---------------------------------------------------------------------------
-
-func TestPrintDeletePropsResponse_Table(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeletePropsResponse(5, 0, coreformat.Table, &buf, false, nil)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "5")
-	assert.Contains(t, out, "0")
-}
-
-func TestPrintDeletePropsResponse_JSON(t *testing.T) {
-	var buf bytes.Buffer
-	// printDeletePropsJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printDeletePropsResponse(4, 0, coreformat.Json, &buf, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintDeletePropsResponse_UnsupportedFormat(t *testing.T) {
-	var buf bytes.Buffer
-	err := printDeletePropsResponse(1, 0, coreformat.Sarif, &buf, false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "rt delete-props")
-}
-
-// ---------------------------------------------------------------------------
-// printBuildAddDependenciesResponse tests
-// ---------------------------------------------------------------------------
-
-func TestPrintBuildAddDependenciesResponse_Table(t *testing.T) {
-	var buf bytes.Buffer
-	err := printBuildAddDependenciesResponse(7, 0, coreformat.Table, &buf, false, nil)
-	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "FIELD")
-	assert.Contains(t, out, "VALUE")
-	assert.Contains(t, out, "success")
-	assert.Contains(t, out, "7")
-	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "0")
-}
-
-func TestPrintBuildAddDependenciesResponse_JSON(t *testing.T) {
-	var buf bytes.Buffer
-	// printBuildAddDependenciesJSON writes to log.Output (stdout), not to buf; we only check no error is returned.
-	err := printBuildAddDependenciesResponse(5, 0, coreformat.Json, &buf, false, nil)
-	require.NoError(t, err)
-}
-
-func TestPrintBuildAddDependenciesResponse_UnsupportedFormat(t *testing.T) {
-	var buf bytes.Buffer
-	err := printBuildAddDependenciesResponse(1, 0, coreformat.Sarif, &buf, false, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported format")
-	assert.Contains(t, err.Error(), "rt build-add-dependencies")
-}
-
-// ---------------------------------------------------------------------------
 // direct-download test helpers
 // ---------------------------------------------------------------------------
 
@@ -1032,7 +903,7 @@ func TestDockerPromoteFormat_XMLRejected(t *testing.T) {
 
 func TestPrintGitLfsCleanResponse_Table(t *testing.T) {
 	var buf bytes.Buffer
-	err := printGitLfsCleanResponse(5, 1, coreformat.Table, &buf, nil)
+	err := printGitLfsCleanResponse(5, 0, coreformat.Table, &buf, nil)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "FIELD")
@@ -1040,7 +911,7 @@ func TestPrintGitLfsCleanResponse_Table(t *testing.T) {
 	assert.Contains(t, out, "success")
 	assert.Contains(t, out, "5")
 	assert.Contains(t, out, "failure")
-	assert.Contains(t, out, "1")
+	assert.Contains(t, out, "0")
 }
 
 func TestPrintGitLfsCleanResponse_JSON(t *testing.T) {
@@ -1146,14 +1017,17 @@ func TestPrintContainerPullJSON_EmptyValues(t *testing.T) {
 
 // sampleNugetDepsTreeJSON returns a minimal solution JSON matching the structure
 // returned by solution.Marshal() — used as test input.
-func sampleNugetDepsTreeJSON(projects []nugetDepsTreeProject) []byte {
+func sampleNugetDepsTreeJSON(t *testing.T, projects []nugetDepsTreeProject) []byte {
 	sol := nugetDepsTreeSolution{Projects: projects}
-	data, _ := json.Marshal(sol)
+	data, err := json.Marshal(sol)
+	if err != nil {
+		t.Logf("failed to marshal nuget deps tree solution: %v", err)
+	}
 	return data
 }
 
 func TestPrintNugetDepsTreeResponse_JSON(t *testing.T) {
-	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+	data := sampleNugetDepsTreeJSON(t, []nugetDepsTreeProject{
 		{Name: "MyProject", Dependencies: map[string]interface{}{"Newtonsoft.Json:13.0.1": nil}},
 	})
 	var buf bytes.Buffer
@@ -1163,7 +1037,7 @@ func TestPrintNugetDepsTreeResponse_JSON(t *testing.T) {
 }
 
 func TestPrintNugetDepsTreeResponse_Table(t *testing.T) {
-	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+	data := sampleNugetDepsTreeJSON(t, []nugetDepsTreeProject{
 		{Name: "MyProject", Dependencies: map[string]interface{}{
 			"Newtonsoft.Json:13.0.1": nil,
 			"Serilog:3.0.0":          nil,
@@ -1180,7 +1054,7 @@ func TestPrintNugetDepsTreeResponse_Table(t *testing.T) {
 }
 
 func TestPrintNugetDepsTreeResponse_UnsupportedFormat(t *testing.T) {
-	data := sampleNugetDepsTreeJSON(nil)
+	data := sampleNugetDepsTreeJSON(t, nil)
 	var buf bytes.Buffer
 	err := printNugetDepsTreeResponse(data, coreformat.Sarif, &buf)
 	require.Error(t, err)
@@ -1193,7 +1067,7 @@ func TestPrintNugetDepsTreeResponse_UnsupportedFormat(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPrintNugetDepsTreeTable_MultipleProjects(t *testing.T) {
-	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+	data := sampleNugetDepsTreeJSON(t, []nugetDepsTreeProject{
 		{Name: "ProjectA", Dependencies: map[string]interface{}{
 			"Newtonsoft.Json:13.0.1": nil,
 			"Serilog:3.0.0":          nil,
@@ -1218,7 +1092,7 @@ func TestPrintNugetDepsTreeTable_MultipleProjects(t *testing.T) {
 }
 
 func TestPrintNugetDepsTreeTable_EmptyProjects(t *testing.T) {
-	data := sampleNugetDepsTreeJSON(nil)
+	data := sampleNugetDepsTreeJSON(t, nil)
 	var buf bytes.Buffer
 	err := printNugetDepsTreeTable(data, &buf)
 	require.NoError(t, err)
@@ -1229,7 +1103,7 @@ func TestPrintNugetDepsTreeTable_EmptyProjects(t *testing.T) {
 }
 
 func TestPrintNugetDepsTreeTable_ProjectWithNoDependencies(t *testing.T) {
-	data := sampleNugetDepsTreeJSON([]nugetDepsTreeProject{
+	data := sampleNugetDepsTreeJSON(t, []nugetDepsTreeProject{
 		{Name: "EmptyProject", Dependencies: map[string]interface{}{}},
 	})
 	var buf bytes.Buffer

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -42,6 +42,9 @@ type BuildPublishCommand struct {
 	// suppressOutput prevents Run() from printing the buildInfoUiUrl JSON to
 	// stdout.  Set this to true when the CLI layer will handle output formatting.
 	suppressOutput bool
+	// collectSha256 causes Run() to store the Sha256Summary even when
+	// detailedSummary is false, so the CLI format layer can include the sha256.
+	collectSha256 bool
 	BuildAddGitCommand
 }
 
@@ -92,6 +95,13 @@ func (bpc *BuildPublishCommand) GetBuildInfoUiUrl() string {
 // stdout.  Use this when the CLI layer will handle output formatting.
 func (bpc *BuildPublishCommand) SetSuppressOutput(suppress bool) *BuildPublishCommand {
 	bpc.suppressOutput = suppress
+	return bpc
+}
+
+// SetCollectSha256 causes Run() to store the Sha256Summary even when
+// detailedSummary is false, so the CLI format layer can include the sha256.
+func (bpc *BuildPublishCommand) SetCollectSha256(collect bool) *BuildPublishCommand {
+	bpc.collectSha256 = collect
 	return bpc
 }
 
@@ -219,7 +229,7 @@ func (bpc *BuildPublishCommand) Run() error {
 		}
 	}
 	summary, err := servicesManager.PublishBuildInfo(buildInfo, bpc.buildConfiguration.GetProject())
-	if bpc.IsDetailedSummary() {
+	if bpc.IsDetailedSummary() || bpc.collectSha256 {
 		bpc.SetSummary(summary)
 	}
 	if err != nil || bpc.config.DryRun {

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -35,6 +35,13 @@ type BuildPublishCommand struct {
 	collectGitInfo     bool
 	collectEnv         bool
 	depExcludeScopes   []string
+	// buildInfoUiUrl holds the Artifactory UI URL of the published build info.
+	// It is populated by Run() and exposed via GetBuildInfoUiUrl() so the CLI
+	// layer can render it when --format is set.
+	buildInfoUiUrl string
+	// suppressOutput prevents Run() from printing the buildInfoUiUrl JSON to
+	// stdout.  Set this to true when the CLI layer will handle output formatting.
+	suppressOutput bool
 	BuildAddGitCommand
 }
 
@@ -73,6 +80,19 @@ func (bpc *BuildPublishCommand) SetDetailedSummary(detailedSummary bool) *BuildP
 
 func (bpc *BuildPublishCommand) IsDetailedSummary() bool {
 	return bpc.detailedSummary
+}
+
+// GetBuildInfoUiUrl returns the Artifactory UI URL for the published build info.
+// This is populated after Run() completes successfully.
+func (bpc *BuildPublishCommand) GetBuildInfoUiUrl() string {
+	return bpc.buildInfoUiUrl
+}
+
+// SetSuppressOutput instructs Run() not to print the buildInfoUiUrl JSON to
+// stdout.  Use this when the CLI layer will handle output formatting.
+func (bpc *BuildPublishCommand) SetSuppressOutput(suppress bool) *BuildPublishCommand {
+	bpc.suppressOutput = suppress
+	return bpc
 }
 
 func (bpc *BuildPublishCommand) CommandName() string {
@@ -230,6 +250,9 @@ func (bpc *BuildPublishCommand) Run() error {
 		return err
 	}
 
+	// Always store the URL so the CLI layer can access it for --format rendering.
+	bpc.buildInfoUiUrl = buildLink
+
 	logMsg := "Build info successfully deployed."
 	if bpc.IsDetailedSummary() {
 		log.Info(logMsg + " Browse it in Artifactory under " + buildLink)
@@ -237,6 +260,9 @@ func (bpc *BuildPublishCommand) Run() error {
 	}
 
 	log.Info(logMsg)
+	if bpc.suppressOutput {
+		return nil
+	}
 	return logJsonOutput(buildLink)
 }
 

--- a/artifactory/commands/buildinfo/publish_test.go
+++ b/artifactory/commands/buildinfo/publish_test.go
@@ -144,6 +144,7 @@ func TestPrintBuildInfoLink(t *testing.T) {
 			nil,
 			"",
 			false,
+			false,
 			BuildAddGitCommand{},
 		}
 		buildPubComService, err := buildPubConf.getBuildInfoUiUrl(linkTypes[i].majorVersion, linkTypes[i].buildTime)

--- a/artifactory/commands/buildinfo/publish_test.go
+++ b/artifactory/commands/buildinfo/publish_test.go
@@ -142,6 +142,8 @@ func TestPrintBuildInfoLink(t *testing.T) {
 			false,
 			false,
 			nil,
+			"",
+			false,
 			BuildAddGitCommand{},
 		}
 		buildPubComService, err := buildPubConf.getBuildInfoUiUrl(linkTypes[i].majorVersion, linkTypes[i].buildTime)

--- a/artifactory/commands/dotnet/nuget.go
+++ b/artifactory/commands/dotnet/nuget.go
@@ -3,7 +3,6 @@ package dotnet
 import (
 	"github.com/jfrog/build-info-go/build/utils/dotnet"
 	"github.com/jfrog/build-info-go/build/utils/dotnet/solution"
-	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"os"
@@ -23,29 +22,31 @@ func (nc *NugetCommand) Run() error {
 	return nc.Exec()
 }
 
-func DependencyTreeCmd() error {
+// DependencyTreeCmd loads the NuGet solution from the current working directory,
+// builds the dependency tree for each project, and returns the marshalled JSON bytes.
+// The caller is responsible for rendering the output.
+func DependencyTreeCmd() ([]byte, error) {
 	workspace, err := os.Getwd()
 	if err != nil {
-		return errorutils.CheckError(err)
+		return nil, errorutils.CheckError(err)
 	}
 
 	sol, err := solution.Load(workspace, "", "", log.Logger)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Create the tree for each project
 	for _, project := range sol.GetProjects() {
 		err = project.CreateDependencyTree(log.Logger)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	// Build the tree.
+	// Build and return the tree JSON.
 	content, err := sol.Marshal()
 	if err != nil {
-		return errorutils.CheckError(err)
+		return nil, errorutils.CheckError(err)
 	}
-	log.Output(clientutils.IndentJson(content))
-	return nil
+	return content, nil
 }

--- a/artifactory/commands/generic/gitlfsclean.go
+++ b/artifactory/commands/generic/gitlfsclean.go
@@ -15,6 +15,8 @@ import (
 type GitLfsCommand struct {
 	GenericCommand
 	configuration *GitLfsCleanConfiguration
+	successCount  int
+	totalCount    int
 }
 
 func NewGitLfsCommand() *GitLfsCommand {
@@ -28,6 +30,13 @@ func (glc *GitLfsCommand) Configuration() *GitLfsCleanConfiguration {
 func (glc *GitLfsCommand) SetConfiguration(configuration *GitLfsCleanConfiguration) *GitLfsCommand {
 	glc.configuration = configuration
 	return glc
+}
+
+// Result returns the operation counts after Run() has completed.
+// successCount is the number of files successfully deleted; totalCount is the total
+// number of unreferenced files that were candidates for deletion.
+func (glc *GitLfsCommand) Result() (successCount, totalCount int) {
+	return glc.successCount, glc.totalCount
 }
 
 func (glc *GitLfsCommand) Run() error {
@@ -55,6 +64,7 @@ func (glc *GitLfsCommand) Run() error {
 	if err != nil || length < 1 {
 		return err
 	}
+	glc.totalCount = length
 
 	if glc.configuration.Quiet {
 		return glc.deleteLfsFilesFromArtifactory(filesToDeleteReader)
@@ -76,7 +86,8 @@ func (glc *GitLfsCommand) deleteLfsFilesFromArtifactory(deleteItems *content.Con
 	if err != nil {
 		return err
 	}
-	_, err = servicesManager.DeleteFiles(deleteItems)
+	deleted, err := servicesManager.DeleteFiles(deleteItems)
+	glc.successCount = deleted
 	if err != nil {
 		return errorutils.CheckError(err)
 	}

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -88,6 +88,7 @@ const (
 	TemplateConsumer       = "template-consumer"
 	ReplicationCreate      = "replication-create"
 	RepoCreate             = "repo-create"
+	RepoUpdate             = "repo-update"
 	RepoDelete             = "repo-delete"
 	ReplicationDelete      = "replication-delete"
 	PermissionTargetDelete = "permission-target-delete"
@@ -405,6 +406,10 @@ const (
 	// Unique repo-create flags
 	repoCreatePrefix = "repo-create-"
 	repoCreateFormat = repoCreatePrefix + Format
+
+	// Unique repo-update flags
+	repoUpdatePrefix = "repo-update-"
+	repoUpdateFormat = repoUpdatePrefix + Format
 
 	// Template user flags
 	vars = "vars"
@@ -854,6 +859,10 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, vars, repoCreateFormat,
 	},
+	RepoUpdate: {
+		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
+		ClientCertKeyPath, vars, repoUpdateFormat,
+	},
 	RepoDelete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, deleteQuiet,
@@ -1169,6 +1178,9 @@ var flagsMap = map[string]components.Flag{
 
 	// RepoCreate specific commands flags
 	repoCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
+
+	// RepoUpdate specific commands flags
+	repoUpdateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	allowInsecureConnections: components.NewBoolFlag(allowInsecureConnections, "Set to true if you wish to configure NuGet sources with unsecured connections. This is recommended for testing purposes only.", components.WithBoolDefaultValueFalse()),
 	npmDetailedSummary:       components.NewBoolFlag(detailedSummary, "Set to true to include a list of the affected files in the command summary.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -264,6 +264,7 @@ const (
 	propsRecursive    = propertiesPrefix + Recursive
 	propsProps        = propertiesPrefix + props
 	propsExcludeProps = propertiesPrefix + excludeProps
+	propsFormat       = propertiesPrefix + Format
 
 	// Unique go publish flags
 	goPublishExclusions = GoPublish + exclusions
@@ -653,7 +654,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		propsRecursive, build, includeDeps, excludeArtifacts, bundle, includeDirs, failNoOp, threads, archiveEntries, propsProps, propsExcludeProps,
-		InsecureTls, retries, retryWaitTime, Project, repoOnly,
+		InsecureTls, retries, retryWaitTime, Project, repoOnly, propsFormat,
 	},
 	BuildPublish: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, buildUrl, bpDryRun,
@@ -1018,6 +1019,7 @@ var flagsMap = map[string]components.Flag{
 	propsProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties are affected.", components.SetMandatoryFalse()),
 	propsExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties are affected.", components.SetMandatoryFalse()),
 	repoOnly:          components.NewBoolFlag(repoOnly, "When true, properties will be applicable only on repository level.", components.WithBoolDefaultValueFalse()),
+	propsFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build Publish and Append specific commands flags
 	buildUrl:          components.NewStringFlag(buildUrl, "Can be used for setting the CI server build URL in the build-info.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -272,6 +272,7 @@ const (
 	buildPublishPrefix = "bp-"
 	bpDryRun           = buildPublishPrefix + dryRun
 	bpDetailedSummary  = buildPublishPrefix + detailedSummary
+	bpFormat           = buildPublishPrefix + Format
 	envInclude         = "env-include"
 	envExclude         = "env-exclude"
 	buildUrl           = "build-url"
@@ -650,7 +651,7 @@ var commandFlags = map[string][]string{
 	},
 	BuildPublish: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, buildUrl, bpDryRun,
-		envInclude, envExclude, InsecureTls, Project, bpDetailedSummary, bpOverwrite, collectEnv, collectGitInfo, gitConfigFilePath, dotGitPath, depExclude,
+		envInclude, envExclude, InsecureTls, Project, bpDetailedSummary, bpOverwrite, collectEnv, collectGitInfo, gitConfigFilePath, dotGitPath, depExclude, bpFormat,
 	},
 	BuildAppend: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, buildUrl, bpDryRun,
@@ -990,6 +991,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Build-publish specific command flags
+	bpFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Search specific commands flags
 	searchFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -447,6 +447,10 @@ const (
 	pingPrefix = "ping-"
 	pingFormat = pingPrefix + Format
 
+	// Unique container-push flags
+	containerPushPrefix = "container-push-"
+	containerPushFormat = containerPushPrefix + Format
+
 	// Unique offline-update flags
 	target = "target"
 
@@ -726,7 +730,7 @@ var commandFlags = map[string][]string{
 	},
 	ContainerPush: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId, skipLogin, threads, Project, detailedSummary, validateSha,
+		serverId, skipLogin, threads, Project, detailedSummary, validateSha, containerPushFormat,
 	},
 	ContainerPull: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
@@ -991,6 +995,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Container-push specific command flags
+	containerPushFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build-publish specific command flags
 	bpFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -209,6 +209,7 @@ const (
 	deb               = "deb"
 	symlinks          = "symlinks"
 	uploadAnt         = uploadPrefix + antFlag
+	uploadFormat      = uploadPrefix + Format
 
 	// Unique download flags
 	downloadPrefix       = "download-"
@@ -596,7 +597,7 @@ var commandFlags = map[string][]string{
 		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, retries, retryWaitTime, dryRun, uploadExplode, symlinks, includeDirs,
 		failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
-		uploadAnt, uploadArchive, uploadMinSplit, uploadSplitCount, chunkSize,
+		uploadAnt, uploadArchive, uploadMinSplit, uploadSplitCount, chunkSize, uploadFormat,
 	},
 	Download: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -973,6 +974,9 @@ var flagsMap = map[string]components.Flag{
 	deleteQuiet:        components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
 	deleteProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be deleted.", components.SetMandatoryFalse()),
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
+
+	// Upload specific command flags
+	uploadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -223,6 +223,7 @@ const (
 	downloadSplitCount   = downloadPrefix + SplitCount
 	validateSymlinks     = "validate-symlinks"
 	skipChecksum         = "skip-checksum"
+	downloadFormat       = downloadPrefix + Format
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -605,7 +606,7 @@ var commandFlags = map[string][]string{
 		sortOrder, limit, offset, downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, downloadMinSplit, downloadSplitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, bypassArchiveInspection, validateSymlinks, bundle, publicGpgKey, includeDirs,
 		downloadProps, downloadExcludeProps, failNoOp, threads, archiveEntries, downloadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
-		skipChecksum,
+		skipChecksum, downloadFormat,
 	},
 	DirectDownload: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -977,6 +978,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Upload specific command flags
 	uploadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Download specific command flags
+	downloadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -247,6 +247,7 @@ const (
 	deleteProps        = deletePrefix + props
 	deleteExcludeProps = deletePrefix + excludeProps
 	deleteQuiet        = deletePrefix + quiet
+	deleteFormat       = deletePrefix + Format
 
 	// Unique search flags
 	searchInclude      = "include"
@@ -633,7 +634,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		deleteRecursive, dryRun, build, includeDeps, excludeArtifacts, deleteQuiet, deleteProps, deleteExcludeProps, failNoOp, threads, archiveEntries,
-		InsecureTls, retries, retryWaitTime, Project,
+		InsecureTls, retries, retryWaitTime, Project, deleteFormat,
 	},
 	Search: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -979,6 +980,7 @@ var flagsMap = map[string]components.Flag{
 	deleteQuiet:        components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
 	deleteProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be deleted.", components.SetMandatoryFalse()),
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
+	deleteFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Upload specific command flags
 	uploadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -314,6 +314,7 @@ const (
 	// Unique build-discard flags
 	buildDiscardPrefix = "bdi-"
 	bdiAsync           = buildDiscardPrefix + Async
+	bdiFormat          = buildDiscardPrefix + Format
 	maxDays            = "max-days"
 	maxBuilds          = "max-builds"
 	excludeBuilds      = "exclude-builds"
@@ -688,7 +689,7 @@ var commandFlags = map[string][]string{
 	},
 	BuildDiscard: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, maxDays, maxBuilds,
-		excludeBuilds, deleteArtifacts, bdiAsync, InsecureTls, Project,
+		excludeBuilds, deleteArtifacts, bdiAsync, InsecureTls, Project, bdiFormat,
 	},
 	GitLfsClean: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, refs, glcRepo, glcDryRun,
@@ -1061,6 +1062,7 @@ var flagsMap = map[string]components.Flag{
 	excludeBuilds:   components.NewStringFlag(excludeBuilds, "List of comma-separated(,) build numbers in the form of \"value1,value2,...\", that should not be removed from Artifactory.", components.SetMandatoryFalse()),
 	deleteArtifacts: components.NewBoolFlag(deleteArtifacts, "If set to true, automatically removes build artifacts stored in Artifactory.", components.WithBoolDefaultValueFalse()),
 	bdiAsync:        components.NewBoolFlag(Async, "If set to true, build discard will run asynchronously and will not wait for response.", components.WithBoolDefaultValueFalse()),
+	bdiFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	// GitLfsClean specific commands flags
 	refs:      components.NewStringFlag(refs, "[Default: refs/remotes/*] List of comma-separated(,) Git references in the form of \"ref1,ref2,...\" which should be preserved.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -302,6 +302,7 @@ const (
 	buildPromotePrefix  = "bpr-"
 	bprDryRun           = buildPromotePrefix + dryRun
 	bprProps            = buildPromotePrefix + props
+	bprFormat           = buildPromotePrefix + Format
 	comment             = "comment"
 	sourceRepo          = "source-repo"
 	includeDependencies = "include-dependencies"
@@ -683,7 +684,7 @@ var commandFlags = map[string][]string{
 	},
 	BuildPromote: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, Status, comment,
-		sourceRepo, includeDependencies, copyFlag, failFast, bprDryRun, bprProps, InsecureTls, Project,
+		sourceRepo, includeDependencies, copyFlag, failFast, bprDryRun, bprProps, InsecureTls, Project, bprFormat,
 	},
 	BuildDiscard: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, maxDays, maxBuilds,
@@ -1052,6 +1053,7 @@ var flagsMap = map[string]components.Flag{
 	failFast:            components.NewBoolFlag(failFast, "[Default: true] If true, fail and abort the operation upon receiving an error.", components.WithBoolDefaultValueFalse()),
 	bprDryRun:           components.NewBoolFlag(dryRun, "If true, promotion is only simulated. The build is not promoted.", components.WithBoolDefaultValueFalse()),
 	bprProps:            components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\" to be attached to the build artifacts.", components.SetMandatoryFalse()),
+	bprFormat:           components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	// BuildDiscard specific commands flags
 	maxDays:         components.NewStringFlag(maxDays, "The maximum number of days to keep builds in Artifactory.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -221,9 +221,10 @@ const (
 	downloadSyncDeletes  = downloadPrefix + syncDeletes
 	downloadMinSplit     = downloadPrefix + MinSplit
 	downloadSplitCount   = downloadPrefix + SplitCount
-	validateSymlinks     = "validate-symlinks"
-	skipChecksum         = "skip-checksum"
-	downloadFormat       = downloadPrefix + Format
+	validateSymlinks      = "validate-symlinks"
+	skipChecksum          = "skip-checksum"
+	downloadFormat        = downloadPrefix + Format
+	directDownloadFormat  = "direct-download-" + Format
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -625,7 +626,7 @@ var commandFlags = map[string][]string{
 		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, exclusions,
 		downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, downloadMinSplit, downloadSplitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, threads, downloadSyncDeletes, syncDeletesQuiet, skipChecksum, failNoOp, detailedSummary, Project,
-		bypassArchiveInspection, validateSymlinks, InsecureTls, bundle,
+		bypassArchiveInspection, validateSymlinks, InsecureTls, bundle, directDownloadFormat,
 	},
 	Move: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -996,6 +997,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Download specific command flags
 	downloadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Direct-download specific command flags
+	directDownloadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -437,6 +437,10 @@ const (
 	maxWaitMinutes = "max-wait-minutes"
 	CreateRepo     = "create-repo"
 
+	// Unique ping flags
+	pingPrefix = "ping-"
+	pingFormat = pingPrefix + Format
+
 	// Unique offline-update flags
 	target = "target"
 
@@ -776,7 +780,7 @@ var commandFlags = map[string][]string{
 	},
 	Ping: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, InsecureTls,
+		ClientCertKeyPath, InsecureTls, pingFormat,
 	},
 	RtCurl: {
 		serverId,
@@ -970,8 +974,11 @@ var flagsMap = map[string]components.Flag{
 	deleteProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be deleted.", components.SetMandatoryFalse()),
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
 
+	// Ping specific command flags
+	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
 	// Search specific commands flags
-	searchFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+	searchFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 	searchRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to search artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	count:              components.NewBoolFlag(count, "Set to true to display only the total of files or folders found.", components.WithBoolDefaultValueFalse()),
 	searchProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be returned.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -292,6 +292,7 @@ const (
 	badRegexp    = badPrefix + regexpFlag
 	badFromRt    = badPrefix + fromRt
 	badModule    = badPrefix + module
+	badFormat    = badPrefix + Format
 
 	// Unique build-add-git flags
 	configFlag = "config"
@@ -665,7 +666,7 @@ var commandFlags = map[string][]string{
 		envInclude, envExclude, InsecureTls, Project,
 	},
 	BuildAddDependencies: {
-		specFlag, specVars, uploadExclusions, badRecursive, badRegexp, badDryRun, Project, badFromRt, serverId, badModule,
+		specFlag, specVars, uploadExclusions, badRecursive, badRegexp, badDryRun, Project, badFromRt, serverId, badModule, badFormat,
 	},
 	BuildAddGit: {
 		configFlag, serverId, Project,
@@ -1040,6 +1041,7 @@ var flagsMap = map[string]components.Flag{
 	badDryRun:    components.NewBoolFlag(dryRun, "Set to true to only get a summary of the dependencies that will be added to the build info.", components.WithBoolDefaultValueFalse()),
 	badFromRt:    components.NewBoolFlag(fromRt, "Set true to search the files in Artifactory, rather than on the local file system. The --regexp option is not supported when --from-rt is set to true.", components.WithBoolDefaultValueFalse()),
 	badModule:    components.NewStringFlag(module, "Optional module name in the build-info for adding the dependency.", components.SetMandatoryFalse()),
+	badFormat:    components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build Add Git specific commands flags
 	configFlag: components.NewStringFlag(configFlag, "Path to a configuration file.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -231,6 +231,7 @@ const (
 	moveFlat         = movePrefix + flat
 	moveProps        = movePrefix + props
 	moveExcludeProps = movePrefix + excludeProps
+	moveFormat       = movePrefix + Format
 
 	// Unique copy flags
 	copyPrefix       = "copy-"
@@ -619,7 +620,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset, moveRecursive,
 		moveFlat, dryRun, build, includeDeps, excludeArtifacts, moveProps, moveExcludeProps, failNoOp, threads, archiveEntries,
-		InsecureTls, retries, retryWaitTime, Project,
+		InsecureTls, retries, retryWaitTime, Project, moveFormat,
 	},
 	Copy: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -963,6 +964,7 @@ var flagsMap = map[string]components.Flag{
 	moveFlat:         components.NewBoolFlag(flat, "If set to false, files are moved according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	moveProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be moved.", components.SetMandatoryFalse()),
 	moveExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be moved.", components.SetMandatoryFalse()),
+	moveFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Copy specific commands flags
 	copyRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to copy artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -82,8 +82,9 @@ const (
 	PipenvInstall          = "pipenv-install"
 	PoetryConfig           = "poetry-config"
 	Poetry                 = "poetry"
-	Ping                   = "ping"
-	RtCurl                 = "rt-curl"
+	Ping           = "ping"
+	NugetDepsTree  = "nuget-deps-tree"
+	RtCurl         = "rt-curl"
 	TemplateConsumer       = "template-consumer"
 	RepoDelete             = "repo-delete"
 	ReplicationDelete      = "replication-delete"
@@ -454,6 +455,10 @@ const (
 	pingPrefix = "ping-"
 	pingFormat = pingPrefix + Format
 
+	// Unique nuget-deps-tree flags
+	nugetDepsTreePrefix = "nuget-deps-tree-"
+	nugetDepsTreeFormat = nugetDepsTreePrefix + Format
+
 	// Unique container-push flags
 	containerPushPrefix = "container-push-"
 	containerPushFormat = containerPushPrefix + Format
@@ -803,6 +808,9 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, InsecureTls, pingFormat,
 	},
+	NugetDepsTree: {
+		nugetDepsTreeFormat,
+	},
 	RtCurl: {
 		serverId,
 	},
@@ -1009,6 +1017,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Ping specific command flags
 	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Nuget-deps-tree specific command flags
+	nugetDepsTreeFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Container-push specific command flags
 	containerPushFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/cmddefs"
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
+	"github.com/jfrog/jfrog-cli-core/v2/common/format"
 	pluginsCommon "github.com/jfrog/jfrog-cli-core/v2/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 )
@@ -251,6 +252,7 @@ const (
 	searchExcludeProps = searchPrefix + excludeProps
 	count              = "count"
 	searchTransitive   = searchPrefix + transitive
+	searchFormat       = searchPrefix + Format
 
 	// Unique properties flags
 	propertiesPrefix  = "props-"
@@ -629,7 +631,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		searchRecursive, build, includeDeps, excludeArtifacts, count, bundle, includeDirs, searchProps, searchExcludeProps, failNoOp, archiveEntries,
-		InsecureTls, searchTransitive, retries, retryWaitTime, Project, searchInclude,
+		InsecureTls, searchTransitive, retries, retryWaitTime, Project, searchInclude, searchFormat,
 	},
 	Properties: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -969,6 +971,7 @@ var flagsMap = map[string]components.Flag{
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
 
 	// Search specific commands flags
+	searchFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 	searchRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to search artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	count:              components.NewBoolFlag(count, "Set to true to display only the total of files or folders found.", components.WithBoolDefaultValueFalse()),
 	searchProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be returned.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -326,11 +326,12 @@ const (
 	repo = "repo"
 
 	// Unique git-lfs-clean flags
-	glcPrefix = "glc-"
-	glcDryRun = glcPrefix + dryRun
-	glcQuiet  = glcPrefix + quiet
-	glcRepo   = glcPrefix + repo
-	refs      = "refs"
+	glcPrefix  = "glc-"
+	glcDryRun  = glcPrefix + dryRun
+	glcQuiet   = glcPrefix + quiet
+	glcRepo    = glcPrefix + repo
+	glcFormat  = glcPrefix + Format
+	refs       = "refs"
 
 	// Build tool config flags
 	global          = "global"
@@ -697,7 +698,7 @@ var commandFlags = map[string][]string{
 	},
 	GitLfsClean: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, refs, glcRepo, glcDryRun,
-		glcQuiet, InsecureTls, retries, retryWaitTime,
+		glcQuiet, InsecureTls, retries, retryWaitTime, glcFormat,
 	},
 	CocoapodsConfig: {
 		global, serverIdResolve, repoResolve,
@@ -1078,6 +1079,7 @@ var flagsMap = map[string]components.Flag{
 	glcRepo:   components.NewStringFlag(repo, "Local Git LFS repository which should be cleaned. If omitted, this is detected from the Git repository.", components.SetMandatoryFalse()),
 	glcDryRun: components.NewBoolFlag(dryRun, "If true, cleanup is only simulated. No files are actually deleted.", components.WithBoolDefaultValueFalse()),
 	glcQuiet:  components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
+	glcFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Config commands flags
 	global:          components.NewBoolFlag(global, "Set to true if you'd like the configuration to be global (for all projects). Specific projects can override the global configuration.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -86,6 +86,7 @@ const (
 	NugetDepsTree  = "nuget-deps-tree"
 	RtCurl         = "rt-curl"
 	TemplateConsumer       = "template-consumer"
+	ReplicationCreate      = "replication-create"
 	RepoDelete             = "repo-delete"
 	ReplicationDelete      = "replication-delete"
 	PermissionTargetDelete = "permission-target-delete"
@@ -395,6 +396,10 @@ const (
 	namespace = "namespace"
 	provider  = "provider"
 	Tag       = "tag"
+
+	// Unique replication-create flags
+	replicationCreatePrefix = "replication-create-"
+	replicationCreateFormat = replicationCreatePrefix + Format
 
 	// Template user flags
 	vars = "vars"
@@ -836,6 +841,10 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, vars,
 	},
+	ReplicationCreate: {
+		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
+		ClientCertKeyPath, vars, replicationCreateFormat,
+	},
 	RepoDelete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, deleteQuiet,
@@ -1145,6 +1154,9 @@ var flagsMap = map[string]components.Flag{
 	targetTag:         components.NewStringFlag("target-tag", "The target tag to assign the image after promotion.", components.SetMandatoryFalse()),
 	dockerPromoteCopy: components.NewBoolFlag("copy", "If set true, the Docker image is copied to the target repository, otherwise it is moved.", components.WithBoolDefaultValueFalse()),
 	dprFormat:         components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
+
+	// ReplicationCreate specific commands flags
+	replicationCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	allowInsecureConnections: components.NewBoolFlag(allowInsecureConnections, "Set to true if you wish to configure NuGet sources with unsecured connections. This is recommended for testing purposes only.", components.WithBoolDefaultValueFalse()),
 	npmDetailedSummary:       components.NewBoolFlag(detailedSummary, "Set to true to include a list of the affected files in the command summary.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -366,6 +366,7 @@ const (
 	sourceTag           = "source-tag"
 	targetTag           = "target-tag"
 	dockerPromoteCopy   = dockerPromotePrefix + Copy
+	dprFormat           = dockerPromotePrefix + Format
 
 	// Unique build docker create
 	imageFile = "image-file"
@@ -731,7 +732,7 @@ var commandFlags = map[string][]string{
 	},
 	DockerPromote: {
 		targetDockerImage, sourceTag, targetTag, dockerPromoteCopy, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId,
+		serverId, dprFormat,
 	},
 	ContainerPush: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
@@ -1123,6 +1124,7 @@ var flagsMap = map[string]components.Flag{
 	sourceTag:         components.NewStringFlag("source-tag", "The tag name to promote.", components.SetMandatoryFalse()),
 	targetTag:         components.NewStringFlag("target-tag", "The target tag to assign the image after promotion.", components.SetMandatoryFalse()),
 	dockerPromoteCopy: components.NewBoolFlag("copy", "If set true, the Docker image is copied to the target repository, otherwise it is moved.", components.WithBoolDefaultValueFalse()),
+	dprFormat:         components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	allowInsecureConnections: components.NewBoolFlag(allowInsecureConnections, "Set to true if you wish to configure NuGet sources with unsecured connections. This is recommended for testing purposes only.", components.WithBoolDefaultValueFalse()),
 	npmDetailedSummary:       components.NewBoolFlag(detailedSummary, "Set to true to include a list of the affected files in the command summary.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -87,6 +87,7 @@ const (
 	RtCurl         = "rt-curl"
 	TemplateConsumer       = "template-consumer"
 	ReplicationCreate      = "replication-create"
+	RepoCreate             = "repo-create"
 	RepoDelete             = "repo-delete"
 	ReplicationDelete      = "replication-delete"
 	PermissionTargetDelete = "permission-target-delete"
@@ -400,6 +401,10 @@ const (
 	// Unique replication-create flags
 	replicationCreatePrefix = "replication-create-"
 	replicationCreateFormat = replicationCreatePrefix + Format
+
+	// Unique repo-create flags
+	repoCreatePrefix = "repo-create-"
+	repoCreateFormat = repoCreatePrefix + Format
 
 	// Template user flags
 	vars = "vars"
@@ -845,6 +850,10 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, vars, replicationCreateFormat,
 	},
+	RepoCreate: {
+		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
+		ClientCertKeyPath, vars, repoCreateFormat,
+	},
 	RepoDelete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, deleteQuiet,
@@ -1157,6 +1166,9 @@ var flagsMap = map[string]components.Flag{
 
 	// ReplicationCreate specific commands flags
 	replicationCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
+
+	// RepoCreate specific commands flags
+	repoCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	allowInsecureConnections: components.NewBoolFlag(allowInsecureConnections, "Set to true if you wish to configure NuGet sources with unsecured connections. This is recommended for testing purposes only.", components.WithBoolDefaultValueFalse()),
 	npmDetailedSummary:       components.NewBoolFlag(detailedSummary, "Set to true to include a list of the affected files in the command summary.", components.WithBoolDefaultValueFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -411,6 +411,9 @@ const (
 	repoUpdatePrefix = "repo-update-"
 	repoUpdateFormat = repoUpdatePrefix + Format
 
+	// Unique template-consumer flags
+	templateConsumerFormat = TemplateConsumer + "-" + Format
+
 	// Template user flags
 	vars = "vars"
 
@@ -849,7 +852,7 @@ var commandFlags = map[string][]string{
 	},
 	TemplateConsumer: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, vars,
+		ClientCertKeyPath, vars, templateConsumerFormat,
 	},
 	ReplicationCreate: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -1199,7 +1202,8 @@ var flagsMap = map[string]components.Flag{
 	ExcludeProjects: components.NewStringFlag(ExcludeProjects, "List of semicolon-separated(;) JFrog Projects to exclude from the transfer. You can use wildcards to specify patterns for the project keys.", components.SetMandatoryFalse()),
 
 	// TemplateConsumer specific commands flags
-	vars: components.NewStringFlag(vars, "List of semicolon-separated(;) variables in the form of \"key1=value1;key2=value2;...\" (wrapped by quotes) to be replaced in the template. In the template, the variables should be used as follows: ${key1}.", components.SetMandatoryFalse()),
+	vars:                   components.NewStringFlag(vars, "List of semicolon-separated(;) variables in the form of \"key1=value1;key2=value2;...\" (wrapped by quotes) to be replaced in the template. In the template, the variables should be used as follows: ${key1}.", components.SetMandatoryFalse()),
+	templateConsumerFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	// ArtifactoryAccessTokenCreate specific commands flags
 	rtAtcGroups:      components.NewStringFlag(Groups, "[Default: *] A list of comma-separated(,) groups for the access token to be associated with. Specify * to indicate that this is a 'user-scoped token', i.e., the token provides the same access privileges that the current subject has, and is therefore evaluated dynamically. ", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -458,6 +458,10 @@ const (
 	containerPushPrefix = "container-push-"
 	containerPushFormat = containerPushPrefix + Format
 
+	// Unique container-pull flags
+	containerPullPrefix = "container-pull-"
+	containerPullFormat = containerPullPrefix + Format
+
 	// Unique offline-update flags
 	target = "target"
 
@@ -741,7 +745,7 @@ var commandFlags = map[string][]string{
 	},
 	ContainerPull: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId, skipLogin, Project,
+		serverId, skipLogin, Project, containerPullFormat,
 	},
 	NpmConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
@@ -1008,6 +1012,9 @@ var flagsMap = map[string]components.Flag{
 
 	// Container-push specific command flags
 	containerPushFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
+
+	// Container-pull specific command flags
+	containerPullFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build-publish specific command flags
 	bpFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/cmddefs"
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
-	"github.com/jfrog/jfrog-cli-core/v2/common/format"
 	pluginsCommon "github.com/jfrog/jfrog-cli-core/v2/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 )
@@ -213,7 +212,6 @@ const (
 	deb               = "deb"
 	symlinks          = "symlinks"
 	uploadAnt         = uploadPrefix + antFlag
-	uploadFormat      = uploadPrefix + Format
 
 	// Unique download flags
 	downloadPrefix       = "download-"
@@ -227,8 +225,6 @@ const (
 	downloadSplitCount   = downloadPrefix + SplitCount
 	validateSymlinks      = "validate-symlinks"
 	skipChecksum          = "skip-checksum"
-	downloadFormat        = downloadPrefix + Format
-	directDownloadFormat  = "direct-download-" + Format
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -236,7 +232,6 @@ const (
 	moveFlat         = movePrefix + flat
 	moveProps        = movePrefix + props
 	moveExcludeProps = movePrefix + excludeProps
-	moveFormat       = movePrefix + Format
 
 	// Unique copy flags
 	copyPrefix       = "copy-"
@@ -244,7 +239,6 @@ const (
 	copyFlat         = copyPrefix + flat
 	copyProps        = copyPrefix + props
 	copyExcludeProps = copyPrefix + excludeProps
-	copyFormat       = copyPrefix + Format
 
 	// Unique delete flags
 	deletePrefix       = "delete-"
@@ -252,7 +246,6 @@ const (
 	deleteProps        = deletePrefix + props
 	deleteExcludeProps = deletePrefix + excludeProps
 	deleteQuiet        = deletePrefix + quiet
-	deleteFormat       = deletePrefix + Format
 
 	// Unique search flags
 	searchInclude      = "include"
@@ -262,14 +255,12 @@ const (
 	searchExcludeProps = searchPrefix + excludeProps
 	count              = "count"
 	searchTransitive   = searchPrefix + transitive
-	searchFormat       = searchPrefix + Format
 
 	// Unique properties flags
 	propertiesPrefix  = "props-"
 	propsRecursive    = propertiesPrefix + Recursive
 	propsProps        = propertiesPrefix + props
 	propsExcludeProps = propertiesPrefix + excludeProps
-	propsFormat       = propertiesPrefix + Format
 
 	// Unique go publish flags
 	goPublishExclusions = GoPublish + exclusions
@@ -278,7 +269,6 @@ const (
 	buildPublishPrefix = "bp-"
 	bpDryRun           = buildPublishPrefix + dryRun
 	bpDetailedSummary  = buildPublishPrefix + detailedSummary
-	bpFormat           = buildPublishPrefix + Format
 	envInclude         = "env-include"
 	envExclude         = "env-exclude"
 	buildUrl           = "build-url"
@@ -297,7 +287,6 @@ const (
 	badRegexp    = badPrefix + regexpFlag
 	badFromRt    = badPrefix + fromRt
 	badModule    = badPrefix + module
-	badFormat    = badPrefix + Format
 
 	// Unique build-add-git flags
 	configFlag = "config"
@@ -309,7 +298,6 @@ const (
 	buildPromotePrefix  = "bpr-"
 	bprDryRun           = buildPromotePrefix + dryRun
 	bprProps            = buildPromotePrefix + props
-	bprFormat           = buildPromotePrefix + Format
 	comment             = "comment"
 	sourceRepo          = "source-repo"
 	includeDependencies = "include-dependencies"
@@ -321,7 +309,6 @@ const (
 	// Unique build-discard flags
 	buildDiscardPrefix = "bdi-"
 	bdiAsync           = buildDiscardPrefix + Async
-	bdiFormat          = buildDiscardPrefix + Format
 	maxDays            = "max-days"
 	maxBuilds          = "max-builds"
 	excludeBuilds      = "exclude-builds"
@@ -334,7 +321,6 @@ const (
 	glcDryRun  = glcPrefix + dryRun
 	glcQuiet   = glcPrefix + quiet
 	glcRepo    = glcPrefix + repo
-	glcFormat  = glcPrefix + Format
 	refs       = "refs"
 
 	// Build tool config flags
@@ -371,7 +357,6 @@ const (
 	sourceTag           = "source-tag"
 	targetTag           = "target-tag"
 	dockerPromoteCopy   = dockerPromotePrefix + Copy
-	dprFormat           = dockerPromotePrefix + Format
 
 	// Unique build docker create
 	imageFile = "image-file"
@@ -398,21 +383,6 @@ const (
 	namespace = "namespace"
 	provider  = "provider"
 	Tag       = "tag"
-
-	// Unique replication-create flags
-	replicationCreatePrefix = "replication-create-"
-	replicationCreateFormat = replicationCreatePrefix + Format
-
-	// Unique repo-create flags
-	repoCreatePrefix = "repo-create-"
-	repoCreateFormat = repoCreatePrefix + Format
-
-	// Unique repo-update flags
-	repoUpdatePrefix = "repo-update-"
-	repoUpdateFormat = repoUpdatePrefix + Format
-
-	// Unique template-consumer flags
-	templateConsumerFormat = TemplateConsumer + "-" + Format
 
 	// Template user flags
 	vars = "vars"
@@ -468,22 +438,6 @@ const (
 	sync           = "sync"
 	maxWaitMinutes = "max-wait-minutes"
 	CreateRepo     = "create-repo"
-
-	// Unique ping flags
-	pingPrefix = "ping-"
-	pingFormat = pingPrefix + Format
-
-	// Unique nuget-deps-tree flags
-	nugetDepsTreePrefix = "nuget-deps-tree-"
-	nugetDepsTreeFormat = nugetDepsTreePrefix + Format
-
-	// Unique container-push flags
-	containerPushPrefix = "container-push-"
-	containerPushFormat = containerPushPrefix + Format
-
-	// Unique container-pull flags
-	containerPullPrefix = "container-pull-"
-	containerPullFormat = containerPullPrefix + Format
 
 	// Unique offline-update flags
 	target = "target"
@@ -640,7 +594,7 @@ var commandFlags = map[string][]string{
 		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, retries, retryWaitTime, dryRun, uploadExplode, symlinks, includeDirs,
 		failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
-		uploadAnt, uploadArchive, uploadMinSplit, uploadSplitCount, chunkSize, uploadFormat,
+		uploadAnt, uploadArchive, uploadMinSplit, uploadSplitCount, chunkSize,
 	},
 	Download: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -648,55 +602,55 @@ var commandFlags = map[string][]string{
 		sortOrder, limit, offset, downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, downloadMinSplit, downloadSplitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, bypassArchiveInspection, validateSymlinks, bundle, publicGpgKey, includeDirs,
 		downloadProps, downloadExcludeProps, failNoOp, threads, archiveEntries, downloadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
-		skipChecksum, downloadFormat,
+		skipChecksum,
 	},
 	DirectDownload: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, exclusions,
 		downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, downloadMinSplit, downloadSplitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, threads, downloadSyncDeletes, syncDeletesQuiet, skipChecksum, failNoOp, detailedSummary, Project,
-		bypassArchiveInspection, validateSymlinks, InsecureTls, bundle, directDownloadFormat,
+		bypassArchiveInspection, validateSymlinks, InsecureTls, bundle,
 	},
 	Move: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset, moveRecursive,
 		moveFlat, dryRun, build, includeDeps, excludeArtifacts, moveProps, moveExcludeProps, failNoOp, threads, archiveEntries,
-		InsecureTls, retries, retryWaitTime, Project, moveFormat,
+		InsecureTls, retries, retryWaitTime, Project,
 	},
 	Copy: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset, copyRecursive,
 		copyFlat, dryRun, build, includeDeps, excludeArtifacts, bundle, copyProps, copyExcludeProps, failNoOp, threads,
-		archiveEntries, InsecureTls, retries, retryWaitTime, Project, copyFormat,
+		archiveEntries, InsecureTls, retries, retryWaitTime, Project,
 	},
 	Delete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		deleteRecursive, dryRun, build, includeDeps, excludeArtifacts, deleteQuiet, deleteProps, deleteExcludeProps, failNoOp, threads, archiveEntries,
-		InsecureTls, retries, retryWaitTime, Project, deleteFormat,
+		InsecureTls, retries, retryWaitTime, Project,
 	},
 	Search: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		searchRecursive, build, includeDeps, excludeArtifacts, count, bundle, includeDirs, searchProps, searchExcludeProps, failNoOp, archiveEntries,
-		InsecureTls, searchTransitive, retries, retryWaitTime, Project, searchInclude, searchFormat,
+		InsecureTls, searchTransitive, retries, retryWaitTime, Project, searchInclude,
 	},
 	Properties: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset,
 		propsRecursive, build, includeDeps, excludeArtifacts, bundle, includeDirs, failNoOp, threads, archiveEntries, propsProps, propsExcludeProps,
-		InsecureTls, retries, retryWaitTime, Project, repoOnly, propsFormat,
+		InsecureTls, retries, retryWaitTime, Project, repoOnly,
 	},
 	BuildPublish: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, buildUrl, bpDryRun,
-		envInclude, envExclude, InsecureTls, Project, bpDetailedSummary, bpOverwrite, collectEnv, collectGitInfo, gitConfigFilePath, dotGitPath, depExclude, bpFormat,
+		envInclude, envExclude, InsecureTls, Project, bpDetailedSummary, bpOverwrite, collectEnv, collectGitInfo, gitConfigFilePath, dotGitPath, depExclude,
 	},
 	BuildAppend: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, buildUrl, bpDryRun,
 		envInclude, envExclude, InsecureTls, Project,
 	},
 	BuildAddDependencies: {
-		specFlag, specVars, uploadExclusions, badRecursive, badRegexp, badDryRun, Project, badFromRt, serverId, badModule, badFormat,
+		specFlag, specVars, uploadExclusions, badRecursive, badRegexp, badDryRun, Project, badFromRt, serverId, badModule,
 	},
 	BuildAddGit: {
 		configFlag, serverId, Project,
@@ -717,15 +671,15 @@ var commandFlags = map[string][]string{
 	},
 	BuildPromote: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, Status, comment,
-		sourceRepo, includeDependencies, copyFlag, failFast, bprDryRun, bprProps, InsecureTls, Project, bprFormat,
+		sourceRepo, includeDependencies, copyFlag, failFast, bprDryRun, bprProps, InsecureTls, Project,
 	},
 	BuildDiscard: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, maxDays, maxBuilds,
-		excludeBuilds, deleteArtifacts, bdiAsync, InsecureTls, Project, bdiFormat,
+		excludeBuilds, deleteArtifacts, bdiAsync, InsecureTls, Project,
 	},
 	GitLfsClean: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, refs, glcRepo, glcDryRun,
-		glcQuiet, InsecureTls, retries, retryWaitTime, glcFormat,
+		glcQuiet, InsecureTls, retries, retryWaitTime,
 	},
 	CocoapodsConfig: {
 		global, serverIdResolve, repoResolve,
@@ -760,15 +714,15 @@ var commandFlags = map[string][]string{
 	},
 	DockerPromote: {
 		targetDockerImage, sourceTag, targetTag, dockerPromoteCopy, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId, dprFormat,
+		serverId,
 	},
 	ContainerPush: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId, skipLogin, threads, Project, detailedSummary, validateSha, containerPushFormat,
+		serverId, skipLogin, threads, Project, detailedSummary, validateSha,
 	},
 	ContainerPull: {
 		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
-		serverId, skipLogin, Project, containerPullFormat,
+		serverId, skipLogin, Project,
 	},
 	NpmConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
@@ -824,11 +778,9 @@ var commandFlags = map[string][]string{
 	},
 	Ping: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, InsecureTls, pingFormat,
+		ClientCertKeyPath, InsecureTls,
 	},
-	NugetDepsTree: {
-		nugetDepsTreeFormat,
-	},
+	NugetDepsTree: {},
 	RtCurl: {
 		serverId,
 	},
@@ -852,19 +804,19 @@ var commandFlags = map[string][]string{
 	},
 	TemplateConsumer: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, vars, templateConsumerFormat,
+		ClientCertKeyPath, vars,
 	},
 	ReplicationCreate: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, vars, replicationCreateFormat,
+		ClientCertKeyPath, vars,
 	},
 	RepoCreate: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, vars, repoCreateFormat,
+		ClientCertKeyPath, vars,
 	},
 	RepoUpdate: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, vars, repoUpdateFormat,
+		ClientCertKeyPath, vars,
 	},
 	RepoDelete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -1020,48 +972,20 @@ var flagsMap = map[string]components.Flag{
 	moveFlat:         components.NewBoolFlag(flat, "If set to false, files are moved according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	moveProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be moved.", components.SetMandatoryFalse()),
 	moveExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be moved.", components.SetMandatoryFalse()),
-	moveFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Copy specific commands flags
 	copyRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to copy artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	copyFlat:         components.NewBoolFlag(flat, "If set to false, files are copied according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	copyProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be copied.", components.SetMandatoryFalse()),
 	copyExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be copied.", components.SetMandatoryFalse()),
-	copyFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Delete specific commands flags
 	deleteRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to delete artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	deleteQuiet:        components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
 	deleteProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be deleted.", components.SetMandatoryFalse()),
 	deleteExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be deleted.", components.SetMandatoryFalse()),
-	deleteFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Upload specific command flags
-	uploadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Download specific command flags
-	downloadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Direct-download specific command flags
-	directDownloadFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Ping specific command flags
-	pingFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Nuget-deps-tree specific command flags
-	nugetDepsTreeFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Container-push specific command flags
-	containerPushFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Container-pull specific command flags
-	containerPullFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
-
-	// Build-publish specific command flags
-	bpFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Search specific commands flags
-	searchFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 	searchRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to search artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),
 	count:              components.NewBoolFlag(count, "Set to true to display only the total of files or folders found.", components.WithBoolDefaultValueFalse()),
 	searchProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be returned.", components.SetMandatoryFalse()),
@@ -1074,7 +998,6 @@ var flagsMap = map[string]components.Flag{
 	propsProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties are affected.", components.SetMandatoryFalse()),
 	propsExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties are affected.", components.SetMandatoryFalse()),
 	repoOnly:          components.NewBoolFlag(repoOnly, "When true, properties will be applicable only on repository level.", components.WithBoolDefaultValueFalse()),
-	propsFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build Publish and Append specific commands flags
 	buildUrl:          components.NewStringFlag(buildUrl, "Can be used for setting the CI server build URL in the build-info.", components.SetMandatoryFalse()),
@@ -1095,7 +1018,6 @@ var flagsMap = map[string]components.Flag{
 	badDryRun:    components.NewBoolFlag(dryRun, "Set to true to only get a summary of the dependencies that will be added to the build info.", components.WithBoolDefaultValueFalse()),
 	badFromRt:    components.NewBoolFlag(fromRt, "Set true to search the files in Artifactory, rather than on the local file system. The --regexp option is not supported when --from-rt is set to true.", components.WithBoolDefaultValueFalse()),
 	badModule:    components.NewStringFlag(module, "Optional module name in the build-info for adding the dependency.", components.SetMandatoryFalse()),
-	badFormat:    components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Build Add Git specific commands flags
 	configFlag: components.NewStringFlag(configFlag, "Path to a configuration file.", components.SetMandatoryFalse()),
@@ -1112,7 +1034,6 @@ var flagsMap = map[string]components.Flag{
 	failFast:            components.NewBoolFlag(failFast, "[Default: true] If true, fail and abort the operation upon receiving an error.", components.WithBoolDefaultValueFalse()),
 	bprDryRun:           components.NewBoolFlag(dryRun, "If true, promotion is only simulated. The build is not promoted.", components.WithBoolDefaultValueFalse()),
 	bprProps:            components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\" to be attached to the build artifacts.", components.SetMandatoryFalse()),
-	bprFormat:           components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	// BuildDiscard specific commands flags
 	maxDays:         components.NewStringFlag(maxDays, "The maximum number of days to keep builds in Artifactory.", components.SetMandatoryFalse()),
@@ -1120,14 +1041,12 @@ var flagsMap = map[string]components.Flag{
 	excludeBuilds:   components.NewStringFlag(excludeBuilds, "List of comma-separated(,) build numbers in the form of \"value1,value2,...\", that should not be removed from Artifactory.", components.SetMandatoryFalse()),
 	deleteArtifacts: components.NewBoolFlag(deleteArtifacts, "If set to true, automatically removes build artifacts stored in Artifactory.", components.WithBoolDefaultValueFalse()),
 	bdiAsync:        components.NewBoolFlag(Async, "If set to true, build discard will run asynchronously and will not wait for response.", components.WithBoolDefaultValueFalse()),
-	bdiFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	// GitLfsClean specific commands flags
 	refs:      components.NewStringFlag(refs, "[Default: refs/remotes/*] List of comma-separated(,) Git references in the form of \"ref1,ref2,...\" which should be preserved.", components.SetMandatoryFalse()),
 	glcRepo:   components.NewStringFlag(repo, "Local Git LFS repository which should be cleaned. If omitted, this is detected from the Git repository.", components.SetMandatoryFalse()),
 	glcDryRun: components.NewBoolFlag(dryRun, "If true, cleanup is only simulated. No files are actually deleted.", components.WithBoolDefaultValueFalse()),
 	glcQuiet:  components.NewBoolFlag(quiet, "[Default: $CI] Set to true to skip the delete confirmation message.", components.WithBoolDefaultValueFalse()),
-	glcFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Config commands flags
 	global:          components.NewBoolFlag(global, "Set to true if you'd like the configuration to be global (for all projects). Specific projects can override the global configuration.", components.WithBoolDefaultValueFalse()),
@@ -1174,16 +1093,6 @@ var flagsMap = map[string]components.Flag{
 	sourceTag:         components.NewStringFlag("source-tag", "The tag name to promote.", components.SetMandatoryFalse()),
 	targetTag:         components.NewStringFlag("target-tag", "The target tag to assign the image after promotion.", components.SetMandatoryFalse()),
 	dockerPromoteCopy: components.NewBoolFlag("copy", "If set true, the Docker image is copied to the target repository, otherwise it is moved.", components.WithBoolDefaultValueFalse()),
-	dprFormat:         components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
-
-	// ReplicationCreate specific commands flags
-	replicationCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
-
-	// RepoCreate specific commands flags
-	repoCreateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
-
-	// RepoUpdate specific commands flags
-	repoUpdateFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
 
 	allowInsecureConnections: components.NewBoolFlag(allowInsecureConnections, "Set to true if you wish to configure NuGet sources with unsecured connections. This is recommended for testing purposes only.", components.WithBoolDefaultValueFalse()),
 	npmDetailedSummary:       components.NewBoolFlag(detailedSummary, "Set to true to include a list of the affected files in the command summary.", components.WithBoolDefaultValueFalse()),
@@ -1202,8 +1111,7 @@ var flagsMap = map[string]components.Flag{
 	ExcludeProjects: components.NewStringFlag(ExcludeProjects, "List of semicolon-separated(;) JFrog Projects to exclude from the transfer. You can use wildcards to specify patterns for the project keys.", components.SetMandatoryFalse()),
 
 	// TemplateConsumer specific commands flags
-	vars:                   components.NewStringFlag(vars, "List of semicolon-separated(;) variables in the form of \"key1=value1;key2=value2;...\" (wrapped by quotes) to be replaced in the template. In the template, the variables should be used as follows: ${key1}.", components.SetMandatoryFalse()),
-	templateConsumerFormat: components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json}), components.SetMandatoryFalse()),
+	vars: components.NewStringFlag(vars, "List of semicolon-separated(;) variables in the form of \"key1=value1;key2=value2;...\" (wrapped by quotes) to be replaced in the template. In the template, the variables should be used as follows: ${key1}.", components.SetMandatoryFalse()),
 
 	// ArtifactoryAccessTokenCreate specific commands flags
 	rtAtcGroups:      components.NewStringFlag(Groups, "[Default: *] A list of comma-separated(,) groups for the access token to be associated with. Specify * to indicate that this is a 'user-scoped token', i.e., the token provides the same access privileges that the current subject has, and is therefore evaluated dynamically. ", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -239,6 +239,7 @@ const (
 	copyFlat         = copyPrefix + flat
 	copyProps        = copyPrefix + props
 	copyExcludeProps = copyPrefix + excludeProps
+	copyFormat       = copyPrefix + Format
 
 	// Unique delete flags
 	deletePrefix       = "delete-"
@@ -626,7 +627,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
 		ClientCertKeyPath, specFlag, specVars, exclusions, sortBy, sortOrder, limit, offset, copyRecursive,
 		copyFlat, dryRun, build, includeDeps, excludeArtifacts, bundle, copyProps, copyExcludeProps, failNoOp, threads,
-		archiveEntries, InsecureTls, retries, retryWaitTime, Project,
+		archiveEntries, InsecureTls, retries, retryWaitTime, Project, copyFormat,
 	},
 	Delete: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
@@ -971,6 +972,7 @@ var flagsMap = map[string]components.Flag{
 	copyFlat:         components.NewBoolFlag(flat, "If set to false, files are copied according to their file system hierarchy.", components.WithBoolDefaultValueFalse()),
 	copyProps:        components.NewStringFlag(props, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts with these properties will be copied.", components.SetMandatoryFalse()),
 	copyExcludeProps: components.NewStringFlag(excludeProps, "List of semicolon-separated(;) properties in the form of \"key1=value1;key2=value2;...\". Only artifacts without the specified properties will be copied.", components.SetMandatoryFalse()),
+	copyFormat:       components.NewStringFlag(Format, format.GetFormatFlagDescription([]format.OutputFormat{format.Json, format.Table}), components.SetMandatoryFalse()),
 
 	// Delete specific commands flags
 	deleteRecursive:    components.NewBoolFlag(Recursive, "[Default: true] Set to false if you do not wish to delete artifacts inside sub-folders in Artifactory.", components.WithBoolDefaultValueFalse()),

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430091103-6242ecf15d29
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430091103-6242ecf15d29 h1:J5+08rOpv/avgt53jNFZ+j5gU8mllcj7Dcfja5Ewodw=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430091103-6242ecf15d29/go.mod h1:bjAkVD8c2W+jg4whqy10bSXDC/c+Se8/ll/GPp5F/+0=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316 h1:xAl5D+SjLeRH1gCsSHFPpXJeQQBv2HDGqDTDkFOKJ2s=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316/go.mod h1:bjAkVD8c2W+jg4whqy10bSXDC/c+Se8/ll/GPp5F/+0=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260416101832-c47c1246283b h1:45UJJVG/jAA7/q2c/I6wOvKx8wu7EqTD2tEUtktgyug=


### PR DESCRIPTION
## Summary

Adds `--format` flag support across `rt` commands so output can be rendered as `json`, `table`, or the default human-readable text. The flag plumbs through to the framework's shared format machinery rather than each command rolling its own.

## Changes

**Commands with new `--format` support**

- Generic: `search`, `ping`, `upload`, `download`, `move`, `copy`, `delete`, `direct-download`, `set-props`, `delete-props`, `git-lfs-clean`
- Build: `build-publish`, `build-promote`, `build-discard`, `build-add-dependencies`
- Docker / Podman: `docker-promote`, `podman-push`, `podman-pull`
- Repo / Replication: `repo-create`, `repo-update`, `replication-create`
- NuGet: `nuget-deps-tree`

**`build-publish` specifics**

- `BuildPublishCommand` now exposes `GetBuildInfoUiUrl()`, `SetSuppressOutput()`, and `SetCollectSha256()` so the CLI layer can render the UI URL (and sha256) when `--format` is set, without double-printing JSON from `Run()`.

**Tests**

- New `artifactory/cli/cli_test.go` (~1.3k lines) covering format rendering across the affected commands.

---

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.