### PR TITLE
RTECO-1048 - Improve skills install command

### DIFF
--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -518,8 +518,9 @@ const (
 	skillsFormat        = "skills-" + Format
 	skipScan            = "skip-scan"
 	autoDeleteOnFailure = "auto-delete-on-failure"
-	agent         		= "agent"
-	projectDir    		= "project-dir"
+	agent               = "agent"
+	projectDir          = "project-dir"
+	skillsGlobal        = "skills-global"
 	skillsLimit         = "skills-" + limit
 	skillsSortBy        = "skills-" + sortBy
 	skillsSortOrder     = "skills-" + sortOrder
@@ -854,7 +855,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, signingKey, keyAlias, skillsQuiet, skipScan, autoDeleteOnFailure,
 	},
 	SkillsInstall: {
-		url, user, password, accessToken, serverId, repo, version, installPath, skillsQuiet,
+		url, user, password, accessToken, serverId, repo, version, agent, projectDir, skillsGlobal, installPath, skillsQuiet,
 	},
 	SkillsUpdate: {
 		url, user, password, accessToken, serverId, repo, version, installPath, dryRun, skillsForce, skillsQuiet,
@@ -866,7 +867,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, skillsFormat, propSearch,
 	},
 	SkillsList: {
-		url, user, password, accessToken, serverId, repo, agent, projectDir, skillsFormat, skillsLimit, skillsSortBy, skillsSortOrder,
+		url, user, password, accessToken, serverId, repo, agent, projectDir, skillsGlobal, skillsFormat, skillsLimit, skillsSortBy, skillsSortOrder,
 	},
 }
 
@@ -1172,7 +1173,7 @@ var flagsMap = map[string]components.Flag{
 	// Skills-specific flags
 	repo:                components.NewStringFlag(repo, "Skills repository key in Artifactory.", components.SetMandatoryFalse()),
 	version:             components.NewStringFlag(version, "Skill version (semver, e.g. 1.2.0) or \"latest\".", components.SetMandatoryFalse()),
-	installPath:         components.NewStringFlag(installPath, "Custom install path for the skill. Default: current directory.", components.SetMandatoryFalse()),
+	installPath:         components.NewStringFlag(installPath, "Base directory for a direct install: files go under <path>/<slug>. Same as skills update. Mutually exclusive with --agent, --project-dir, and --global on install. Default for update only: current directory.", components.SetMandatoryFalse()),
 	skillsForce:         components.NewBoolFlag(skillsForce, "Re-download and reinstall even if the skill is already at the target version.", components.WithBoolDefaultValueFalse()),
 	signingKey:          components.NewStringFlag(signingKey, "Path to PGP private key for signing evidence. Overrides EVD_SIGNING_KEY_PATH env var.", components.SetMandatoryFalse()),
 	keyAlias:            components.NewStringFlag(keyAlias, "Alias for the signing key. Overrides EVD_KEY_ALIAS env var.", components.SetMandatoryFalse()),
@@ -1181,8 +1182,9 @@ var flagsMap = map[string]components.Flag{
 	propSearch:          components.NewBoolFlag(propSearch, "Use Artifactory property search (skill.name) instead of Skills API search.", components.WithBoolDefaultValueFalse()),
 	skipScan:            components.NewBoolFlag(skipScan, "Skip Xray security scan after publish. Can also be set via JFROG_CLI_SKIP_SKILLS_SCAN=true.", components.WithBoolDefaultValueFalse()),
 	autoDeleteOnFailure: components.NewBoolFlag(autoDeleteOnFailure, "Automatically delete the artifact if Xray scan identifies it as malicious.", components.WithBoolDefaultValueFalse()),
-	agent:               components.NewStringFlag(agent, "AI agent name to list locally installed skills for. Supported: claude-code, cursor, github-copilot, windsurf.", components.SetMandatoryFalse()),
-	projectDir:          components.NewStringFlag(projectDir, "Path to the project root for project-scoped skills. Use '.' for the current directory. When this flag is not set, the global agent skills directory is used as the fallback.", components.SetMandatoryFalse()),
+	agent:               components.NewStringFlag(agent, "Comma-separated AI agent names for install; a single name for list. Resolved from ~/.jfrog/agents/agent_config.json first, then built-in fallbacks (claude-code, cursor, github-copilot, windsurf, codex, agents).", components.SetMandatoryFalse()),
+	projectDir:          components.NewStringFlag(projectDir, "Project root directory combined with each agent's project path from config. Default: current directory when --global is not set. Mutually exclusive with --global.", components.SetMandatoryFalse()),
+	skillsGlobal:        components.NewBoolFlag(global, "[Default: false] Install or list under each agent's global directory from config instead of under the project root. Mutually exclusive with --project-dir.", components.WithBoolDefaultValueFalse()),
 	skillsLimit:         components.NewStringFlag(limit, "Maximum number of skills to return. Fetches all by default.", components.SetMandatoryFalse()),
 	skillsSortBy:        components.NewStringFlag(sortBy, "Field to sort by. With --repo: updated (default), downloads. With --agent: name (default, only option).", components.SetMandatoryFalse()),
 	skillsSortOrder:     components.NewStringFlag(sortOrder, "Sort order for --agent. Supported: asc (default), desc. Not supported with --repo.", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -855,7 +855,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, signingKey, keyAlias, skillsQuiet, skipScan, autoDeleteOnFailure,
 	},
 	SkillsInstall: {
-		url, user, password, accessToken, serverId, repo, version, agent, projectDir, skillsGlobal, installPath, skillsQuiet,
+		url, user, password, accessToken, serverId, repo, version, agent, projectDir, skillsGlobal, installPath, skillsFormat, skillsQuiet,
 	},
 	SkillsUpdate: {
 		url, user, password, accessToken, serverId, repo, version, installPath, dryRun, skillsForce, skillsQuiet,
@@ -1182,9 +1182,9 @@ var flagsMap = map[string]components.Flag{
 	propSearch:          components.NewBoolFlag(propSearch, "Use Artifactory property search (skill.name) instead of Skills API search.", components.WithBoolDefaultValueFalse()),
 	skipScan:            components.NewBoolFlag(skipScan, "Skip Xray security scan after publish. Can also be set via JFROG_CLI_SKIP_SKILLS_SCAN=true.", components.WithBoolDefaultValueFalse()),
 	autoDeleteOnFailure: components.NewBoolFlag(autoDeleteOnFailure, "Automatically delete the artifact if Xray scan identifies it as malicious.", components.WithBoolDefaultValueFalse()),
-	agent:               components.NewStringFlag(agent, "Comma-separated AI agent names for install; a single name for list. Resolved from ~/.jfrog/agents/agent_config.json first, then built-in fallbacks (claude-code, cursor, github-copilot, windsurf, codex, agents).", components.SetMandatoryFalse()),
+	agent:               components.NewStringFlag(agent, "Comma-separated AI agent names for install; a single name for list. Resolved from ~/.jfrog/agents/agent-config.json first, then built-in fallbacks (claude-code, cursor, github-copilot, windsurf, codex, agents).", components.SetMandatoryFalse()),
 	projectDir:          components.NewStringFlag(projectDir, "Project root directory combined with each agent's project path from config. Default: current directory when --global is not set. Mutually exclusive with --global.", components.SetMandatoryFalse()),
-	skillsGlobal:        components.NewBoolFlag(global, "[Default: false] Install or list under each agent's global directory from config instead of under the project root. Mutually exclusive with --project-dir.", components.WithBoolDefaultValueFalse()),
+	skillsGlobal:        components.NewBoolFlag(global, "Install or list under each agent's global directory from config instead of under the project root. Mutually exclusive with --project-dir.", components.WithBoolDefaultValueFalse()),
 	skillsLimit:         components.NewStringFlag(limit, "Maximum number of skills to return. Fetches all by default.", components.SetMandatoryFalse()),
 	skillsSortBy:        components.NewStringFlag(sortBy, "Field to sort by. With --repo: updated (default), downloads. With --agent: name (default, only option).", components.SetMandatoryFalse()),
 	skillsSortOrder:     components.NewStringFlag(sortOrder, "Sort order for --agent. Supported: asc (default), desc. Not supported with --repo.", components.SetMandatoryFalse()),

--- a/skills/cli/cli.go
+++ b/skills/cli/cli.go
@@ -16,7 +16,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsList),
-			Description: "List skills from an Artifactory repository (--repo) or from a local AI agent's skills directory (--agent). Exactly one of --repo or --agent must be specified.",
+			Description: "List skills from an Artifactory repository (--repo) or from a local agent install (--agent). Exactly one of --repo or --agent is required. With --agent, use --project-dir for the project root (default: current directory) or --global for each agent's global directory.",
 			Action:      skillslist.RunList,
 			Hidden:      true,
 		},
@@ -30,7 +30,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "install",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsInstall),
-			Description: "Install a skill from Artifactory. Verifies evidence using Artifactory keys automatically.",
+			Description: "Install a skill from Artifactory. Use --agent (comma-separated names) with --project-dir (default: current directory) or --global, or use --path <dir> for a direct install to <dir>/<slug> (same layout as skills update). Agent paths use ~/.jfrog/agents/agent_config.json with built-in fallbacks. Verifies evidence when signing keys are configured.",
 			Arguments:   getInstallArguments(),
 			Action:      install.RunInstall,
 		},

--- a/skills/cli/cli.go
+++ b/skills/cli/cli.go
@@ -30,7 +30,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "install",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsInstall),
-			Description: "Install a skill from Artifactory. Use --agent (comma-separated names) with --project-dir (default: current directory) or --global, or use --path <dir> for a direct install to <dir>/<slug> (same layout as skills update). Agent paths use ~/.jfrog/agents/agent_config.json with built-in fallbacks. Verifies evidence when signing keys are configured.",
+			Description: "Install a skill from Artifactory. Use --agent (comma-separated names) with --project-dir (default: current directory) or --global, or use --path <dir> for a direct install to <dir>/<slug> (same layout as skills update). Agent paths use ~/.jfrog/agents/agent-config.json with built-in fallbacks. Verifies evidence when signing keys are configured. Use --format json for machine-readable install summary.",
 			Arguments:   getInstallArguments(),
 			Action:      install.RunInstall,
 		},

--- a/skills/commands/install/install.go
+++ b/skills/commands/install/install.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/publish"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
@@ -27,10 +28,10 @@ const (
 	scopeGlobal  scope = "global"
 )
 
-// agentTarget is one agent plus absolute destination dir (includes slug).
-type agentTarget struct {
-	Agent   common.AgentSpec
-	DestDir string // absolute; ends with /<slug>
+// agentSkillInstallDir pairs an agent (or path-mode sentinel) with the absolute skill install directory (includes slug).
+type agentSkillInstallDir struct {
+	Agent          common.AgentSpec
+	DestinationDir string // absolute; ends with /<slug>
 }
 
 // InstallCommand installs a skill for configured agents or legacy --path (update).
@@ -41,9 +42,11 @@ type InstallCommand struct {
 	version       string
 	agents        []common.AgentSpec
 	scope         scope
-	projectDir    string // absolute project root for project scope
-	// installPath: legacy base dir (e.g. skills update --path); wins over agents.
+	projectDir    string // project root for project scope (--project-dir)
+	// installPath is the base directory for jf skills install --path. The skill is installed at
+	// <installPath>/<slug> and takes precedence over --agent / --project-dir / --skills-global.
 	installPath string
+	format      string
 	quiet       bool
 }
 
@@ -77,8 +80,8 @@ func (ic *InstallCommand) SetAgents(agents []common.AgentSpec) *InstallCommand {
 }
 
 // SetGlobal sets global vs project scope.
-func (ic *InstallCommand) SetGlobal(useGlobal bool) *InstallCommand {
-	if useGlobal {
+func (ic *InstallCommand) SetGlobal(isGlobal bool) *InstallCommand {
+	if isGlobal {
 		ic.scope = scopeGlobal
 	} else {
 		ic.scope = scopeProject
@@ -94,6 +97,12 @@ func (ic *InstallCommand) SetProjectDir(projectRoot string) *InstallCommand {
 
 func (ic *InstallCommand) SetQuiet(quiet bool) *InstallCommand {
 	ic.quiet = quiet
+	return ic
+}
+
+// SetFormat sets summary output: "table" (default) or "json".
+func (ic *InstallCommand) SetFormat(format string) *InstallCommand {
+	ic.format = format
 	return ic
 }
 
@@ -116,21 +125,21 @@ func (ic *InstallCommand) Run() error {
 		return fmt.Errorf("at least one agent is required")
 	}
 
-	targets, err := ic.resolveTargets()
+	installTargets, err := ic.resolveAgentTargetDirectories()
 	if err != nil {
 		return err
 	}
 
-	resolvedVersion, err := ic.resolveVersion()
+	resolvedVersion, err := common.ResolveSkillVersion(ic.serverDetails, ic.repoKey, ic.slug, ic.version, ic.quiet)
 	if err != nil {
 		return err
 	}
 	ic.version = resolvedVersion
 
 	if ic.installPath != "" {
-		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' to %s", ic.slug, ic.version, targets[0].DestDir))
+		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' to %s", ic.slug, ic.version, installTargets[0].DestinationDir))
 	} else {
-		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' for %d agent(s)", ic.slug, ic.version, len(targets)))
+		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' for %d agent(s)", ic.slug, ic.version, len(installTargets)))
 	}
 
 	tmpDir, err := os.MkdirTemp("", "skill-install-*")
@@ -168,20 +177,43 @@ func (ic *InstallCommand) Run() error {
 		}
 	}
 
-	results := make([]installResult, 0, len(targets))
-	for _, target := range targets {
-		if err := ensureDestDir(target.DestDir); err != nil {
-			results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusFailed, Detail: err.Error()})
+	results := make([]installAttemptResult, 0, len(installTargets))
+	for _, target := range installTargets {
+		if err := ensureDestinationDir(target.DestinationDir); err != nil {
+			ir := installAttemptResult{
+				Agent:  target.Agent.Name,
+				Scope:  string(ic.scope),
+				Path:   target.DestinationDir,
+				Status: skillInstallStatusFailed,
+				Detail: err.Error(),
+			}
+			results = append(results, ir)
 			continue
 		}
-		if err := copyDir(unzipDir, target.DestDir); err != nil {
-			results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusFailed, Detail: err.Error()})
+		if err := copyDir(unzipDir, target.DestinationDir); err != nil {
+			ir := installAttemptResult{
+				Agent:  target.Agent.Name,
+				Scope:  string(ic.scope),
+				Path:   target.DestinationDir,
+				Status: skillInstallStatusFailed,
+				Detail: err.Error(),
+			}
+			results = append(results, ir)
 			continue
 		}
-		results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusOK, Detail: skillInstallDetailOK})
+		ir := installAttemptResult{
+			Agent:  target.Agent.Name,
+			Scope:  string(ic.scope),
+			Path:   target.DestinationDir,
+			Status: skillInstallStatusOK,
+			Detail: skillInstallDetailOK,
+		}
+		results = append(results, ir)
 	}
 
-	printSummary(ic.slug, ic.version, results)
+	if err := printSummary(ic.slug, ic.version, results, ic.format); err != nil {
+		return err
+	}
 
 	for _, result := range results {
 		if result.Status != skillInstallStatusOK {
@@ -191,37 +223,33 @@ func (ic *InstallCommand) Run() error {
 	return nil
 }
 
-// resolveTargets builds per-agent dest dirs, or one direct target if installPath is set (install/update --path).
-func (ic *InstallCommand) resolveTargets() ([]agentTarget, error) {
+// resolveAgentTargetDirectories builds per-agent dest dirs, or one direct target if installPath is set (install/update --path).
+func (ic *InstallCommand) resolveAgentTargetDirectories() ([]agentSkillInstallDir, error) {
 	if ic.installPath != "" {
 		base, err := filepath.Abs(ic.installPath)
 		if err != nil {
 			return nil, fmt.Errorf("invalid install path %q: %w", ic.installPath, err)
 		}
-		return []agentTarget{{
-			Agent:   common.AgentSpec{Name: "(path)"},
-			DestDir: filepath.Join(base, ic.slug),
+		return []agentSkillInstallDir{{
+			Agent:          common.AgentSpec{Name: "(path)"},
+			DestinationDir: filepath.Join(base, ic.slug),
 		}}, nil
 	}
 	if ic.scope == scopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
-	targets := make([]agentTarget, 0, len(ic.agents))
+	targets := make([]agentSkillInstallDir, 0, len(ic.agents))
 	for _, agentSpec := range ic.agents {
 		base, err := common.ResolveAgentInstallDir(agentSpec, ic.projectDir, ic.scope == scopeGlobal)
 		if err != nil {
 			return nil, err
 		}
-		targets = append(targets, agentTarget{
-			Agent:   agentSpec,
-			DestDir: filepath.Join(base, ic.slug),
+		targets = append(targets, agentSkillInstallDir{
+			Agent:          agentSpec,
+			DestinationDir: filepath.Join(base, ic.slug),
 		})
 	}
 	return targets, nil
-}
-
-func (ic *InstallCommand) resolveVersion() (string, error) {
-	return common.ResolveSkillVersion(ic.serverDetails, ic.repoKey, ic.slug, ic.version, ic.quiet)
 }
 
 func (ic *InstallCommand) downloadZip(tmpDir string) (string, error) {
@@ -284,8 +312,8 @@ func (ic *InstallCommand) verifyEvidence() error {
 	})
 }
 
-// ensureDestDir mkdirs if missing, errors if path exists and is not a dir.
-func ensureDestDir(dest string) error {
+// ensureDestinationDir mkdirs if missing, errors if path exists and is not a dir.
+func ensureDestinationDir(dest string) error {
 	info, err := os.Stat(dest)
 	switch {
 	case err == nil && !info.IsDir():
@@ -295,7 +323,11 @@ func ensureDestDir(dest string) error {
 	case errors.Is(err, fs.ErrNotExist):
 		// #nosec G301 -- skill files need to be readable across the user's tools.
 		if mkErr := os.MkdirAll(dest, 0750); mkErr != nil {
-			return fmt.Errorf("failed to create install destination %q: %w", dest, mkErr)
+			return fmt.Errorf(
+				"failed to create install destination %q: %w. "+
+					"Create the directory at that path (including parent folders if needed), then run the command again",
+				dest, mkErr,
+			)
 		}
 		return nil
 	default:
@@ -420,6 +452,94 @@ func copyFile(src, dst string) error {
 	return err
 }
 
+// validateInstallCommand validates `jf skills install` flags and resolves --path or agent/project options.
+// absoluteInstallBaseDir is the absolute --path base (skill at join(base, slug)); empty when using agents.
+func validateInstallCommand(c *components.Context) (absoluteInstallBaseDir string, specs []common.AgentSpec, projectDirAbs string, isGlobal bool, err error) {
+	// Trimmed --path; non-empty selects path mode instead of --agent.
+	pathInstallBase := strings.TrimSpace(c.GetStringFlagValue("path"))
+	rawAgents := strings.TrimSpace(c.GetStringFlagValue("agent"))
+	isGlobal = c.GetBoolFlagValue("global")
+	projectDir := strings.TrimSpace(c.GetStringFlagValue("project-dir"))
+
+	if pathInstallBase != "" {
+		if rawAgents != "" {
+			err = fmt.Errorf("--path cannot be combined with --agent")
+			return
+		}
+		if isGlobal {
+			err = fmt.Errorf("--path cannot be combined with --global")
+			return
+		}
+		if projectDir != "" {
+			err = fmt.Errorf("--path cannot be combined with --project-dir")
+			return
+		}
+		if err = common.ValidateExistingDir(pathInstallBase); err != nil {
+			err = fmt.Errorf("--path: %w", err)
+			return
+		}
+		var absBase string
+		absBase, err = filepath.Abs(pathInstallBase)
+		if err != nil {
+			err = fmt.Errorf("invalid --path %q: %w", pathInstallBase, err)
+			return
+		}
+		absoluteInstallBaseDir = absBase
+		return
+	}
+
+	var registry map[string]common.AgentSpec
+	registry, err = common.LoadAgentRegistry()
+	if err != nil {
+		return
+	}
+	if rawAgents == "" {
+		err = fmt.Errorf("--agent is required unless --path is set. Supported agents: %s", common.AgentNames(registry))
+		return
+	}
+
+	var agentNames []string
+	agentNames, err = common.ParseAgentList(rawAgents)
+	if err != nil {
+		return
+	}
+
+	specs = make([]common.AgentSpec, 0, len(agentNames))
+	for _, name := range agentNames {
+		var spec common.AgentSpec
+		spec, err = common.ResolveAgent(registry, name)
+		if err != nil {
+			return
+		}
+		specs = append(specs, spec)
+	}
+
+	if isGlobal && projectDir != "" {
+		err = fmt.Errorf("--global and --project-dir are mutually exclusive, please choose either --global or --project-dir")
+		return
+	}
+
+	if !isGlobal {
+		dir := projectDir
+		if dir == "" {
+			dir = "."
+		}
+		var abs string
+		abs, err = filepath.Abs(dir)
+		if err != nil {
+			err = fmt.Errorf("invalid --project-dir %q: %w", dir, err)
+			return
+		}
+		info, statErr := os.Stat(abs)
+		if statErr != nil || !info.IsDir() {
+			err = fmt.Errorf("--project-dir %q is not an existing directory", dir)
+			return
+		}
+		projectDirAbs = abs
+	}
+	return
+}
+
 // RunInstall is the CLI action for `jf skills install`.
 func RunInstall(c *components.Context) error {
 	if c.GetNumberOfArgs() < 1 {
@@ -427,76 +547,13 @@ func RunInstall(c *components.Context) error {
 	}
 
 	slug := c.GetArgumentAt(0)
+	if err := publish.ValidateSlug(slug); err != nil {
+		return err
+	}
 
-	directBase := strings.TrimSpace(c.GetStringFlagValue("path"))
-	rawAgents := strings.TrimSpace(c.GetStringFlagValue("agent"))
-	useGlobal := c.GetBoolFlagValue("global")
-	projectDirFlag := strings.TrimSpace(c.GetStringFlagValue("project-dir"))
-
-	var pathInstallAbs string
-	var specs []common.AgentSpec
-	var projectDirAbs string
-
-	if directBase != "" {
-		if rawAgents != "" {
-			return fmt.Errorf("--path cannot be combined with --agent")
-		}
-		if useGlobal {
-			return fmt.Errorf("--path cannot be combined with --global")
-		}
-		if projectDirFlag != "" {
-			return fmt.Errorf("--path cannot be combined with --project-dir")
-		}
-		if err := common.ValidateExistingDir(directBase); err != nil {
-			return fmt.Errorf("--path: %w", err)
-		}
-		absBase, err := filepath.Abs(directBase)
-		if err != nil {
-			return fmt.Errorf("invalid --path %q: %w", directBase, err)
-		}
-		pathInstallAbs = absBase
-	} else {
-		registry, err := common.LoadAgentRegistry()
-		if err != nil {
-			return err
-		}
-		if rawAgents == "" {
-			return fmt.Errorf("--agent is required unless --path is set. Supported agents: %s", common.AgentNames(registry))
-		}
-
-		agentNames, err := common.ParseAgentList(rawAgents)
-		if err != nil {
-			return err
-		}
-
-		specs = make([]common.AgentSpec, 0, len(agentNames))
-		for _, name := range agentNames {
-			spec, err := common.ResolveAgent(registry, name)
-			if err != nil {
-				return err
-			}
-			specs = append(specs, spec)
-		}
-
-		if useGlobal && projectDirFlag != "" {
-			return fmt.Errorf("--global and --project-dir are mutually exclusive")
-		}
-
-		if !useGlobal {
-			dir := projectDirFlag
-			if dir == "" {
-				dir = "."
-			}
-			abs, err := filepath.Abs(dir)
-			if err != nil {
-				return fmt.Errorf("invalid --project-dir %q: %w", dir, err)
-			}
-			info, statErr := os.Stat(abs)
-			if statErr != nil || !info.IsDir() {
-				return fmt.Errorf("--project-dir %q is not an existing directory", dir)
-			}
-			projectDirAbs = abs
-		}
+	absoluteInstallBaseDir, specs, projectDirAbs, isGlobal, err := validateInstallCommand(c)
+	if err != nil {
+		return err
 	}
 
 	serverDetails, err := common.GetServerDetails(c)
@@ -510,13 +567,18 @@ func RunInstall(c *components.Context) error {
 	}
 
 	version := c.GetStringFlagValue("version")
-	if pathInstallAbs != "" {
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+	if absoluteInstallBaseDir != "" {
 		return NewInstallCommand().
 			SetServerDetails(serverDetails).
 			SetRepoKey(repoKey).
 			SetSlug(slug).
 			SetVersion(version).
-			SetInstallPath(pathInstallAbs).
+			SetInstallPath(absoluteInstallBaseDir).
+			SetFormat(format).
 			SetQuiet(quiet).
 			Run()
 	}
@@ -527,8 +589,9 @@ func RunInstall(c *components.Context) error {
 		SetSlug(slug).
 		SetVersion(version).
 		SetAgents(specs).
-		SetGlobal(useGlobal).
+		SetGlobal(isGlobal).
 		SetProjectDir(projectDirAbs).
+		SetFormat(format).
 		SetQuiet(quiet).
 		Run()
 }

--- a/skills/commands/install/install.go
+++ b/skills/commands/install/install.go
@@ -2,8 +2,10 @@ package install
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,19 +19,36 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-const defaultInstallBase = "."
+// scope is project (under project root) or global (agent home paths).
+type scope string
 
+const (
+	scopeProject scope = "project"
+	scopeGlobal  scope = "global"
+)
+
+// agentTarget is one agent plus absolute destination dir (includes slug).
+type agentTarget struct {
+	Agent   common.AgentSpec
+	DestDir string // absolute; ends with /<slug>
+}
+
+// InstallCommand installs a skill for configured agents or legacy --path (update).
 type InstallCommand struct {
 	serverDetails *config.ServerDetails
 	repoKey       string
 	slug          string
 	version       string
-	installPath   string
-	quiet         bool
+	agents        []common.AgentSpec
+	scope         scope
+	projectDir    string // absolute project root for project scope
+	// installPath: legacy base dir (e.g. skills update --path); wins over agents.
+	installPath string
+	quiet       bool
 }
 
 func NewInstallCommand() *InstallCommand {
-	return &InstallCommand{}
+	return &InstallCommand{scope: scopeProject}
 }
 
 func (ic *InstallCommand) SetServerDetails(details *config.ServerDetails) *InstallCommand {
@@ -52,13 +71,35 @@ func (ic *InstallCommand) SetVersion(version string) *InstallCommand {
 	return ic
 }
 
-func (ic *InstallCommand) SetInstallPath(path string) *InstallCommand {
-	ic.installPath = path
+func (ic *InstallCommand) SetAgents(agents []common.AgentSpec) *InstallCommand {
+	ic.agents = agents
+	return ic
+}
+
+// SetGlobal sets global vs project scope.
+func (ic *InstallCommand) SetGlobal(useGlobal bool) *InstallCommand {
+	if useGlobal {
+		ic.scope = scopeGlobal
+	} else {
+		ic.scope = scopeProject
+	}
+	return ic
+}
+
+// SetProjectDir sets absolute project root for project scope.
+func (ic *InstallCommand) SetProjectDir(projectRoot string) *InstallCommand {
+	ic.projectDir = projectRoot
 	return ic
 }
 
 func (ic *InstallCommand) SetQuiet(quiet bool) *InstallCommand {
 	ic.quiet = quiet
+	return ic
+}
+
+// SetInstallPath sets direct install base (same as skills update --path): skill at <base>/<slug>.
+func (ic *InstallCommand) SetInstallPath(installPath string) *InstallCommand {
+	ic.installPath = installPath
 	return ic
 }
 
@@ -71,13 +112,26 @@ func (ic *InstallCommand) CommandName() string {
 }
 
 func (ic *InstallCommand) Run() error {
-	version, err := ic.resolveVersion()
+	if ic.installPath == "" && len(ic.agents) == 0 {
+		return fmt.Errorf("at least one agent is required")
+	}
+
+	targets, err := ic.resolveTargets()
 	if err != nil {
 		return err
 	}
-	ic.version = version
 
-	log.Info(fmt.Sprintf("Installing skill '%s' version '%s'", ic.slug, ic.version))
+	resolvedVersion, err := ic.resolveVersion()
+	if err != nil {
+		return err
+	}
+	ic.version = resolvedVersion
+
+	if ic.installPath != "" {
+		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' to %s", ic.slug, ic.version, targets[0].DestDir))
+	} else {
+		log.Info(fmt.Sprintf("Installing skill '%s' version '%s' for %d agent(s)", ic.slug, ic.version, len(targets)))
+	}
 
 	tmpDir, err := os.MkdirTemp("", "skill-install-*")
 	if err != nil {
@@ -114,51 +168,60 @@ func (ic *InstallCommand) Run() error {
 		}
 	}
 
-	destDir := ic.getDestDir()
-	if err := copyDir(unzipDir, destDir); err != nil {
-		return fmt.Errorf("failed to copy skill files: %w", err)
+	results := make([]installResult, 0, len(targets))
+	for _, target := range targets {
+		if err := ensureDestDir(target.DestDir); err != nil {
+			results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusFailed, Detail: err.Error()})
+			continue
+		}
+		if err := copyDir(unzipDir, target.DestDir); err != nil {
+			results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusFailed, Detail: err.Error()})
+			continue
+		}
+		results = append(results, installResult{Agent: target.Agent.Name, Scope: string(ic.scope), Path: target.DestDir, Status: skillInstallStatusOK, Detail: skillInstallDetailOK})
 	}
 
-	log.Info(fmt.Sprintf("Skill '%s' version '%s' installed to %s", ic.slug, ic.version, destDir))
+	printSummary(ic.slug, ic.version, results)
+
+	for _, result := range results {
+		if result.Status != skillInstallStatusOK {
+			return fmt.Errorf("installation failed for one or more agents (see summary above)")
+		}
+	}
 	return nil
 }
 
-func (ic *InstallCommand) resolveVersion() (string, error) {
-	if ic.version == "latest" || ic.version == "" {
-		versions, err := common.ListVersions(ic.serverDetails, ic.repoKey, ic.slug)
+// resolveTargets builds per-agent dest dirs, or one direct target if installPath is set (install/update --path).
+func (ic *InstallCommand) resolveTargets() ([]agentTarget, error) {
+	if ic.installPath != "" {
+		base, err := filepath.Abs(ic.installPath)
 		if err != nil {
-			if strings.Contains(err.Error(), "404 Not Found") {
-				return "", fmt.Errorf("skill '%s' not found in repository '%s'", ic.slug, ic.repoKey)
-			}
-			if ic.version == "" {
-				return "", fmt.Errorf("failed to list versions (provide --version explicitly): %w", err)
-			}
-			return "", fmt.Errorf("failed to list versions: %w", err)
+			return nil, fmt.Errorf("invalid install path %q: %w", ic.installPath, err)
 		}
-
-		versionStrs := make([]string, len(versions))
-		for i, v := range versions {
-			versionStrs[i] = v.Version
-		}
-
-		if ic.version == "latest" {
-			return common.LatestVersion(versionStrs)
-		}
-
-		if ic.quiet || common.IsNonInteractive() {
-			return "", fmt.Errorf("--version is required in non-interactive mode (use semver or \"latest\")")
-		}
-
-		latest, err := common.LatestVersion(versionStrs)
-		if err != nil {
-			return "", err
-		}
-		log.Info("Available versions:", versionStrs)
-		log.Info("Using latest version:", latest)
-		return latest, nil
+		return []agentTarget{{
+			Agent:   common.AgentSpec{Name: "(path)"},
+			DestDir: filepath.Join(base, ic.slug),
+		}}, nil
 	}
+	if ic.scope == scopeProject && ic.projectDir == "" {
+		return nil, fmt.Errorf("project directory is required for project-scoped install")
+	}
+	targets := make([]agentTarget, 0, len(ic.agents))
+	for _, agentSpec := range ic.agents {
+		base, err := common.ResolveAgentInstallDir(agentSpec, ic.projectDir, ic.scope == scopeGlobal)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, agentTarget{
+			Agent:   agentSpec,
+			DestDir: filepath.Join(base, ic.slug),
+		})
+	}
+	return targets, nil
+}
 
-	return ic.version, nil
+func (ic *InstallCommand) resolveVersion() (string, error) {
+	return common.ResolveSkillVersion(ic.serverDetails, ic.repoKey, ic.slug, ic.version, ic.quiet)
 }
 
 func (ic *InstallCommand) downloadZip(tmpDir string) (string, error) {
@@ -221,12 +284,23 @@ func (ic *InstallCommand) verifyEvidence() error {
 	})
 }
 
-func (ic *InstallCommand) getDestDir() string {
-	base := ic.installPath
-	if base == "" {
-		base = defaultInstallBase
+// ensureDestDir mkdirs if missing, errors if path exists and is not a dir.
+func ensureDestDir(dest string) error {
+	info, err := os.Stat(dest)
+	switch {
+	case err == nil && !info.IsDir():
+		return fmt.Errorf("install destination %q exists and is not a directory", dest)
+	case err == nil:
+		return nil
+	case errors.Is(err, fs.ErrNotExist):
+		// #nosec G301 -- skill files need to be readable across the user's tools.
+		if mkErr := os.MkdirAll(dest, 0750); mkErr != nil {
+			return fmt.Errorf("failed to create install destination %q: %w", dest, mkErr)
+		}
+		return nil
+	default:
+		return fmt.Errorf("install destination %q is not accessible: %w", dest, err)
 	}
-	return filepath.Join(base, ic.slug)
 }
 
 func unzipFile(src, dest string) error {
@@ -349,29 +423,112 @@ func copyFile(src, dst string) error {
 // RunInstall is the CLI action for `jf skills install`.
 func RunInstall(c *components.Context) error {
 	if c.GetNumberOfArgs() < 1 {
-		return fmt.Errorf("usage: jf skills install <slug> [--repo <repo>] [options]")
+		return fmt.Errorf("usage: jf skills install <slug> (--agent <name[,name...]> [--global] [--project-dir <dir>]] | --path <dir>) [--repo <repo>] [--version <ver>]")
 	}
 
 	slug := c.GetArgumentAt(0)
+
+	directBase := strings.TrimSpace(c.GetStringFlagValue("path"))
+	rawAgents := strings.TrimSpace(c.GetStringFlagValue("agent"))
+	useGlobal := c.GetBoolFlagValue("global")
+	projectDirFlag := strings.TrimSpace(c.GetStringFlagValue("project-dir"))
+
+	var pathInstallAbs string
+	var specs []common.AgentSpec
+	var projectDirAbs string
+
+	if directBase != "" {
+		if rawAgents != "" {
+			return fmt.Errorf("--path cannot be combined with --agent")
+		}
+		if useGlobal {
+			return fmt.Errorf("--path cannot be combined with --global")
+		}
+		if projectDirFlag != "" {
+			return fmt.Errorf("--path cannot be combined with --project-dir")
+		}
+		if err := common.ValidateExistingDir(directBase); err != nil {
+			return fmt.Errorf("--path: %w", err)
+		}
+		absBase, err := filepath.Abs(directBase)
+		if err != nil {
+			return fmt.Errorf("invalid --path %q: %w", directBase, err)
+		}
+		pathInstallAbs = absBase
+	} else {
+		registry, err := common.LoadAgentRegistry()
+		if err != nil {
+			return err
+		}
+		if rawAgents == "" {
+			return fmt.Errorf("--agent is required unless --path is set. Supported agents: %s", common.AgentNames(registry))
+		}
+
+		agentNames, err := common.ParseAgentList(rawAgents)
+		if err != nil {
+			return err
+		}
+
+		specs = make([]common.AgentSpec, 0, len(agentNames))
+		for _, name := range agentNames {
+			spec, err := common.ResolveAgent(registry, name)
+			if err != nil {
+				return err
+			}
+			specs = append(specs, spec)
+		}
+
+		if useGlobal && projectDirFlag != "" {
+			return fmt.Errorf("--global and --project-dir are mutually exclusive")
+		}
+
+		if !useGlobal {
+			dir := projectDirFlag
+			if dir == "" {
+				dir = "."
+			}
+			abs, err := filepath.Abs(dir)
+			if err != nil {
+				return fmt.Errorf("invalid --project-dir %q: %w", dir, err)
+			}
+			info, statErr := os.Stat(abs)
+			if statErr != nil || !info.IsDir() {
+				return fmt.Errorf("--project-dir %q is not an existing directory", dir)
+			}
+			projectDirAbs = abs
+		}
+	}
 
 	serverDetails, err := common.GetServerDetails(c)
 	if err != nil {
 		return err
 	}
-
 	quiet := common.IsQuiet(c)
 	repoKey, err := common.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet)
 	if err != nil {
 		return err
 	}
 
-	cmd := NewInstallCommand().
+	version := c.GetStringFlagValue("version")
+	if pathInstallAbs != "" {
+		return NewInstallCommand().
+			SetServerDetails(serverDetails).
+			SetRepoKey(repoKey).
+			SetSlug(slug).
+			SetVersion(version).
+			SetInstallPath(pathInstallAbs).
+			SetQuiet(quiet).
+			Run()
+	}
+
+	return NewInstallCommand().
 		SetServerDetails(serverDetails).
 		SetRepoKey(repoKey).
 		SetSlug(slug).
-		SetVersion(c.GetStringFlagValue("version")).
-		SetInstallPath(c.GetStringFlagValue("path")).
-		SetQuiet(quiet)
-
-	return cmd.Run()
+		SetVersion(version).
+		SetAgents(specs).
+		SetGlobal(useGlobal).
+		SetProjectDir(projectDirAbs).
+		SetQuiet(quiet).
+		Run()
 }

--- a/skills/commands/install/install_test.go
+++ b/skills/commands/install/install_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,13 +59,76 @@ func TestCopyDir(t *testing.T) {
 	assert.Equal(t, "content2", string(data))
 }
 
-func TestGetDestDir(t *testing.T) {
-	cmd := NewInstallCommand().SetSlug("my-skill")
+func TestResolveTargets_ProjectScope(t *testing.T) {
+	projectRoot := t.TempDir()
+	cmd := NewInstallCommand().
+		SetSlug("my-skill").
+		SetAgents([]common.AgentSpec{
+			{Name: "cursor", Config: common.AgentConfig{ProjectDir: ".cursor/skills"}},
+			{Name: "claude-code", Config: common.AgentConfig{ProjectDir: ".claude/skills"}},
+		}).
+		SetGlobal(false).
+		SetProjectDir(projectRoot)
 
-	assert.Equal(t, filepath.Join(".", "my-skill"), cmd.getDestDir())
+	targets, err := cmd.resolveTargets()
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, filepath.Join(projectRoot, ".cursor", "skills", "my-skill"), targets[0].DestDir)
+	assert.Equal(t, filepath.Join(projectRoot, ".claude", "skills", "my-skill"), targets[1].DestDir)
+}
 
-	cmd.SetInstallPath("/custom/path")
-	assert.Equal(t, filepath.Join("/custom/path", "my-skill"), cmd.getDestDir())
+func TestResolveTargets_GlobalScope(t *testing.T) {
+	globalBase := filepath.Join(t.TempDir(), "global", ".cursor", "skills")
+	wantBase, err := filepath.Abs(globalBase)
+	require.NoError(t, err)
+
+	cmd := NewInstallCommand().
+		SetSlug("alpha").
+		SetAgents([]common.AgentSpec{
+			{Name: "cursor", Config: common.AgentConfig{GlobalDir: globalBase}},
+		}).
+		SetGlobal(true)
+
+	targets, err := cmd.resolveTargets()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(wantBase, "alpha"), targets[0].DestDir)
+}
+
+func TestResolveTargets_LegacyInstallPath(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := NewInstallCommand().SetSlug("legacy").SetInstallPath(tmp)
+	targets, err := cmd.resolveTargets()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(tmp, "legacy"), targets[0].DestDir)
+}
+
+func TestEnsureDestDir_CreatesUnderExistingParent(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "skill-x")
+	require.NoError(t, ensureDestDir(dest))
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestEnsureDestDir_CreatesNestedPath(t *testing.T) {
+	root := t.TempDir()
+	dest := filepath.Join(root, ".cursor", "skills", "alpha")
+	require.NoError(t, ensureDestDir(dest))
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestEnsureDestDir_RejectsFileAtDestination(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "blocker")
+	require.NoError(t, os.WriteFile(dest, []byte("hi"), 0o644))
+	err := ensureDestDir(dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
 }
 
 func createTestZip(t *testing.T, zipPath string, files map[string]string) {

--- a/skills/commands/install/install_test.go
+++ b/skills/commands/install/install_test.go
@@ -59,7 +59,7 @@ func TestCopyDir(t *testing.T) {
 	assert.Equal(t, "content2", string(data))
 }
 
-func TestResolveTargets_ProjectScope(t *testing.T) {
+func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {
 	projectRoot := t.TempDir()
 	cmd := NewInstallCommand().
 		SetSlug("my-skill").
@@ -70,14 +70,14 @@ func TestResolveTargets_ProjectScope(t *testing.T) {
 		SetGlobal(false).
 		SetProjectDir(projectRoot)
 
-	targets, err := cmd.resolveTargets()
+	targets, err := cmd.resolveAgentTargetDirectories()
 	require.NoError(t, err)
 	require.Len(t, targets, 2)
-	assert.Equal(t, filepath.Join(projectRoot, ".cursor", "skills", "my-skill"), targets[0].DestDir)
-	assert.Equal(t, filepath.Join(projectRoot, ".claude", "skills", "my-skill"), targets[1].DestDir)
+	assert.Equal(t, filepath.Join(projectRoot, ".cursor", "skills", "my-skill"), targets[0].DestinationDir)
+	assert.Equal(t, filepath.Join(projectRoot, ".claude", "skills", "my-skill"), targets[1].DestinationDir)
 }
 
-func TestResolveTargets_GlobalScope(t *testing.T) {
+func TestResolveAgentTargetDirectories_GlobalScope(t *testing.T) {
 	globalBase := filepath.Join(t.TempDir(), "global", ".cursor", "skills")
 	wantBase, err := filepath.Abs(globalBase)
 	require.NoError(t, err)
@@ -89,44 +89,44 @@ func TestResolveTargets_GlobalScope(t *testing.T) {
 		}).
 		SetGlobal(true)
 
-	targets, err := cmd.resolveTargets()
+	targets, err := cmd.resolveAgentTargetDirectories()
 	require.NoError(t, err)
 	require.Len(t, targets, 1)
-	assert.Equal(t, filepath.Join(wantBase, "alpha"), targets[0].DestDir)
+	assert.Equal(t, filepath.Join(wantBase, "alpha"), targets[0].DestinationDir)
 }
 
-func TestResolveTargets_LegacyInstallPath(t *testing.T) {
+func TestResolveAgentTargetDirectories_LegacyInstallPath(t *testing.T) {
 	tmp := t.TempDir()
 	cmd := NewInstallCommand().SetSlug("legacy").SetInstallPath(tmp)
-	targets, err := cmd.resolveTargets()
+	targets, err := cmd.resolveAgentTargetDirectories()
 	require.NoError(t, err)
 	require.Len(t, targets, 1)
-	assert.Equal(t, filepath.Join(tmp, "legacy"), targets[0].DestDir)
+	assert.Equal(t, filepath.Join(tmp, "legacy"), targets[0].DestinationDir)
 }
 
-func TestEnsureDestDir_CreatesUnderExistingParent(t *testing.T) {
+func TestEnsureDestinationDir_CreatesUnderExistingParent(t *testing.T) {
 	parent := t.TempDir()
 	dest := filepath.Join(parent, "skill-x")
-	require.NoError(t, ensureDestDir(dest))
+	require.NoError(t, ensureDestinationDir(dest))
 	info, err := os.Stat(dest)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
 }
 
-func TestEnsureDestDir_CreatesNestedPath(t *testing.T) {
+func TestEnsureDestinationDir_CreatesNestedPath(t *testing.T) {
 	root := t.TempDir()
 	dest := filepath.Join(root, ".cursor", "skills", "alpha")
-	require.NoError(t, ensureDestDir(dest))
+	require.NoError(t, ensureDestinationDir(dest))
 	info, err := os.Stat(dest)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
 }
 
-func TestEnsureDestDir_RejectsFileAtDestination(t *testing.T) {
+func TestEnsureDestinationDir_RejectsFileAtDestination(t *testing.T) {
 	parent := t.TempDir()
 	dest := filepath.Join(parent, "blocker")
 	require.NoError(t, os.WriteFile(dest, []byte("hi"), 0o644))
-	err := ensureDestDir(dest)
+	err := ensureDestinationDir(dest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
 }

--- a/skills/commands/install/summary.go
+++ b/skills/commands/install/summary.go
@@ -1,6 +1,10 @@
 package install
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -11,20 +15,36 @@ const (
 	skillInstallDetailOK     = "Executed successfully with no issues."
 )
 
-type installResult struct {
-	Agent  string `col-name:"Agent"`
-	Scope  string `col-name:"Scope"`
-	Path   string `col-name:"Path"`
-	Status string `col-name:"Status"`
-	Detail string `col-name:"Detail"`
+type installAttemptResult struct {
+	Agent  string `json:"agent" col-name:"Agent"`
+	Scope  string `json:"scope" col-name:"Scope"`
+	Path   string `json:"path" col-name:"Path"`
+	Status string `json:"status" col-name:"Status"`
+	Detail string `json:"detail" col-name:"Detail"`
 }
 
-func printSummary(slug, version string, results []installResult) {
+type installSummaryJSON struct {
+	Slug    string                 `json:"slug"`
+	Version string                 `json:"version"`
+	Results []installAttemptResult `json:"results"`
+}
+
+func printSummary(slug, version string, results []installAttemptResult, format string) error {
 	if len(results) == 0 {
-		return
+		return nil
+	}
+	if strings.EqualFold(format, "json") {
+		payload := installSummaryJSON{Slug: slug, Version: version, Results: results}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal install summary: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
 	}
 	log.Info("Skill installation summary for '" + slug + "' v" + version + ":")
 	if err := coreutils.PrintTable(results, "Installed", "No skills installed", false); err != nil {
 		log.Warn("Failed to render install summary: " + err.Error())
 	}
+	return nil
 }

--- a/skills/commands/install/summary.go
+++ b/skills/commands/install/summary.go
@@ -1,0 +1,30 @@
+package install
+
+import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	skillInstallStatusOK     = "ok"
+	skillInstallStatusFailed = "failed"
+	skillInstallDetailOK     = "Executed successfully with no issues."
+)
+
+type installResult struct {
+	Agent  string `col-name:"Agent"`
+	Scope  string `col-name:"Scope"`
+	Path   string `col-name:"Path"`
+	Status string `col-name:"Status"`
+	Detail string `col-name:"Detail"`
+}
+
+func printSummary(slug, version string, results []installResult) {
+	if len(results) == 0 {
+		return
+	}
+	log.Info("Skill installation summary for '" + slug + "' v" + version + ":")
+	if err := coreutils.PrintTable(results, "Installed", "No skills installed", false); err != nil {
+		log.Warn("Failed to render install summary: " + err.Error())
+	}
+}

--- a/skills/commands/list/list.go
+++ b/skills/commands/list/list.go
@@ -38,6 +38,7 @@ type ListCommand struct {
 	repoKey       string
 	agentName     string
 	projectDir    string
+	global        bool
 	format        string
 	limit         int
 	sortBy        string
@@ -61,6 +62,11 @@ func (lc *ListCommand) SetAgentName(agentName string) *ListCommand {
 
 func (lc *ListCommand) SetProjectDir(projectDir string) *ListCommand {
 	lc.projectDir = projectDir
+	return lc
+}
+
+func (lc *ListCommand) SetGlobal(useGlobal bool) *ListCommand {
+	lc.global = useGlobal
 	return lc
 }
 
@@ -90,6 +96,9 @@ func (lc *ListCommand) Run() error {
 	}
 	if lc.repoKey != "" && lc.agentName != "" {
 		return fmt.Errorf("--repo and --agent are mutually exclusive; specify only one")
+	}
+	if lc.global && lc.projectDir != "" {
+		return fmt.Errorf("--global and --project-dir are mutually exclusive")
 	}
 
 	if lc.agentName != "" {
@@ -122,20 +131,18 @@ func (lc *ListCommand) listRepoSkills() error {
 }
 
 func (lc *ListCommand) listLocalSkills() error {
-	normalized := strings.ToLower(strings.TrimSpace(lc.agentName))
-
-	agent, known := common.Agents[normalized]
-	if !known {
-		return fmt.Errorf("unknown agent %q. Supported agents: %s", lc.agentName, common.SupportedAgentsList())
+	registry, err := common.LoadAgentRegistry()
+	if err != nil {
+		return err
+	}
+	spec, err := common.ResolveAgent(registry, lc.agentName)
+	if err != nil {
+		return err
 	}
 
-	var dir string
-	if lc.projectDir != "" {
-		// Project-scoped: only look in <projectDir>/<agent-relative-path>, no fallback
-		dir = filepath.Join(lc.projectDir, agent.ProjectDir)
-	} else {
-		// Global scope
-		dir = expandHome(agent.GlobalDir)
+	dir, err := common.ResolveAgentInstallDir(spec, lc.projectDir, lc.global)
+	if err != nil {
+		return err
 	}
 
 	entries, err := os.ReadDir(dir)
@@ -203,17 +210,6 @@ func (lc *ListCommand) printResults(results []listResult) error {
 	return coreutils.PrintTable(results, "Skills", "No skills found", false)
 }
 
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return path
-		}
-		return filepath.Join(home, path[2:])
-	}
-	return path
-}
-
 func RunList(c *components.Context) error {
 	repoKey := c.GetStringFlagValue("repo")
 	agentName := c.GetStringFlagValue("agent")
@@ -266,6 +262,14 @@ func RunList(c *components.Context) error {
 	}
 
 	projectDir := c.GetStringFlagValue("project-dir")
+	useGlobal := c.GetBoolFlagValue("global")
+	if useGlobal && projectDir != "" {
+		return fmt.Errorf("--global and --project-dir are mutually exclusive")
+	}
+	// --agent without --project-dir/--global: use cwd
+	if !useGlobal && projectDir == "" && agentName != "" {
+		projectDir = "."
+	}
 	if projectDir != "" {
 		absPath, err := filepath.Abs(projectDir)
 		if err != nil {
@@ -278,6 +282,7 @@ func RunList(c *components.Context) error {
 	cmd.SetRepoKey(repoKey).
 		SetAgentName(agentName).
 		SetProjectDir(projectDir).
+		SetGlobal(useGlobal).
 		SetFormat(format).
 		SetLimit(limit).
 		SetSortBy(sortBy).

--- a/skills/commands/list/list.go
+++ b/skills/commands/list/list.go
@@ -98,7 +98,7 @@ func (lc *ListCommand) Run() error {
 		return fmt.Errorf("--repo and --agent are mutually exclusive; specify only one")
 	}
 	if lc.global && lc.projectDir != "" {
-		return fmt.Errorf("--global and --project-dir are mutually exclusive")
+		return fmt.Errorf("--global and --project-dir are mutually exclusive, please choose either --global or --project-dir")
 	}
 
 	if lc.agentName != "" {
@@ -263,9 +263,6 @@ func RunList(c *components.Context) error {
 
 	projectDir := c.GetStringFlagValue("project-dir")
 	useGlobal := c.GetBoolFlagValue("global")
-	if useGlobal && projectDir != "" {
-		return fmt.Errorf("--global and --project-dir are mutually exclusive")
-	}
 	// --agent without --project-dir/--global: use cwd
 	if !useGlobal && projectDir == "" && agentName != "" {
 		projectDir = "."

--- a/skills/commands/list/list_test.go
+++ b/skills/commands/list/list_test.go
@@ -38,27 +38,6 @@ func captureStdout(t *testing.T, fn func()) []byte {
 }
 
 // ---------------------------------------------------------------------------
-// expandHome
-// ---------------------------------------------------------------------------
-
-func TestExpandHome_Tilde(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-	expanded := expandHome("~/.claude/skills")
-	assert.Equal(t, filepath.Join(home, ".claude/skills"), expanded)
-}
-
-func TestExpandHome_NoTilde(t *testing.T) {
-	path := "/absolute/path/skills"
-	assert.Equal(t, path, expandHome(path))
-}
-
-func TestExpandHome_TildeOnly(t *testing.T) {
-	// "~" without slash should be returned as-is (not a valid prefix)
-	assert.Equal(t, "~", expandHome("~"))
-}
-
-// ---------------------------------------------------------------------------
 // ListCommand.Run — validation
 // ---------------------------------------------------------------------------
 
@@ -202,7 +181,7 @@ func TestListLocalSkills_GlobalDir(t *testing.T) {
 
 	captureLog(t)
 	cmd := &ListCommand{}
-	cmd.SetAgentName("cursor").SetFormat("json")
+	cmd.SetAgentName("cursor").SetGlobal(true).SetFormat("json")
 
 	jsonOut := captureStdout(t, func() {
 		require.NoError(t, cmd.Run())
@@ -337,7 +316,14 @@ func TestPrintResults_Empty_JSON(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAgents_AllKnownAgents(t *testing.T) {
-	expected := []string{"claude-code", "cursor", "github-copilot", "windsurf"}
+	expected := []string{
+		"claude-code",
+		"codex",
+		"cross-agent",
+		"cursor",
+		"github-copilot",
+		"windsurf",
+	}
 	for _, name := range expected {
 		cfg, ok := common.Agents[name]
 		assert.True(t, ok, "expected agent %q to be in Agents", name)

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -6,15 +6,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/install"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/publish"
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -59,7 +55,7 @@ func RunUpdate(c *components.Context) error {
 		return err
 	}
 
-	targetVersion, err = resolveTargetVersion(serverDetails, repoKey, slug, targetVersion, quiet)
+	targetVersion, err = common.ResolveSkillVersion(serverDetails, repoKey, slug, targetVersion, quiet)
 	if err != nil {
 		return err
 	}
@@ -129,13 +125,8 @@ func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 }
 
 func validateInstallBase(path string) error {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return fmt.Errorf("invalid install path: %w", err)
-	}
-	info, err := os.Stat(absPath)
-	if err != nil || !info.IsDir() {
-		return fmt.Errorf("install path '%s' is not a valid directory", path)
+	if err := common.ValidateExistingDir(path); err != nil {
+		return fmt.Errorf("install path %q: %w", path, err)
 	}
 	return nil
 }
@@ -154,58 +145,4 @@ func readInstalledVersion(skillDir string) (string, error) {
 		return "", fmt.Errorf("could not read installed skill metadata from %s: %w", skillDir, err)
 	}
 	return meta.Version, nil
-}
-
-func resolveTargetVersion(serverDetails *config.ServerDetails, repoKey, slug, version string, quiet bool) (string, error) {
-	versions, err := common.ListVersions(serverDetails, repoKey, slug)
-	if err != nil {
-		if strings.Contains(err.Error(), "404 Not Found") {
-			return "", fmt.Errorf("skill '%s' not found in repository '%s'", slug, repoKey)
-		}
-		return "", fmt.Errorf("failed to list versions: %w", err)
-	}
-
-	versionStrs := make([]string, len(versions))
-	for i, v := range versions {
-		versionStrs[i] = v.Version
-	}
-
-	return selectVersion(versionStrs, version, repoKey, quiet)
-}
-
-func selectVersion(available []string, requested, repoKey string, quiet bool) (string, error) {
-	if requested == "" || requested == "latest" {
-		latest, err := common.LatestVersion(available)
-		if err != nil {
-			return "", fmt.Errorf("failed to determine latest version: %w", err)
-		}
-		log.Info(fmt.Sprintf("Using latest version: %s", latest))
-		return latest, nil
-	}
-
-	for _, v := range available {
-		if v == requested {
-			return requested, nil
-		}
-	}
-
-	if quiet || common.IsNonInteractive() {
-		return "", fmt.Errorf(
-			"version '%s' not found in repository '%s'.\nAvailable versions: %s",
-			requested, repoKey, strings.Join(available, ", "),
-		)
-	}
-
-	log.Warn(fmt.Sprintf("Version '%s' not found. Please select from the available versions below.", requested))
-
-	options := make([]prompt.Suggest, len(available))
-	for i, v := range available {
-		options[i] = prompt.Suggest{Text: v}
-	}
-	selected := ioutils.AskFromListWithMismatchConfirmation(
-		"Select a version:",
-		fmt.Sprintf("'%s' is not in the list of available versions.", requested),
-		options,
-	)
-	return selected, nil
 }

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -48,7 +48,7 @@ func TestReadInstalledVersion_NotInstalled(t *testing.T) {
 func TestRunUpdate_PathDoesNotExist(t *testing.T) {
 	err := validateInstallBase("/nonexistent/path/xyz")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not a valid directory")
+	assert.Contains(t, err.Error(), "install path")
 }
 
 func TestValidateInstallBase_NotADirectory(t *testing.T) {
@@ -57,7 +57,7 @@ func TestValidateInstallBase_NotADirectory(t *testing.T) {
 
 	err := validateInstallBase(file)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not a valid directory")
+	assert.Contains(t, err.Error(), "not a directory")
 }
 
 func TestReadInstalledVersion_InvalidFrontmatter(t *testing.T) {
@@ -65,42 +65,6 @@ func TestReadInstalledVersion_InvalidFrontmatter(t *testing.T) {
 	_, err := readInstalledVersion(dir)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not read installed skill metadata")
-}
-
-// ── selectVersion ────────────────────────────────────────────────────────────
-
-func TestSelectVersion_ExactMatchReturnsIt(t *testing.T) {
-	available := []string{"1.0.0", "1.1.0", "2.0.0"}
-	got, err := selectVersion(available, "1.1.0", "skills-local", true)
-	require.NoError(t, err)
-	assert.Equal(t, "1.1.0", got)
-}
-
-func TestSelectVersion_LatestEmpty(t *testing.T) {
-	available := []string{"1.0.0", "1.1.0", "2.0.0"}
-	got, err := selectVersion(available, "", "skills-local", true)
-	require.NoError(t, err)
-	assert.Equal(t, "2.0.0", got)
-}
-
-func TestSelectVersion_LatestKeyword(t *testing.T) {
-	available := []string{"1.0.0", "3.0.0", "2.0.0"}
-	got, err := selectVersion(available, "latest", "skills-local", true)
-	require.NoError(t, err)
-	assert.Equal(t, "3.0.0", got)
-}
-
-func TestSelectVersion_NotFoundQuiet(t *testing.T) {
-	available := []string{"1.0.0", "1.1.0"}
-	_, err := selectVersion(available, "9.9.9", "skills-local", true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
-}
-
-func TestSelectVersion_EmptyAvailableList(t *testing.T) {
-	_, err := selectVersion([]string{}, "", "skills-local", true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "latest version")
 }
 
 // ── reserveUpdateBackupPath ──────────────────────────────────────────────────

--- a/skills/common/agents.go
+++ b/skills/common/agents.go
@@ -1,30 +1,212 @@
 package common
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 )
 
 // AgentConfig holds the skills directory paths for an AI agent.
 type AgentConfig struct {
-	GlobalDir  string // e.g. ~/.cursor/skills
-	ProjectDir string // e.g. .cursor/skills (relative to project root)
+	GlobalDir  string `json:"globalDir"`
+	ProjectDir string `json:"projectDir"`
 }
 
-// Agents is the single source of truth for all supported AI agents and their skill paths.
+// AgentSpec is a resolved agent; FromConfig marks JSON vs built-in.
+type AgentSpec struct {
+	Name       string
+	Config     AgentConfig
+	FromConfig bool
+}
+
+// Agents is built-in defaults; merged with ~/.jfrog/agents/agent_config.json.
 var Agents = map[string]AgentConfig{
 	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},
 	"cursor":         {GlobalDir: "~/.cursor/skills", ProjectDir: ".cursor/skills"},
-	"github-copilot": {GlobalDir: "~/.github/copilot/skills", ProjectDir: ".github/copilot/skills"},
-	"windsurf":       {GlobalDir: "~/.windsurf/skills", ProjectDir: ".windsurf/skills"},
+	"github-copilot": {GlobalDir: "~/.copilot/skills", ProjectDir: ".github/skills"},
+	"windsurf":       {GlobalDir: "~/.codeium/windsurf/skills", ProjectDir: ".windsurf/skills"},
+	"codex":          {GlobalDir: "~/.codex/skills", ProjectDir: ".codex/skills"},
+	"cross-agent":    {GlobalDir: "~/.agents/skills", ProjectDir: ".agents/skills"},
 }
 
-// SupportedAgentsList returns a human-readable comma-separated list of supported agent names.
-func SupportedAgentsList() string {
-	names := make([]string, 0, len(Agents))
-	for name := range Agents {
+const (
+	agentsConfigSubdir = "agents"
+	agentsConfigFile   = "agent_config.json"
+)
+
+type agentConfigDocument struct {
+	Agents map[string]AgentConfig `json:"agents"`
+}
+
+// AgentConfigPath is ~/.jfrog/agents/agent_config.json (file may be missing).
+func AgentConfigPath() (string, error) {
+	home, err := coreutils.GetJfrogHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, agentsConfigSubdir, agentsConfigFile), nil
+}
+
+// LoadAgentRegistry merges agent_config.json over built-in Agents (keys lowercased).
+func LoadAgentRegistry() (map[string]AgentSpec, error) {
+	registry := make(map[string]AgentSpec, len(Agents))
+	for name, config := range Agents {
+		registry[strings.ToLower(name)] = AgentSpec{
+			Name:       name,
+			Config:     config,
+			FromConfig: false,
+		}
+	}
+
+	path, err := AgentConfigPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve agent config path: %w", err)
+	}
+
+	// #nosec G304 -- path is constructed from the JFrog home dir, not user input.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return registry, nil
+		}
+		return nil, fmt.Errorf("failed to read agent config %s: %w", path, err)
+	}
+
+	if len(data) == 0 {
+		return registry, nil
+	}
+
+	var parsedConfig agentConfigDocument
+	if err := json.Unmarshal(data, &parsedConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse agent config %s: %w", path, err)
+	}
+
+	for name, config := range parsedConfig.Agents {
+		normalizedName := strings.ToLower(strings.TrimSpace(name))
+		if normalizedName == "" {
+			return nil, fmt.Errorf("agent config %s contains an entry with an empty name", path)
+		}
+		if config.GlobalDir == "" && config.ProjectDir == "" {
+			return nil, fmt.Errorf("agent %q in %s must define globalDir and/or projectDir", name, path)
+		}
+		registry[normalizedName] = AgentSpec{
+			Name:       normalizedName,
+			Config:     config,
+			FromConfig: true,
+		}
+	}
+
+	return registry, nil
+}
+
+// ResolveAgent returns spec or an error listing supported agents.
+func ResolveAgent(registry map[string]AgentSpec, name string) (AgentSpec, error) {
+	normalizedName := strings.ToLower(strings.TrimSpace(name))
+	if normalizedName == "" {
+		return AgentSpec{}, fmt.Errorf("agent name is required.\n%s", AgentRegistryHelp(registry))
+	}
+	spec, ok := registry[normalizedName]
+	if !ok {
+		return AgentSpec{}, fmt.Errorf("unknown agent %q.\n%s", name, AgentRegistryHelp(registry))
+	}
+	return spec, nil
+}
+
+// ParseAgentList parses comma-separated agent names (trim, lower, no dups).
+func ParseAgentList(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("--agent is required (comma-separated list of agent names)")
+	}
+
+	seen := make(map[string]struct{})
+	var result []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name == "" {
+			return nil, fmt.Errorf("--agent contains an empty name in %q", raw)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("--agent lists %q more than once", name)
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+// AgentNames returns the registry's agent names, sorted alphabetically.
+func AgentNames(registry map[string]AgentSpec) string {
+	names := make([]string, 0, len(registry))
+	for name := range registry {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	return strings.Join(names, ", ")
+}
+
+// AgentRegistryHelp lists agents/paths and how to edit agent_config.json.
+func AgentRegistryHelp(registry map[string]AgentSpec) string {
+	configPath, _ := AgentConfigPath()
+	keys := make([]string, 0, len(registry))
+	for name := range registry {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+
+	var helpBuf strings.Builder
+	helpBuf.WriteString("Supported agents:\n")
+	for _, name := range keys {
+		spec := registry[name]
+		fmt.Fprintf(&helpBuf, "  - %s (project: %s, global: %s)\n", name, spec.Config.ProjectDir, spec.Config.GlobalDir)
+	}
+	fmt.Fprintf(&helpBuf, "\nTo add or override an agent, edit %s. Example:\n", configPath)
+	helpBuf.WriteString(`  {
+    "agents": {
+      "my-agent": { "projectDir": ".my-agent/skills", "globalDir": "~/.my-agent/skills" }
+    }
+  }`)
+	return helpBuf.String()
+}
+
+// ResolveAgentInstallDir is absolute global dir or projectDir + project-relative path.
+func ResolveAgentInstallDir(spec AgentSpec, projectDir string, global bool) (string, error) {
+	if global {
+		dir := ExpandHome(spec.Config.GlobalDir)
+		if dir == "" {
+			return "", fmt.Errorf("agent %q has no global directory configured", spec.Name)
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", fmt.Errorf("invalid global path for agent %q: %w", spec.Name, err)
+		}
+		return abs, nil
+	}
+	if spec.Config.ProjectDir == "" {
+		return "", fmt.Errorf("agent %q has no project directory configured", spec.Name)
+	}
+	if projectDir == "" {
+		projectDir = "."
+	}
+	return filepath.Abs(filepath.Join(projectDir, spec.Config.ProjectDir))
+}
+
+// SupportedAgentsList is comma-separated names from registry or built-ins.
+func SupportedAgentsList() string {
+	registry, err := LoadAgentRegistry()
+	if err != nil || len(registry) == 0 {
+		names := make([]string, 0, len(Agents))
+		for name := range Agents {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return strings.Join(names, ", ")
+	}
+	return AgentNames(registry)
 }

--- a/skills/common/agents.go
+++ b/skills/common/agents.go
@@ -27,6 +27,7 @@ type AgentSpec struct {
 }
 
 // Agents is built-in defaults; merged with ~/.jfrog/agents/agent_config.json.
+// Reference: https://github.com/vercel-labs/skills/pull/76/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172
 var Agents = map[string]AgentConfig{
 	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},
 	"cursor":         {GlobalDir: "~/.cursor/skills", ProjectDir: ".cursor/skills"},
@@ -38,14 +39,14 @@ var Agents = map[string]AgentConfig{
 
 const (
 	agentsConfigSubdir = "agents"
-	agentsConfigFile   = "agent_config.json"
+	agentsConfigFile   = "agent-config.json"
 )
 
 type agentConfigDocument struct {
 	Agents map[string]AgentConfig `json:"agents"`
 }
 
-// AgentConfigPath is ~/.jfrog/agents/agent_config.json (file may be missing).
+// AgentConfigPath is ~/.jfrog/agents/agent-config.json (file may be missing).
 func AgentConfigPath() (string, error) {
 	home, err := coreutils.GetJfrogHomeDir()
 	if err != nil {
@@ -54,7 +55,8 @@ func AgentConfigPath() (string, error) {
 	return filepath.Join(home, agentsConfigSubdir, agentsConfigFile), nil
 }
 
-// LoadAgentRegistry merges agent_config.json over built-in Agents (keys lowercased).
+// LoadAgentRegistry merges agent-config.json over built-in Agents (keys lowercased).
+// A missing agent-config.json is not an error; built-in defaults are returned unchanged.
 func LoadAgentRegistry() (map[string]AgentSpec, error) {
 	registry := make(map[string]AgentSpec, len(Agents))
 	for name, config := range Agents {
@@ -151,7 +153,7 @@ func AgentNames(registry map[string]AgentSpec) string {
 	return strings.Join(names, ", ")
 }
 
-// AgentRegistryHelp lists agents/paths and how to edit agent_config.json.
+// AgentRegistryHelp lists agents/paths and how to edit agent-config.json.
 func AgentRegistryHelp(registry map[string]AgentSpec) string {
 	configPath, _ := AgentConfigPath()
 	keys := make([]string, 0, len(registry))

--- a/skills/common/agents_test.go
+++ b/skills/common/agents_test.go
@@ -32,7 +32,7 @@ func withJfrogHome(t *testing.T) string {
 
 func writeAgentConfig(t *testing.T, home, body string) {
 	t.Helper()
-	path := filepath.Join(home, "agents", "agent_config.json")
+	path := filepath.Join(home, "agents", "agent-config.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
 }

--- a/skills/common/agents_test.go
+++ b/skills/common/agents_test.go
@@ -1,10 +1,14 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSupportedAgentsList_SortedAndStable(t *testing.T) {
@@ -16,4 +20,129 @@ func TestSupportedAgentsList_SortedAndStable(t *testing.T) {
 	for i := 1; i < len(parts); i++ {
 		assert.LessOrEqual(t, parts[i-1], parts[i])
 	}
+}
+
+// withJfrogHome sets JFROG_CLI_HOME_DIR to a temp dir.
+func withJfrogHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv(coreutils.HomeDir, dir)
+	return dir
+}
+
+func writeAgentConfig(t *testing.T, home, body string) {
+	t.Helper()
+	path := filepath.Join(home, "agents", "agent_config.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+func TestLoadAgentRegistry_FallbackOnly(t *testing.T) {
+	withJfrogHome(t)
+
+	registry, err := LoadAgentRegistry()
+	require.NoError(t, err)
+
+	cursor, ok := registry["cursor"]
+	require.True(t, ok)
+	assert.False(t, cursor.FromConfig)
+	assert.Equal(t, ".cursor/skills", cursor.Config.ProjectDir)
+}
+
+func TestLoadAgentRegistry_OverridesAndAdds(t *testing.T) {
+	home := withJfrogHome(t)
+	writeAgentConfig(t, home, `{
+		"agents": {
+			"cursor": {"globalDir": "/abs/cursor", "projectDir": ".override/cursor"},
+			"my-agent": {"globalDir": "~/.my/skills", "projectDir": ".my/skills"}
+		}
+	}`)
+
+	registry, err := LoadAgentRegistry()
+	require.NoError(t, err)
+
+	cursor := registry["cursor"]
+	assert.True(t, cursor.FromConfig)
+	assert.Equal(t, ".override/cursor", cursor.Config.ProjectDir)
+	assert.Equal(t, "/abs/cursor", cursor.Config.GlobalDir)
+
+	custom, ok := registry["my-agent"]
+	require.True(t, ok)
+	assert.True(t, custom.FromConfig)
+	assert.Equal(t, ".my/skills", custom.Config.ProjectDir)
+
+	claude := registry["claude-code"]
+	assert.False(t, claude.FromConfig)
+	assert.Equal(t, ".claude/skills", claude.Config.ProjectDir)
+}
+
+func TestLoadAgentRegistry_RejectsEmptyEntry(t *testing.T) {
+	home := withJfrogHome(t)
+	writeAgentConfig(t, home, `{"agents": {"broken": {}}}`)
+
+	_, err := LoadAgentRegistry()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must define globalDir and/or projectDir")
+}
+
+func TestLoadAgentRegistry_RejectsBadJSON(t *testing.T) {
+	home := withJfrogHome(t)
+	writeAgentConfig(t, home, `not-json`)
+
+	_, err := LoadAgentRegistry()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse agent config")
+}
+
+func TestParseAgentList(t *testing.T) {
+	got, err := ParseAgentList("cursor, Claude-Code")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cursor", "claude-code"}, got)
+}
+
+func TestParseAgentList_EmptyAndDuplicates(t *testing.T) {
+	_, err := ParseAgentList("")
+	require.Error(t, err)
+
+	_, err = ParseAgentList("cursor,,claude-code")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty name")
+
+	_, err = ParseAgentList("cursor,cursor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than once")
+}
+
+func TestResolveAgent_Unknown(t *testing.T) {
+	withJfrogHome(t)
+	registry, err := LoadAgentRegistry()
+	require.NoError(t, err)
+
+	_, err = ResolveAgent(registry, "no-such-agent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Supported agents")
+	assert.Contains(t, err.Error(), "cursor")
+}
+
+func TestResolveAgentInstallDir_GlobalAndProject(t *testing.T) {
+	withJfrogHome(t)
+	globalDir := "/var/data/.cursor/skills"
+	spec := AgentSpec{
+		Name:   "cursor",
+		Config: AgentConfig{GlobalDir: globalDir, ProjectDir: ".cursor/skills"},
+	}
+
+	wantGlobal, err := filepath.Abs(globalDir)
+	require.NoError(t, err)
+
+	abs, err := ResolveAgentInstallDir(spec, "", true)
+	require.NoError(t, err)
+	assert.Equal(t, wantGlobal, abs)
+
+	projectRoot := t.TempDir()
+	wantProject, err := filepath.Abs(filepath.Join(projectRoot, spec.Config.ProjectDir))
+	require.NoError(t, err)
+	abs, err = ResolveAgentInstallDir(spec, projectRoot, false)
+	require.NoError(t, err)
+	assert.Equal(t, wantProject, abs)
 }

--- a/skills/common/skills_util.go
+++ b/skills/common/skills_util.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	prompt "github.com/c-bata/go-prompt"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// ResolveSkillVersion lists remote versions then applies SelectSkillVersion rules.
+func ResolveSkillVersion(serverDetails *config.ServerDetails, repoKey, slug, requested string, quiet bool) (string, error) {
+	versions, err := ListVersions(serverDetails, repoKey, slug)
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return "", fmt.Errorf("skill '%s' not found in repository '%s'", slug, repoKey)
+		}
+		return "", fmt.Errorf("failed to list versions: %w", err)
+	}
+	available := make([]string, len(versions))
+	for idx, skillVersion := range versions {
+		available[idx] = skillVersion.Version
+	}
+	return SelectSkillVersion(available, requested, repoKey, quiet)
+}
+
+// SelectSkillVersion resolves "" / "latest" / exact match / prompt.
+func SelectSkillVersion(available []string, requested, repoKey string, quiet bool) (string, error) {
+	if requested == "" || requested == "latest" {
+		latest, err := LatestVersion(available)
+		if err != nil {
+			return "", fmt.Errorf("failed to determine latest version: %w", err)
+		}
+		log.Info(fmt.Sprintf("Using latest version: %s", latest))
+		return latest, nil
+	}
+
+	for _, version := range available {
+		if version == requested {
+			return requested, nil
+		}
+	}
+
+	if quiet || IsNonInteractive() {
+		return "", fmt.Errorf(
+			"version '%s' not found in repository '%s'.\nAvailable versions: %s",
+			requested, repoKey, strings.Join(available, ", "),
+		)
+	}
+
+	log.Warn(fmt.Sprintf("Version '%s' not found. Please select from the available versions below.", requested))
+
+	options := make([]prompt.Suggest, len(available))
+	for idx, version := range available {
+		options[idx] = prompt.Suggest{Text: version}
+	}
+	selected := ioutils.AskFromListWithMismatchConfirmation(
+		"Select a version:",
+		fmt.Sprintf("'%s' is not in the list of available versions.", requested),
+		options,
+	)
+	return selected, nil
+}
+
+// ValidateExistingDir requires path to exist and be a directory (after filepath.Abs).
+func ValidateExistingDir(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return fmt.Errorf("path %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path %q is not a directory", path)
+	}
+	return nil
+}
+
+// ExpandHome maps ~/ to the user home directory.
+func ExpandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/skills/common/skills_util_test.go
+++ b/skills/common/skills_util_test.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "tilde relative path", in: "~/x/y", want: filepath.Join(home, "x/y")},
+		{name: "claude skills path", in: "~/.claude/skills", want: filepath.Join(home, ".claude/skills")},
+		{name: "absolute path", in: "/abs/path", want: "/abs/path"},
+		{name: "absolute long path", in: "/absolute/path/skills", want: "/absolute/path/skills"},
+		{name: "tilde only unchanged", in: "~", want: "~"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ExpandHome(tt.in))
+		})
+	}
+}
+
+func TestSelectSkillVersion_ExactMatchReturnsIt(t *testing.T) {
+	available := []string{"1.0.0", "1.1.0", "2.0.0"}
+	got, err := SelectSkillVersion(available, "1.1.0", "skills-local", true)
+	require.NoError(t, err)
+	assert.Equal(t, "1.1.0", got)
+}
+
+func TestSelectSkillVersion_LatestEmpty(t *testing.T) {
+	available := []string{"1.0.0", "1.1.0", "2.0.0"}
+	got, err := SelectSkillVersion(available, "", "skills-local", true)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", got)
+}
+
+func TestSelectSkillVersion_LatestKeyword(t *testing.T) {
+	available := []string{"1.0.0", "3.0.0", "2.0.0"}
+	got, err := SelectSkillVersion(available, "latest", "skills-local", true)
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.0", got)
+}
+
+func TestSelectSkillVersion_NotFoundQuiet(t *testing.T) {
+	available := []string{"1.0.0", "1.1.0"}
+	_, err := SelectSkillVersion(available, "9.9.9", "skills-local", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSelectSkillVersion_EmptyAvailableList(t *testing.T) {
+	_, err := SelectSkillVersion([]string{}, "", "skills-local", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "latest version")
+}


### PR DESCRIPTION
### Overview 

**Improvement of skill install command. The following features and changes were made on this the existing skill install command**

-  Jfrog-cli can now use agent_config.json file to know agents and their global + project path to install skills\
- User can navigate to "~/.jfrog/skills/agent_config.json" file and add custom agent's global + project path
- If user don't give any --project-dir / global to "jf skills list" or "jf skills install" commands, CWD is taken as the path by default to install (or show installed agents)
- Moved utility functions to skills_util.go
- To support backward compatability, we are still supporting --path, if user provides --path, (--agent or --project-dir) is not needed.   --path overrides --agent/--project-dir
- Added --format json, default format is table

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
