### PR TITLE
Fix JFrog CLI documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ##  General
 
-**jfrog-cli-artifactory** is a Go module that encompasses some of the Artifactory commands of [JFrog CLI](https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli). This module is an Embedded JFrog CLI Plugin and is referenced as a Go module within the [JFrog CLI codebase](https://github.com/jfrog/jfrog-cli).
+**jfrog-cli-artifactory** is a Go module that encompasses some of the Artifactory commands of [JFrog CLI](https://docs.jfrog.com/artifactory/docs/binaries-management-with-jfrog-artifactory). This module is an Embedded JFrog CLI Plugin and is referenced as a Go module within the [JFrog CLI codebase](https://github.com/jfrog/jfrog-cli).
 
 ## 🫱🏻‍🫲🏼 Contributions
 


### PR DESCRIPTION
Updated the link to the JFrog CLI documentation for accuracy.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
