### PR TITLE
RTECO-1007 - Collect build-info on jf skills publish

### DIFF
--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -844,6 +844,7 @@ var commandFlags = map[string][]string{
 	},
 	SkillsPublish: {
 		url, user, password, accessToken, serverId, repo, version, signingKey, keyAlias, skillsQuiet, skipScan, autoDeleteOnFailure,
+		BuildName, BuildNumber, module,
 	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, installPath, skillsQuiet,

--- a/skills/commands/publish/publish.go
+++ b/skills/commands/publish/publish.go
@@ -101,8 +101,8 @@ func (pc *PublishCommand) SetAutoDeleteOnFailure(autoDelete bool) *PublishComman
 	return pc
 }
 
-func (pc *PublishCommand) SetBuildConfiguration(buildCfg *build.BuildConfiguration) *PublishCommand {
-	pc.buildConfiguration = buildCfg
+func (pc *PublishCommand) SetBuildConfiguration(buildConfig *build.BuildConfiguration) *PublishCommand {
+	pc.buildConfiguration = buildConfig
 	return pc
 }
 
@@ -173,8 +173,16 @@ func (pc *PublishCommand) Run() error {
 		return err
 	}
 
+	collectBuildInfo := false
+	if pc.buildConfiguration != nil {
+		collectBuildInfo, err = pc.buildConfiguration.IsCollectBuildInfo()
+		if err != nil {
+			return err
+		}
+	}
+
 	target := fmt.Sprintf("%s/%s/%s/", pc.repoKey, slug, version)
-	artifactsDetailsReader, err := pc.upload(zipPath, target)
+	artifactsDetailsReader, err := pc.upload(zipPath, target, collectBuildInfo)
 	if err != nil {
 		return fmt.Errorf("upload failed: %w", err)
 	}
@@ -503,23 +511,23 @@ func computeSHA256(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// applyDefaultBuildInfoModule sets the build-info module id from the skill slug when
-// --module is omitted. Otherwise an empty module id is merged using the build name.
-func applyDefaultBuildInfoModule(buildCfg *build.BuildConfiguration, slug string) error {
-	if buildCfg == nil || buildCfg.GetModule() != "" {
+// applyDefaultBuildInfoModule sets the build-info module id from the skill slug
+// when --module is omitted.
+func applyDefaultBuildInfoModule(buildConfig *build.BuildConfiguration, slug string) error {
+	if buildConfig == nil || buildConfig.GetModule() != "" {
 		return nil
 	}
-	toCollect, err := buildCfg.IsCollectBuildInfo()
+	toCollect, err := buildConfig.IsCollectBuildInfo()
 	if err != nil {
 		return err
 	}
 	if toCollect {
-		buildCfg.SetModule(slug)
+		buildConfig.SetModule(slug)
 	}
 	return nil
 }
 
-func (pc *PublishCommand) upload(zipPath, target string) (*content.ContentReader, error) {
+func (pc *PublishCommand) upload(zipPath, target string, collectBuildInfo bool) (*content.ContentReader, error) {
 	serviceManager, err := utils.CreateUploadServiceManager(pc.serverDetails, 1, 3, 0, false, nil)
 	if err != nil {
 		return nil, err
@@ -530,12 +538,10 @@ func (pc *PublishCommand) upload(zipPath, target string) (*content.ContentReader
 	uploadParams.Target = target
 	uploadParams.Flat = true
 
-	toCollect, err := pc.buildConfiguration.IsCollectBuildInfo()
-	if err != nil {
-		return nil, err
-	}
-
-	if toCollect {
+	if collectBuildInfo {
+		if pc.buildConfiguration == nil {
+			return nil, fmt.Errorf("build-info collection requested, but build configuration is nil")
+		}
 		buildProps, err := build.CreateBuildPropsFromConfiguration(pc.buildConfiguration)
 		if err != nil {
 			return nil, err
@@ -675,7 +681,7 @@ func RunPublish(c *components.Context) error {
 		return err
 	}
 
-	buildCfg, err := pluginsCommon.CreateBuildConfigurationWithModule(c)
+	buildConfig, err := pluginsCommon.CreateBuildConfigurationWithModule(c)
 	if err != nil {
 		return err
 	}
@@ -690,7 +696,7 @@ func RunPublish(c *components.Context) error {
 		SetQuiet(quiet).
 		SetSkipScan(c.GetBoolFlagValue("skip-scan")).
 		SetAutoDeleteOnFailure(c.GetBoolFlagValue("auto-delete-on-failure")).
-		SetBuildConfiguration(buildCfg)
+		SetBuildConfiguration(buildConfig)
 
 	return cmd.Run()
 }

--- a/skills/commands/publish/publish.go
+++ b/skills/commands/publish/publish.go
@@ -169,15 +169,14 @@ func (pc *PublishCommand) Run() error {
 		return fmt.Errorf("failed to compute SHA256: %w", err)
 	}
 
-	if err := applyDefaultBuildInfoModule(pc.buildConfiguration, slug); err != nil {
-		return err
-	}
-
 	collectBuildInfo := false
 	if pc.buildConfiguration != nil {
 		collectBuildInfo, err = pc.buildConfiguration.IsCollectBuildInfo()
 		if err != nil {
 			return err
+		}
+		if collectBuildInfo && pc.buildConfiguration.GetModule() == "" {
+			pc.buildConfiguration.SetModule(slug)
 		}
 	}
 
@@ -511,22 +510,6 @@ func computeSHA256(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// applyDefaultBuildInfoModule sets the build-info module id from the skill slug
-// when --module is omitted.
-func applyDefaultBuildInfoModule(buildConfig *build.BuildConfiguration, slug string) error {
-	if buildConfig == nil || buildConfig.GetModule() != "" {
-		return nil
-	}
-	toCollect, err := buildConfig.IsCollectBuildInfo()
-	if err != nil {
-		return err
-	}
-	if toCollect {
-		buildConfig.SetModule(slug)
-	}
-	return nil
-}
-
 func (pc *PublishCommand) upload(zipPath, target string, collectBuildInfo bool) (*content.ContentReader, error) {
 	serviceManager, err := utils.CreateUploadServiceManager(pc.serverDetails, 1, 3, 0, false, nil)
 	if err != nil {
@@ -548,15 +531,15 @@ func (pc *PublishCommand) upload(zipPath, target string, collectBuildInfo bool) 
 		}
 		uploadParams.BuildProps = buildProps
 
-		uploadSummary, err := serviceManager.UploadFilesWithSummary(artifactory.UploadServiceOptions{}, uploadParams)
+		summary, err := serviceManager.UploadFilesWithSummary(artifactory.UploadServiceOptions{}, uploadParams)
 		if err != nil {
 			return nil, err
 		}
-		if uploadSummary != nil {
-			if uploadSummary.TransferDetailsReader != nil {
-				_ = uploadSummary.TransferDetailsReader.Close()
+		if summary != nil {
+			if summary.TransferDetailsReader != nil {
+				_ = summary.TransferDetailsReader.Close()
 			}
-			return uploadSummary.ArtifactsDetailsReader, nil
+			return summary.ArtifactsDetailsReader, nil
 		}
 		return nil, nil
 	}

--- a/skills/commands/publish/publish.go
+++ b/skills/commands/publish/publish.go
@@ -14,13 +14,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/common/build"
+	pluginsCommon "github.com/jfrog/jfrog-cli-core/v2/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-
+	rtServicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -45,6 +49,7 @@ type PublishCommand struct {
 	quiet               bool
 	skipScan            bool
 	autoDeleteOnFailure bool
+	buildConfiguration  *build.BuildConfiguration
 }
 
 func NewPublishCommand() *PublishCommand {
@@ -93,6 +98,11 @@ func (pc *PublishCommand) SetSkipScan(skip bool) *PublishCommand {
 
 func (pc *PublishCommand) SetAutoDeleteOnFailure(autoDelete bool) *PublishCommand {
 	pc.autoDeleteOnFailure = autoDelete
+	return pc
+}
+
+func (pc *PublishCommand) SetBuildConfiguration(buildCfg *build.BuildConfiguration) *PublishCommand {
+	pc.buildConfiguration = buildCfg
 	return pc
 }
 
@@ -159,9 +169,24 @@ func (pc *PublishCommand) Run() error {
 		return fmt.Errorf("failed to compute SHA256: %w", err)
 	}
 
+	if err := applyDefaultBuildInfoModule(pc.buildConfiguration, slug); err != nil {
+		return err
+	}
+
 	target := fmt.Sprintf("%s/%s/%s/", pc.repoKey, slug, version)
-	if err := pc.upload(zipPath, target); err != nil {
+	artifactsDetailsReader, err := pc.upload(zipPath, target)
+	if err != nil {
 		return fmt.Errorf("upload failed: %w", err)
+	}
+	if artifactsDetailsReader != nil {
+		defer func() { _ = artifactsDetailsReader.Close() }()
+		buildArtifacts, err := rtServicesUtils.ConvertArtifactsDetailsToBuildInfoArtifacts(artifactsDetailsReader)
+		if err != nil {
+			return fmt.Errorf("failed to convert artifacts for build-info: %w", err)
+		}
+		if err := build.PopulateBuildArtifactsAsPartials(buildArtifacts, pc.buildConfiguration, entities.Generic); err != nil {
+			return fmt.Errorf("failed to save build-info partials: %w", err)
+		}
 	}
 
 	log.Info("Upload complete. Attaching evidence...")
@@ -478,10 +503,26 @@ func computeSHA256(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func (pc *PublishCommand) upload(zipPath, target string) error {
-	serviceManager, err := utils.CreateUploadServiceManager(pc.serverDetails, 1, 3, 0, false, nil)
+// applyDefaultBuildInfoModule sets the build-info module id from the skill slug when
+// --module is omitted. Otherwise an empty module id is merged using the build name.
+func applyDefaultBuildInfoModule(buildCfg *build.BuildConfiguration, slug string) error {
+	if buildCfg == nil || buildCfg.GetModule() != "" {
+		return nil
+	}
+	toCollect, err := buildCfg.IsCollectBuildInfo()
 	if err != nil {
 		return err
+	}
+	if toCollect {
+		buildCfg.SetModule(slug)
+	}
+	return nil
+}
+
+func (pc *PublishCommand) upload(zipPath, target string) (*content.ContentReader, error) {
+	serviceManager, err := utils.CreateUploadServiceManager(pc.serverDetails, 1, 3, 0, false, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	uploadParams := services.NewUploadParams()
@@ -489,8 +530,33 @@ func (pc *PublishCommand) upload(zipPath, target string) error {
 	uploadParams.Target = target
 	uploadParams.Flat = true
 
+	toCollect, err := pc.buildConfiguration.IsCollectBuildInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if toCollect {
+		buildProps, err := build.CreateBuildPropsFromConfiguration(pc.buildConfiguration)
+		if err != nil {
+			return nil, err
+		}
+		uploadParams.BuildProps = buildProps
+
+		uploadSummary, err := serviceManager.UploadFilesWithSummary(artifactory.UploadServiceOptions{}, uploadParams)
+		if err != nil {
+			return nil, err
+		}
+		if uploadSummary != nil {
+			if uploadSummary.TransferDetailsReader != nil {
+				_ = uploadSummary.TransferDetailsReader.Close()
+			}
+			return uploadSummary.ArtifactsDetailsReader, nil
+		}
+		return nil, nil
+	}
+
 	_, _, err = serviceManager.UploadFiles(artifactory.UploadServiceOptions{}, uploadParams)
-	return err
+	return nil, err
 }
 
 func (pc *PublishCommand) attachEvidence(slug, version, sha256Hex string) {
@@ -609,6 +675,11 @@ func RunPublish(c *components.Context) error {
 		return err
 	}
 
+	buildCfg, err := pluginsCommon.CreateBuildConfigurationWithModule(c)
+	if err != nil {
+		return err
+	}
+
 	cmd := NewPublishCommand().
 		SetServerDetails(serverDetails).
 		SetRepoKey(repoKey).
@@ -618,7 +689,8 @@ func RunPublish(c *components.Context) error {
 		SetKeyAlias(c.GetStringFlagValue("key-alias")).
 		SetQuiet(quiet).
 		SetSkipScan(c.GetBoolFlagValue("skip-scan")).
-		SetAutoDeleteOnFailure(c.GetBoolFlagValue("auto-delete-on-failure"))
+		SetAutoDeleteOnFailure(c.GetBoolFlagValue("auto-delete-on-failure")).
+		SetBuildConfiguration(buildCfg)
 
 	return cmd.Run()
 }

--- a/skills/commands/publish/publish_test.go
+++ b/skills/commands/publish/publish_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -615,4 +616,42 @@ func TestCollectFiles_Sorted(t *testing.T) {
 		assert.True(t, files[i-1].relPath < files[i].relPath,
 			"files should be sorted: %s should come before %s", files[i-1].relPath, files[i].relPath)
 	}
+}
+
+func TestApplyDefaultBuildInfoModule(t *testing.T) {
+	t.Run("nil build configuration", func(t *testing.T) {
+		require.NoError(t, applyDefaultBuildInfoModule(nil, "my-skill"))
+	})
+
+	t.Run("no build-info collection", func(t *testing.T) {
+		buildCfg := build.NewBuildConfiguration("", "", "", "")
+		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
+		assert.Empty(t, buildCfg.GetModule())
+	})
+
+	t.Run("collect from flags leaves module default to slug", func(t *testing.T) {
+		buildCfg := build.NewBuildConfiguration("pipeline", "42", "", "")
+		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
+		assert.Equal(t, "my-skill", buildCfg.GetModule())
+	})
+
+	t.Run("collect from JFROG_CLI_BUILD env when struct fields empty", func(t *testing.T) {
+		t.Setenv("JFROG_CLI_BUILD_NAME", "ci-build")
+		t.Setenv("JFROG_CLI_BUILD_NUMBER", "55")
+		buildCfg := build.NewBuildConfiguration("", "", "", "")
+		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
+		assert.Equal(t, "my-skill", buildCfg.GetModule())
+	})
+
+	t.Run("explicit --module unchanged", func(t *testing.T) {
+		buildCfg := build.NewBuildConfiguration("pipeline", "42", "custom-mod", "")
+		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
+		assert.Equal(t, "custom-mod", buildCfg.GetModule())
+	})
+
+	t.Run("only build name no number", func(t *testing.T) {
+		buildCfg := build.NewBuildConfiguration("pipeline", "", "", "")
+		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
+		assert.Empty(t, buildCfg.GetModule())
+	})
 }

--- a/skills/commands/publish/publish_test.go
+++ b/skills/commands/publish/publish_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -616,42 +615,4 @@ func TestCollectFiles_Sorted(t *testing.T) {
 		assert.True(t, files[i-1].relPath < files[i].relPath,
 			"files should be sorted: %s should come before %s", files[i-1].relPath, files[i].relPath)
 	}
-}
-
-func TestApplyDefaultBuildInfoModule(t *testing.T) {
-	t.Run("nil build configuration", func(t *testing.T) {
-		require.NoError(t, applyDefaultBuildInfoModule(nil, "my-skill"))
-	})
-
-	t.Run("no build-info collection", func(t *testing.T) {
-		buildCfg := build.NewBuildConfiguration("", "", "", "")
-		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
-		assert.Empty(t, buildCfg.GetModule())
-	})
-
-	t.Run("collect from flags leaves module default to slug", func(t *testing.T) {
-		buildCfg := build.NewBuildConfiguration("pipeline", "42", "", "")
-		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
-		assert.Equal(t, "my-skill", buildCfg.GetModule())
-	})
-
-	t.Run("collect from JFROG_CLI_BUILD env when struct fields empty", func(t *testing.T) {
-		t.Setenv("JFROG_CLI_BUILD_NAME", "ci-build")
-		t.Setenv("JFROG_CLI_BUILD_NUMBER", "55")
-		buildCfg := build.NewBuildConfiguration("", "", "", "")
-		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
-		assert.Equal(t, "my-skill", buildCfg.GetModule())
-	})
-
-	t.Run("explicit --module unchanged", func(t *testing.T) {
-		buildCfg := build.NewBuildConfiguration("pipeline", "42", "custom-mod", "")
-		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
-		assert.Equal(t, "custom-mod", buildCfg.GetModule())
-	})
-
-	t.Run("only build name no number", func(t *testing.T) {
-		buildCfg := build.NewBuildConfiguration("pipeline", "", "", "")
-		require.NoError(t, applyDefaultBuildInfoModule(buildCfg, "my-skill"))
-		assert.Empty(t, buildCfg.GetModule())
-	})
 }


### PR DESCRIPTION
### Collect build-info on jf skills publish

- Support --build-name and --build-number (--module optional) on skills publish; honor JFROG_CLI_BUILD_* when flags are unset.
- Record the published skill zip as build-info partials after upload; publish with jf rt build-publish as usual.
- Default module id to the skill name from SKILL.md when --module is omitted.
- Avoided writing tests for BuildConfiguration of --build-name & --build-number, because BuildConfiguration tests for build-info are already covered in jfrog-cli-core

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
