### PR TITLE
Fix duplicate dependency entries in build-info for jf uv build and publish

### DIFF
--- a/artifactory/commands/python/native_uv.go
+++ b/artifactory/commands/python/native_uv.go
@@ -127,8 +127,10 @@ func (c *NativeUVCommand) Run() error {
 				if biErr := uvGetScriptBuildInfo(scriptPath, c.buildConfiguration, serverDetails); biErr != nil {
 					log.Warn("Failed to collect UV script build info: " + biErr.Error())
 				}
-			} else {
-				// For commands that modify the venv, capture exactly what was installed.
+			} else if c.commandName != "build" {
+				// "build" only creates local dist/ files — nothing is uploaded to Artifactory,
+				// so it must not save a partial build-info. Saving unenriched deps from "build"
+				// would create duplicate dependency entries when merged with a prior "sync" partial.
 				var installed map[string]string
 				if uvModifiesVenv(c.commandName) {
 					installed = uvInstalledPackages()
@@ -711,6 +713,12 @@ func uvGetBuildInfo(workingDir string, buildConfiguration *buildUtils.BuildConfi
 				}
 			}
 		}
+	}
+
+	// publish only records artifacts — deps come from the sync/install partial and
+	// must not be duplicated here without enrichment.
+	if cmdName == "publish" && len(bi.Modules) > 0 {
+		bi.Modules[0].Dependencies = nil
 	}
 
 	switch cmdName {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
## Fix: Duplicate dependency entries in build-info for `jf uv build` and `publish`

Running the full `jf uv` workflow (`sync` → `build` → `publish` → `jf rt bp`) produced duplicate dependency entries in the published build-info, with some entries missing sha1/md5.

Both `jf uv build` and `jf uv publish` were saving partial build-info files containing all dependencies from uv.lock — but without Artifactory AQL enrichment. When `jf rt bp` merged all partials, each dependency appeared multiple times with one copy missing checksums.

### Fix
Two changes to `native_uv.go`:
1. **Skip build-info for `jf uv build`** — `uv build` only creates local dist files and uploads nothing to Artifactory. Its unenriched dep list would duplicate the already-enriched deps from the `sync` partial.

2. **Clear dependencies from the `publish` partial** — `jf uv publish` records artifacts(wheel/tarball paths and checksums). Dependencies are already captured with full sha1/md5 by the `sync` partial. Re-adding them here unenriched causes duplication.

### Result
- Each dependency appears exactly once in the merged build-info
- All dependencies have sha1 + md5 populated (enriched via Artifactory AQL during `sync`)
- Artifacts have correct repo paths and build properties stamped