### PR TITLE
RTECO-1011 - Improve skill commands

### DIFF
--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -81,9 +81,9 @@ const (
 	PipenvInstall          = "pipenv-install"
 	PoetryConfig           = "poetry-config"
 	Poetry                 = "poetry"
-	Ping                   = "ping"
-	NugetDepsTree          = "nuget-deps-tree"
-	RtCurl                 = "rt-curl"
+	Ping           = "ping"
+	NugetDepsTree  = "nuget-deps-tree"
+	RtCurl         = "rt-curl"
 	TemplateConsumer       = "template-consumer"
 	ReplicationCreate      = "replication-create"
 	RepoCreate             = "repo-create"
@@ -223,8 +223,8 @@ const (
 	downloadSyncDeletes  = downloadPrefix + syncDeletes
 	downloadMinSplit     = downloadPrefix + MinSplit
 	downloadSplitCount   = downloadPrefix + SplitCount
-	validateSymlinks     = "validate-symlinks"
-	skipChecksum         = "skip-checksum"
+	validateSymlinks      = "validate-symlinks"
+	skipChecksum          = "skip-checksum"
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -317,11 +317,11 @@ const (
 	repo = "repo"
 
 	// Unique git-lfs-clean flags
-	glcPrefix = "glc-"
-	glcDryRun = glcPrefix + dryRun
-	glcQuiet  = glcPrefix + quiet
-	glcRepo   = glcPrefix + repo
-	refs      = "refs"
+	glcPrefix  = "glc-"
+	glcDryRun  = glcPrefix + dryRun
+	glcQuiet   = glcPrefix + quiet
+	glcRepo    = glcPrefix + repo
+	refs       = "refs"
 
 	// Build tool config flags
 	global          = "global"
@@ -528,6 +528,8 @@ const (
 	skillsLimit         = "skills-" + limit
 	skillsSortBy        = "skills-" + sortBy
 	skillsSortOrder     = "skills-" + sortOrder
+	skillsCheckUpdates  = "skills-check-updates"
+	checkUpdates        = "check-updates"
 )
 
 var commandFlags = map[string][]string{
@@ -885,7 +887,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, skillsFormat, propSearch,
 	},
 	SkillsList: {
-		url, user, password, accessToken, serverId, repo, agent, projectDir, skillsGlobal, skillsFormat, skillsLimit, skillsSortBy, skillsSortOrder,
+		url, user, password, accessToken, serverId, repo, agent, projectDir, skillsGlobal, skillsFormat, skillsLimit, skillsSortBy, skillsSortOrder, skillsCheckUpdates,
 	},
 }
 
@@ -1206,6 +1208,7 @@ var flagsMap = map[string]components.Flag{
 	skillsLimit:         components.NewStringFlag(limit, "Maximum number of skills to return. Fetches all by default.", components.SetMandatoryFalse()),
 	skillsSortBy:        components.NewStringFlag(sortBy, "Field to sort by. With --repo: updated (default), downloads. With --agent: name (default, only option).", components.SetMandatoryFalse()),
 	skillsSortOrder:     components.NewStringFlag(sortOrder, "Sort order for --agent. Supported: asc (default), desc. Not supported with --repo.", components.SetMandatoryFalse()),
+	skillsCheckUpdates:  components.NewBoolFlag(checkUpdates, "With --agent only: compare installed skills to the registry (requires jf config server). Adds registry latest and status columns. Not supported with --repo.", components.WithBoolDefaultValueFalse()),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -81,9 +81,9 @@ const (
 	PipenvInstall          = "pipenv-install"
 	PoetryConfig           = "poetry-config"
 	Poetry                 = "poetry"
-	Ping           = "ping"
-	NugetDepsTree  = "nuget-deps-tree"
-	RtCurl         = "rt-curl"
+	Ping                   = "ping"
+	NugetDepsTree          = "nuget-deps-tree"
+	RtCurl                 = "rt-curl"
 	TemplateConsumer       = "template-consumer"
 	ReplicationCreate      = "replication-create"
 	RepoCreate             = "repo-create"
@@ -223,8 +223,8 @@ const (
 	downloadSyncDeletes  = downloadPrefix + syncDeletes
 	downloadMinSplit     = downloadPrefix + MinSplit
 	downloadSplitCount   = downloadPrefix + SplitCount
-	validateSymlinks      = "validate-symlinks"
-	skipChecksum          = "skip-checksum"
+	validateSymlinks     = "validate-symlinks"
+	skipChecksum         = "skip-checksum"
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -317,11 +317,11 @@ const (
 	repo = "repo"
 
 	// Unique git-lfs-clean flags
-	glcPrefix  = "glc-"
-	glcDryRun  = glcPrefix + dryRun
-	glcQuiet   = glcPrefix + quiet
-	glcRepo    = glcPrefix + repo
-	refs       = "refs"
+	glcPrefix = "glc-"
+	glcDryRun = glcPrefix + dryRun
+	glcQuiet  = glcPrefix + quiet
+	glcRepo   = glcPrefix + repo
+	refs      = "refs"
 
 	// Build tool config flags
 	global          = "global"
@@ -876,7 +876,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, agent, projectDir, skillsGlobal, installPath, skillsFormat, skillsQuiet,
 	},
 	SkillsUpdate: {
-		url, user, password, accessToken, serverId, repo, version, installPath, dryRun, skillsForce, skillsQuiet,
+		url, user, password, accessToken, serverId, repo, version, agent, projectDir, skillsGlobal, installPath, skillsFormat, skillsQuiet, dryRun, skillsForce,
 	},
 	SkillsDelete: {
 		url, user, password, accessToken, serverId, repo, version, dryRun,
@@ -1191,7 +1191,7 @@ var flagsMap = map[string]components.Flag{
 	// Skills-specific flags
 	repo:                components.NewStringFlag(repo, "Skills repository key in Artifactory.", components.SetMandatoryFalse()),
 	version:             components.NewStringFlag(version, "Skill version (semver, e.g. 1.2.0) or \"latest\".", components.SetMandatoryFalse()),
-	installPath:         components.NewStringFlag(installPath, "Base directory for a direct install: files go under <path>/<slug>. Same as skills update. Mutually exclusive with --agent, --project-dir, and --global on install. Default for update only: current directory.", components.SetMandatoryFalse()),
+	installPath:         components.NewStringFlag(installPath, "Base directory for a direct install or update: files go under <path>/<slug>. Mutually exclusive with --agent, --project-dir, and --global.", components.SetMandatoryFalse()),
 	skillsForce:         components.NewBoolFlag(skillsForce, "Re-download and reinstall even if the skill is already at the target version.", components.WithBoolDefaultValueFalse()),
 	signingKey:          components.NewStringFlag(signingKey, "Path to PGP private key for signing evidence. Overrides EVD_SIGNING_KEY_PATH env var.", components.SetMandatoryFalse()),
 	keyAlias:            components.NewStringFlag(keyAlias, "Alias for the signing key. Overrides EVD_KEY_ALIAS env var.", components.SetMandatoryFalse()),
@@ -1200,9 +1200,9 @@ var flagsMap = map[string]components.Flag{
 	propSearch:          components.NewBoolFlag(propSearch, "Use Artifactory property search (skill.name) instead of Skills API search.", components.WithBoolDefaultValueFalse()),
 	skipScan:            components.NewBoolFlag(skipScan, "Skip Xray security scan after publish. Can also be set via JFROG_CLI_SKIP_SKILLS_SCAN=true.", components.WithBoolDefaultValueFalse()),
 	autoDeleteOnFailure: components.NewBoolFlag(autoDeleteOnFailure, "Automatically delete the artifact if Xray scan identifies it as malicious.", components.WithBoolDefaultValueFalse()),
-	agent:               components.NewStringFlag(agent, "Comma-separated AI agent names for install; a single name for list. Resolved from ~/.jfrog/agents/agent-config.json first, then built-in fallbacks (claude-code, cursor, github-copilot, windsurf, codex, agents).", components.SetMandatoryFalse()),
+	agent:               components.NewStringFlag(agent, "Comma-separated AI agent names for install or update; a single name for list. Resolved from ~/.jfrog/agents/agent-config.json first, then built-in fallbacks (claude-code, cursor, github-copilot, windsurf, codex, agents).", components.SetMandatoryFalse()),
 	projectDir:          components.NewStringFlag(projectDir, "Project root directory combined with each agent's project path from config. Default: current directory when --global is not set. Mutually exclusive with --global.", components.SetMandatoryFalse()),
-	skillsGlobal:        components.NewBoolFlag(global, "Install or list under each agent's global directory from config instead of under the project root. Mutually exclusive with --project-dir.", components.WithBoolDefaultValueFalse()),
+	skillsGlobal:        components.NewBoolFlag(global, "Install, update, or list under each agent's global directory from config instead of under the project root. Mutually exclusive with --project-dir.", components.WithBoolDefaultValueFalse()),
 	skillsLimit:         components.NewStringFlag(limit, "Maximum number of skills to return. Fetches all by default.", components.SetMandatoryFalse()),
 	skillsSortBy:        components.NewStringFlag(sortBy, "Field to sort by. With --repo: updated (default), downloads. With --agent: name (default, only option).", components.SetMandatoryFalse()),
 	skillsSortOrder:     components.NewStringFlag(sortOrder, "Sort order for --agent. Supported: asc (default), desc. Not supported with --repo.", components.SetMandatoryFalse()),

--- a/skills/cli/cli.go
+++ b/skills/cli/cli.go
@@ -38,7 +38,7 @@ func GetCommands() []components.Command {
 			Name:        "update",
 			Hidden:      true,
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsUpdate),
-			Description: "Update an installed skill to the latest (or a specific) version. Use --path to specify where the skill is installed (default: current directory). Use --dry-run to preview and --force to re-download even if already up to date.",
+			Description: "Update an installed skill to the latest (or a specific) version. Same targeting flags as install: use --agent (comma-separated) with --project-dir (default: current directory) or --global, or --path <dir> for a direct update at <dir>/<slug>. Preflight skips targets that are not installed or already at the target version (use --force to re-download). Logs skip and failure reasons when not quiet. Downloads once for all targets. Use --dry-run to preview, --format json for machine-readable summaries.",
 			Arguments:   getUpdateArguments(),
 			Action:      update.RunUpdate,
 		},

--- a/skills/cli/cli.go
+++ b/skills/cli/cli.go
@@ -16,7 +16,7 @@ func GetCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsList),
-			Description: "List skills from an Artifactory repository (--repo) or from a local agent install (--agent). Exactly one of --repo or --agent is required. With --agent, use --project-dir for the project root (default: current directory) or --global for each agent's global directory.",
+			Description: "List skills: registry (--repo), project-local (--agent [--project-dir], default .), or global-local (--agent --global). Use --check-updates with --agent to compare installs to the registry. --repo and --agent are mutually exclusive; --global and --project-dir are mutually exclusive.",
 			Action:      skillslist.RunList,
 			Hidden:      true,
 		},
@@ -38,7 +38,7 @@ func GetCommands() []components.Command {
 			Name:        "update",
 			Hidden:      true,
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsUpdate),
-			Description: "Update an installed skill to the latest (or a specific) version. Same targeting flags as install: use --agent (comma-separated) with --project-dir (default: current directory) or --global, or --path <dir> for a direct update at <dir>/<slug>. Preflight skips targets that are not installed or already at the target version (use --force to re-download). Logs skip and failure reasons when not quiet. Downloads once for all targets. Use --dry-run to preview, --format json for machine-readable summaries.",
+			Description: "Update an installed skill to the latest (or a specific) version. Same targeting flags as install: use --agent (comma-separated) with --project-dir (default: current directory) or --global, or --path <dir> for a direct update at <dir>/<slug>. Pre-update checks skip targets that are not installed or already at the target version (use --force to re-download). Logs skip and failure reasons when not quiet. Downloads once for all targets. Use --dry-run to preview, --format json for machine-readable summaries.",
 			Arguments:   getUpdateArguments(),
 			Action:      update.RunUpdate,
 		},

--- a/skills/commands/install/install.go
+++ b/skills/commands/install/install.go
@@ -31,7 +31,8 @@ const (
 // agentSkillInstallDir pairs an agent (or path-mode sentinel) with the absolute skill install directory (includes slug).
 type agentSkillInstallDir struct {
 	Agent          common.AgentSpec
-	DestinationDir string // absolute; ends with /<slug>
+	DestinationDir string
+	Scope          string
 }
 
 // InstallCommand installs a skill for configured agents or legacy --path (update).
@@ -42,12 +43,23 @@ type InstallCommand struct {
 	version       string
 	agents        []common.AgentSpec
 	scope         scope
-	projectDir    string // project root for project scope (--project-dir)
+	projectDir    string
 	// installPath is the base directory for jf skills install --path. The skill is installed at
 	// <installPath>/<slug> and takes precedence over --agent / --project-dir / --skills-global.
 	installPath string
 	format      string
 	quiet       bool
+	// explicitTargets, when set, overrides resolveAgentTargetDirectories (used by skills update).
+	explicitTargets []common.AgentTarget
+	suppressSummary bool
+}
+
+// FetchExtractInvocationCount counts completed FetchAndExtractTo calls (for tests).
+var FetchExtractInvocationCount int
+
+// ResetFetchExtractInvocationCount resets FetchExtractInvocationCount (for tests).
+func ResetFetchExtractInvocationCount() {
+	FetchExtractInvocationCount = 0
 }
 
 func NewInstallCommand() *InstallCommand {
@@ -112,6 +124,18 @@ func (ic *InstallCommand) SetInstallPath(installPath string) *InstallCommand {
 	return ic
 }
 
+// SetTargets overrides target resolution. Used by skills update for a filtered subset.
+func (ic *InstallCommand) SetTargets(targets []common.AgentTarget) *InstallCommand {
+	ic.explicitTargets = targets
+	return ic
+}
+
+// SetSuppressSummary skips PrintSummary at the end of Run (caller prints a merged summary).
+func (ic *InstallCommand) SetSuppressSummary(suppress bool) *InstallCommand {
+	ic.suppressSummary = suppress
+	return ic
+}
+
 func (ic *InstallCommand) ServerDetails() (*config.ServerDetails, error) {
 	return ic.serverDetails, nil
 }
@@ -121,7 +145,7 @@ func (ic *InstallCommand) CommandName() string {
 }
 
 func (ic *InstallCommand) Run() error {
-	if ic.installPath == "" && len(ic.agents) == 0 {
+	if ic.installPath == "" && len(ic.agents) == 0 && len(ic.explicitTargets) == 0 {
 		return fmt.Errorf("at least one agent is required")
 	}
 
@@ -150,106 +174,145 @@ func (ic *InstallCommand) Run() error {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	zipPath, err := ic.downloadZip(tmpDir)
+	unzipDir, err := ic.FetchAndExtractTo(tmpDir)
 	if err != nil {
-		if strings.Contains(err.Error(), "403") {
-			return ic.diagnoseDownloadForbidden(err)
-		}
-		return fmt.Errorf("download failed: %w", err)
-	}
-
-	unzipDir := filepath.Join(tmpDir, "contents")
-	if err := unzipFile(zipPath, unzipDir); err != nil {
-		return fmt.Errorf("unzip failed: %w", err)
-	}
-
-	if err := ic.verifyEvidence(); err != nil {
-		if ic.quiet || common.IsNonInteractive() {
-			if common.ShouldFailOnMissingEvidence() {
-				return fmt.Errorf("evidence verification failed for skill '%s': %s. Set JFROG_SKILLS_DISABLE_QUIET_FAILURE=true to proceed without evidence", ic.slug, err.Error())
-			}
-			log.Warn(fmt.Sprintf("Evidence verification failed for skill '%s': %s. Proceeding with installation.", ic.slug, err.Error()))
-		} else {
-			log.Warn("Evidence verification failed:", err.Error())
-			if !coreutils.AskYesNo("The skill is unattested. Continue with installation?", false) {
-				return fmt.Errorf("installation aborted by user")
-			}
-		}
-	}
-
-	results := make([]installAttemptResult, 0, len(installTargets))
-	for _, target := range installTargets {
-		if err := ensureDestinationDir(target.DestinationDir); err != nil {
-			ir := installAttemptResult{
-				Agent:  target.Agent.Name,
-				Scope:  string(ic.scope),
-				Path:   target.DestinationDir,
-				Status: skillInstallStatusFailed,
-				Detail: err.Error(),
-			}
-			results = append(results, ir)
-			continue
-		}
-		if err := copyDir(unzipDir, target.DestinationDir); err != nil {
-			ir := installAttemptResult{
-				Agent:  target.Agent.Name,
-				Scope:  string(ic.scope),
-				Path:   target.DestinationDir,
-				Status: skillInstallStatusFailed,
-				Detail: err.Error(),
-			}
-			results = append(results, ir)
-			continue
-		}
-		ir := installAttemptResult{
-			Agent:  target.Agent.Name,
-			Scope:  string(ic.scope),
-			Path:   target.DestinationDir,
-			Status: skillInstallStatusOK,
-			Detail: skillInstallDetailOK,
-		}
-		results = append(results, ir)
-	}
-
-	if err := printSummary(ic.slug, ic.version, results, ic.format); err != nil {
 		return err
 	}
 
+	results := ic.copyExtractedToTargets(unzipDir, installTargets)
+
+	if !ic.suppressSummary {
+		if err := PrintSummary(ic.slug, ic.version, results, ic.format); err != nil {
+			return err
+		}
+	}
+
 	for _, result := range results {
-		if result.Status != skillInstallStatusOK {
+		if result.Status != SummaryStatusOK {
+			if ic.suppressSummary {
+				return fmt.Errorf("installation failed for one or more targets")
+			}
 			return fmt.Errorf("installation failed for one or more agents (see summary above)")
 		}
 	}
 	return nil
 }
 
+// FetchAndExtractTo downloads the skill zip into tmpDir, extracts it, and runs evidence checks.
+// The returned unzipDir is under tmpDir; callers must keep tmpDir until copies finish.
+func (ic *InstallCommand) FetchAndExtractTo(tmpDir string) (unzipDir string, err error) {
+	FetchExtractInvocationCount++
+
+	zipPath, err := ic.downloadZip(tmpDir)
+	if err != nil {
+		if strings.Contains(err.Error(), "403") {
+			return "", ic.diagnoseDownloadForbidden(err)
+		}
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+
+	unzipDir = filepath.Join(tmpDir, "contents")
+	if err := unzipFile(zipPath, unzipDir); err != nil {
+		return "", fmt.Errorf("unzip failed: %w", err)
+	}
+
+	if err := ic.handleEvidenceVerification(); err != nil {
+		return "", err
+	}
+	return unzipDir, nil
+}
+
+// CopyExtractedToAgentTargets copies an unpacked skill tree to the given resolved targets.
+func (ic *InstallCommand) CopyExtractedToAgentTargets(unzipDir string, targets []common.AgentTarget) []SummaryRow {
+	return ic.copyExtractedToTargets(unzipDir, agentDirsFromTargets(targets))
+}
+
+func (ic *InstallCommand) copyExtractedToTargets(unzipDir string, installTargets []agentSkillInstallDir) []SummaryRow {
+	results := make([]SummaryRow, 0, len(installTargets))
+	for _, target := range installTargets {
+		if err := ensureDestinationDir(target.DestinationDir); err != nil {
+			results = append(results, SummaryRow{
+				Agent:  target.Agent.Name,
+				Scope:  target.Scope,
+				Path:   target.DestinationDir,
+				Status: SummaryStatusFailed,
+				Detail: err.Error(),
+			})
+			continue
+		}
+		if err := copyDir(unzipDir, target.DestinationDir); err != nil {
+			results = append(results, SummaryRow{
+				Agent:  target.Agent.Name,
+				Scope:  target.Scope,
+				Path:   target.DestinationDir,
+				Status: SummaryStatusFailed,
+				Detail: err.Error(),
+			})
+			continue
+		}
+		results = append(results, SummaryRow{
+			Agent:  target.Agent.Name,
+			Scope:  target.Scope,
+			Path:   target.DestinationDir,
+			Status: SummaryStatusOK,
+			Detail: SummaryDetailOKInstall,
+		})
+	}
+	return results
+}
+
+func (ic *InstallCommand) handleEvidenceVerification() error {
+	err := ic.verifyEvidence()
+	if err == nil {
+		return nil
+	}
+	if ic.quiet || common.IsNonInteractive() {
+		if common.ShouldFailOnMissingEvidence() {
+			return fmt.Errorf("evidence verification failed for skill '%s': %s. Set JFROG_SKILLS_DISABLE_QUIET_FAILURE=true to proceed without evidence", ic.slug, err.Error())
+		}
+		log.Warn(fmt.Sprintf("Evidence verification failed for skill '%s': %s. Proceeding with installation.", ic.slug, err.Error()))
+		return nil
+	}
+	log.Warn("Evidence verification failed:", err.Error())
+	if !coreutils.AskYesNo("The skill is unattested. Continue with installation?", false) {
+		return fmt.Errorf("installation aborted by user")
+	}
+	return nil
+}
+
 // resolveAgentTargetDirectories builds per-agent dest dirs, or one direct target if installPath is set (install/update --path).
 func (ic *InstallCommand) resolveAgentTargetDirectories() ([]agentSkillInstallDir, error) {
+	if len(ic.explicitTargets) > 0 {
+		return agentDirsFromTargets(ic.explicitTargets), nil
+	}
 	if ic.installPath != "" {
-		base, err := filepath.Abs(ic.installPath)
+		targets, err := common.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
 		if err != nil {
-			return nil, fmt.Errorf("invalid install path %q: %w", ic.installPath, err)
+			return nil, err
 		}
-		return []agentSkillInstallDir{{
-			Agent:          common.AgentSpec{Name: "(path)"},
-			DestinationDir: filepath.Join(base, ic.slug),
-		}}, nil
+		return agentDirsFromTargets(targets), nil
 	}
 	if ic.scope == scopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
-	targets := make([]agentSkillInstallDir, 0, len(ic.agents))
-	for _, agentSpec := range ic.agents {
-		base, err := common.ResolveAgentInstallDir(agentSpec, ic.projectDir, ic.scope == scopeGlobal)
-		if err != nil {
-			return nil, err
-		}
-		targets = append(targets, agentSkillInstallDir{
-			Agent:          agentSpec,
-			DestinationDir: filepath.Join(base, ic.slug),
-		})
+	isGlobal := ic.scope == scopeGlobal
+	targets, err := common.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
+	if err != nil {
+		return nil, err
 	}
-	return targets, nil
+	return agentDirsFromTargets(targets), nil
+}
+
+func agentDirsFromTargets(targets []common.AgentTarget) []agentSkillInstallDir {
+	out := make([]agentSkillInstallDir, len(targets))
+	for i, t := range targets {
+		out[i] = agentSkillInstallDir{
+			Agent:          t.Agent,
+			DestinationDir: t.DestinationDir,
+			Scope:          string(t.Scope),
+		}
+	}
+	return out
 }
 
 func (ic *InstallCommand) downloadZip(tmpDir string) (string, error) {
@@ -310,6 +373,62 @@ func (ic *InstallCommand) verifyEvidence() error {
 	return common.VerifyEvidence(ic.serverDetails, common.VerifyEvidenceOpts{
 		SubjectRepoPath: subjectRepoPath,
 	})
+}
+
+// RunInstall is the CLI action for `jf skills install`.
+func RunInstall(c *components.Context) error {
+	if c.GetNumberOfArgs() < 1 {
+		return fmt.Errorf("usage: jf skills install <slug> (--agent <name[,name...]> [--global] [--project-dir <dir>]] | --path <dir>) [--repo <repo>] [--version <ver>]")
+	}
+
+	slug := c.GetArgumentAt(0)
+	if err := publish.ValidateSlug(slug); err != nil {
+		return err
+	}
+
+	absoluteInstallBaseDir, specs, projectDirAbs, isGlobal, err := common.ValidateInstallFlags(c)
+	if err != nil {
+		return err
+	}
+
+	serverDetails, err := common.GetServerDetails(c)
+	if err != nil {
+		return err
+	}
+	quiet := common.IsQuiet(c)
+	repoKey, err := common.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet)
+	if err != nil {
+		return err
+	}
+
+	version := c.GetStringFlagValue("version")
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+	if absoluteInstallBaseDir != "" {
+		return NewInstallCommand().
+			SetServerDetails(serverDetails).
+			SetRepoKey(repoKey).
+			SetSlug(slug).
+			SetVersion(version).
+			SetInstallPath(absoluteInstallBaseDir).
+			SetFormat(format).
+			SetQuiet(quiet).
+			Run()
+	}
+
+	return NewInstallCommand().
+		SetServerDetails(serverDetails).
+		SetRepoKey(repoKey).
+		SetSlug(slug).
+		SetVersion(version).
+		SetAgents(specs).
+		SetGlobal(isGlobal).
+		SetProjectDir(projectDirAbs).
+		SetFormat(format).
+		SetQuiet(quiet).
+		Run()
 }
 
 // ensureDestinationDir mkdirs if missing, errors if path exists and is not a dir.
@@ -376,7 +495,6 @@ func unzipFile(src, dest string) error {
 }
 
 func extractFile(f *zip.File, dest string) error {
-	// Reject paths containing traversal sequences as defense-in-depth
 	if strings.Contains(dest, "..") {
 		return fmt.Errorf("illegal file path: %s", dest)
 	}
@@ -450,148 +568,4 @@ func copyFile(src, dst string) error {
 
 	_, err = io.Copy(out, in)
 	return err
-}
-
-// validateInstallCommand validates `jf skills install` flags and resolves --path or agent/project options.
-// absoluteInstallBaseDir is the absolute --path base (skill at join(base, slug)); empty when using agents.
-func validateInstallCommand(c *components.Context) (absoluteInstallBaseDir string, specs []common.AgentSpec, projectDirAbs string, isGlobal bool, err error) {
-	// Trimmed --path; non-empty selects path mode instead of --agent.
-	pathInstallBase := strings.TrimSpace(c.GetStringFlagValue("path"))
-	rawAgents := strings.TrimSpace(c.GetStringFlagValue("agent"))
-	isGlobal = c.GetBoolFlagValue("global")
-	projectDir := strings.TrimSpace(c.GetStringFlagValue("project-dir"))
-
-	if pathInstallBase != "" {
-		if rawAgents != "" {
-			err = fmt.Errorf("--path cannot be combined with --agent")
-			return
-		}
-		if isGlobal {
-			err = fmt.Errorf("--path cannot be combined with --global")
-			return
-		}
-		if projectDir != "" {
-			err = fmt.Errorf("--path cannot be combined with --project-dir")
-			return
-		}
-		if err = common.ValidateExistingDir(pathInstallBase); err != nil {
-			err = fmt.Errorf("--path: %w", err)
-			return
-		}
-		var absBase string
-		absBase, err = filepath.Abs(pathInstallBase)
-		if err != nil {
-			err = fmt.Errorf("invalid --path %q: %w", pathInstallBase, err)
-			return
-		}
-		absoluteInstallBaseDir = absBase
-		return
-	}
-
-	var registry map[string]common.AgentSpec
-	registry, err = common.LoadAgentRegistry()
-	if err != nil {
-		return
-	}
-	if rawAgents == "" {
-		err = fmt.Errorf("--agent is required unless --path is set. Supported agents: %s", common.AgentNames(registry))
-		return
-	}
-
-	var agentNames []string
-	agentNames, err = common.ParseAgentList(rawAgents)
-	if err != nil {
-		return
-	}
-
-	specs = make([]common.AgentSpec, 0, len(agentNames))
-	for _, name := range agentNames {
-		var spec common.AgentSpec
-		spec, err = common.ResolveAgent(registry, name)
-		if err != nil {
-			return
-		}
-		specs = append(specs, spec)
-	}
-
-	if isGlobal && projectDir != "" {
-		err = fmt.Errorf("--global and --project-dir are mutually exclusive, please choose either --global or --project-dir")
-		return
-	}
-
-	if !isGlobal {
-		dir := projectDir
-		if dir == "" {
-			dir = "."
-		}
-		var abs string
-		abs, err = filepath.Abs(dir)
-		if err != nil {
-			err = fmt.Errorf("invalid --project-dir %q: %w", dir, err)
-			return
-		}
-		info, statErr := os.Stat(abs)
-		if statErr != nil || !info.IsDir() {
-			err = fmt.Errorf("--project-dir %q is not an existing directory", dir)
-			return
-		}
-		projectDirAbs = abs
-	}
-	return
-}
-
-// RunInstall is the CLI action for `jf skills install`.
-func RunInstall(c *components.Context) error {
-	if c.GetNumberOfArgs() < 1 {
-		return fmt.Errorf("usage: jf skills install <slug> (--agent <name[,name...]> [--global] [--project-dir <dir>]] | --path <dir>) [--repo <repo>] [--version <ver>]")
-	}
-
-	slug := c.GetArgumentAt(0)
-	if err := publish.ValidateSlug(slug); err != nil {
-		return err
-	}
-
-	absoluteInstallBaseDir, specs, projectDirAbs, isGlobal, err := validateInstallCommand(c)
-	if err != nil {
-		return err
-	}
-
-	serverDetails, err := common.GetServerDetails(c)
-	if err != nil {
-		return err
-	}
-	quiet := common.IsQuiet(c)
-	repoKey, err := common.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet)
-	if err != nil {
-		return err
-	}
-
-	version := c.GetStringFlagValue("version")
-	format := "table"
-	if c.GetStringFlagValue("format") != "" {
-		format = c.GetStringFlagValue("format")
-	}
-	if absoluteInstallBaseDir != "" {
-		return NewInstallCommand().
-			SetServerDetails(serverDetails).
-			SetRepoKey(repoKey).
-			SetSlug(slug).
-			SetVersion(version).
-			SetInstallPath(absoluteInstallBaseDir).
-			SetFormat(format).
-			SetQuiet(quiet).
-			Run()
-	}
-
-	return NewInstallCommand().
-		SetServerDetails(serverDetails).
-		SetRepoKey(repoKey).
-		SetSlug(slug).
-		SetVersion(version).
-		SetAgents(specs).
-		SetGlobal(isGlobal).
-		SetProjectDir(projectDirAbs).
-		SetFormat(format).
-		SetQuiet(quiet).
-		Run()
 }

--- a/skills/commands/install/install.go
+++ b/skills/commands/install/install.go
@@ -31,7 +31,7 @@ const (
 // agentSkillInstallDir pairs an agent (or path-mode sentinel) with the absolute skill install directory (includes slug).
 type agentSkillInstallDir struct {
 	Agent          common.AgentSpec
-	DestinationDir string
+	DestinationDir string // absolute; ends with /<slug>
 	Scope          string
 }
 
@@ -43,7 +43,7 @@ type InstallCommand struct {
 	version       string
 	agents        []common.AgentSpec
 	scope         scope
-	projectDir    string
+	projectDir    string // project root for project scope (--project-dir)
 	// installPath is the base directory for jf skills install --path. The skill is installed at
 	// <installPath>/<slug> and takes precedence over --agent / --project-dir / --skills-global.
 	installPath string
@@ -52,14 +52,6 @@ type InstallCommand struct {
 	// explicitTargets, when set, overrides resolveAgentTargetDirectories (used by skills update).
 	explicitTargets []common.AgentTarget
 	suppressSummary bool
-}
-
-// FetchExtractInvocationCount counts completed FetchAndExtractTo calls (for tests).
-var FetchExtractInvocationCount int
-
-// ResetFetchExtractInvocationCount resets FetchExtractInvocationCount (for tests).
-func ResetFetchExtractInvocationCount() {
-	FetchExtractInvocationCount = 0
 }
 
 func NewInstallCommand() *InstallCommand {
@@ -201,8 +193,6 @@ func (ic *InstallCommand) Run() error {
 // FetchAndExtractTo downloads the skill zip into tmpDir, extracts it, and runs evidence checks.
 // The returned unzipDir is under tmpDir; callers must keep tmpDir until copies finish.
 func (ic *InstallCommand) FetchAndExtractTo(tmpDir string) (unzipDir string, err error) {
-	FetchExtractInvocationCount++
-
 	zipPath, err := ic.downloadZip(tmpDir)
 	if err != nil {
 		if strings.Contains(err.Error(), "403") {
@@ -241,6 +231,16 @@ func (ic *InstallCommand) copyExtractedToTargets(unzipDir string, installTargets
 			continue
 		}
 		if err := copyDir(unzipDir, target.DestinationDir); err != nil {
+			results = append(results, SummaryRow{
+				Agent:  target.Agent.Name,
+				Scope:  target.Scope,
+				Path:   target.DestinationDir,
+				Status: SummaryStatusFailed,
+				Detail: err.Error(),
+			})
+			continue
+		}
+		if err := ic.writeSkillInfoManifest(target); err != nil {
 			results = append(results, SummaryRow{
 				Agent:  target.Agent.Name,
 				Scope:  target.Scope,
@@ -313,6 +313,26 @@ func agentDirsFromTargets(targets []common.AgentTarget) []agentSkillInstallDir {
 		}
 	}
 	return out
+}
+
+func (ic *InstallCommand) writeSkillInfoManifest(target agentSkillInstallDir) error {
+	dirName := filepath.Base(target.DestinationDir)
+	slug := ic.slug
+	if dirName != "" && dirName != slug {
+		log.Warn(fmt.Sprintf("Install directory name %q differs from slug %q; manifest will record slug %q for API consistency", dirName, slug, slug))
+	}
+	manifest := common.SkillInfoManifest{
+		SchemaVersion:    common.SkillInfoManifestSchemaVersion,
+		Repo:             ic.repoKey,
+		Slug:             slug,
+		InstalledVersion: ic.version,
+		Scope:            target.Scope,
+		Agent:            target.Agent.Name,
+	}
+	if target.Scope == string(common.ScopeProject) && ic.projectDir != "" {
+		manifest.ProjectDir = ic.projectDir
+	}
+	return common.WriteSkillInfoManifest(target.DestinationDir, manifest)
 }
 
 func (ic *InstallCommand) downloadZip(tmpDir string) (string, error) {

--- a/skills/commands/install/install_test.go
+++ b/skills/commands/install/install_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -129,6 +130,20 @@ func TestEnsureDestinationDir_RejectsFileAtDestination(t *testing.T) {
 	err := ensureDestinationDir(dest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestFetchExtractInvocationCountIncrements(t *testing.T) {
+	ResetFetchExtractInvocationCount()
+	ic := NewInstallCommand().
+		SetServerDetails(&config.ServerDetails{Url: "http://127.0.0.1:59999"}).
+		SetRepoKey("skills-local").
+		SetSlug("noop-skill").
+		SetVersion("1.0.0").
+		SetQuiet(true)
+	tmp := t.TempDir()
+	_, err := ic.FetchAndExtractTo(tmp)
+	require.Error(t, err)
+	assert.Equal(t, 1, FetchExtractInvocationCount)
 }
 
 func createTestZip(t *testing.T, zipPath string, files map[string]string) {

--- a/skills/commands/install/install_test.go
+++ b/skills/commands/install/install_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,18 +131,36 @@ func TestEnsureDestinationDir_RejectsFileAtDestination(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a directory")
 }
 
-func TestFetchExtractInvocationCountIncrements(t *testing.T) {
-	ResetFetchExtractInvocationCount()
+func TestCopyExtractedToTargets_WritesInstallManifest(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: x\nversion: 1.0.0\n---\n"), 0o644))
+	dest := filepath.Join(t.TempDir(), "my-skill")
+	projectRoot := t.TempDir()
+
 	ic := NewInstallCommand().
-		SetServerDetails(&config.ServerDetails{Url: "http://127.0.0.1:59999"}).
-		SetRepoKey("skills-local").
-		SetSlug("noop-skill").
-		SetVersion("1.0.0").
-		SetQuiet(true)
-	tmp := t.TempDir()
-	_, err := ic.FetchAndExtractTo(tmp)
-	require.Error(t, err)
-	assert.Equal(t, 1, FetchExtractInvocationCount)
+		SetRepoKey("skills-repo").
+		SetSlug("my-skill").
+		SetVersion("1.2.3").
+		SetProjectDir(projectRoot)
+
+	targets := []agentSkillInstallDir{{
+		Agent:          common.AgentSpec{Name: "cursor"},
+		DestinationDir: dest,
+		Scope:          "project",
+	}}
+	rows := ic.copyExtractedToTargets(src, targets)
+	require.Len(t, rows, 1)
+	assert.Equal(t, SummaryStatusOK, rows[0].Status)
+
+	got, err := common.ReadSkillInfoManifest(dest)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "skills-repo", got.Repo)
+	assert.Equal(t, "my-skill", got.Slug)
+	assert.Equal(t, "1.2.3", got.InstalledVersion)
+	assert.Equal(t, "project", got.Scope)
+	assert.Equal(t, "cursor", got.Agent)
+	assert.Equal(t, projectRoot, got.ProjectDir)
 }
 
 func createTestZip(t *testing.T, zipPath string, files map[string]string) {

--- a/skills/commands/install/summary.go
+++ b/skills/commands/install/summary.go
@@ -13,7 +13,7 @@ import (
 const (
 	SummaryStatusOK        = "ok"
 	SummaryStatusFailed    = "failed"
-	SummaryStatusUpToDate  = "up-to-date"
+	SummaryStatusSkipped   = "skipped"
 	SummaryDetailOKInstall = "Executed successfully with no issues."
 )
 

--- a/skills/commands/install/summary.go
+++ b/skills/commands/install/summary.go
@@ -9,13 +9,16 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// Summary row statuses for install/update tables and JSON output.
 const (
-	skillInstallStatusOK     = "ok"
-	skillInstallStatusFailed = "failed"
-	skillInstallDetailOK     = "Executed successfully with no issues."
+	SummaryStatusOK        = "ok"
+	SummaryStatusFailed    = "failed"
+	SummaryStatusUpToDate  = "up-to-date"
+	SummaryDetailOKInstall = "Executed successfully with no issues."
 )
 
-type installAttemptResult struct {
+// SummaryRow is one row in the install/update summary table.
+type SummaryRow struct {
 	Agent  string `json:"agent" col-name:"Agent"`
 	Scope  string `json:"scope" col-name:"Scope"`
 	Path   string `json:"path" col-name:"Path"`
@@ -23,18 +26,19 @@ type installAttemptResult struct {
 	Detail string `json:"detail" col-name:"Detail"`
 }
 
-type installSummaryJSON struct {
-	Slug    string                 `json:"slug"`
-	Version string                 `json:"version"`
-	Results []installAttemptResult `json:"results"`
+type summaryJSON struct {
+	Slug    string       `json:"slug"`
+	Version string       `json:"version"`
+	Results []SummaryRow `json:"results"`
 }
 
-func printSummary(slug, version string, results []installAttemptResult, format string) error {
+// PrintSummary renders a table or JSON summary of an install/update run.
+func PrintSummary(slug, version string, results []SummaryRow, format string) error {
 	if len(results) == 0 {
 		return nil
 	}
 	if strings.EqualFold(format, "json") {
-		payload := installSummaryJSON{Slug: slug, Version: version, Results: results}
+		payload := summaryJSON{Slug: slug, Version: version, Results: results}
 		data, err := json.MarshalIndent(payload, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal install summary: %w", err)

--- a/skills/commands/list/list.go
+++ b/skills/commands/list/list.go
@@ -24,15 +24,36 @@ const (
 	sortByName      = "name"
 	sortOrderAsc    = "asc"
 	sortOrderDesc   = "desc"
+	emDash          = "\u2014"
+
+	manifestRepoUnknownDisplay = "(unknown)"
+	repoListSourcePrefix       = "Repo: "
+
+	listCheckStatusUnknown = "unknown"
+	listCheckStatusBehind  = "behind"
+	listCheckStatusCurrent = "current"
 )
 
-type listResult struct {
+// repoListRow is one row for registry mode (jf skills list --repo).
+type repoListRow struct {
 	Name        string `json:"name" col-name:"Name"`
 	Version     string `json:"version" col-name:"Version"`
 	Description string `json:"description" col-name:"Description"`
 	Source      string `json:"source" col-name:"Source"`
 }
 
+// localListRow is one row for local mode (jf skills list --agent).
+type localListRow struct {
+	Name           string `json:"name" col-name:"SKILL"`
+	Version        string `json:"version" col-name:"INSTALLED"`
+	Description    string `json:"description" col-name:"Description"`
+	Repo           string `json:"repo" col-name:"REPO"`
+	Path           string `json:"path" col-name:"PATH"`
+	RegistryLatest string `json:"registryLatest,omitempty" col-name:"REGISTRY LATEST" omitempty:"true"`
+	Status         string `json:"status,omitempty" col-name:"STATUS" omitempty:"true"`
+}
+
+// ListCommand lists skills from Artifactory or from a local agent install directory.
 type ListCommand struct {
 	serverDetails *config.ServerDetails
 	repoKey       string
@@ -43,6 +64,7 @@ type ListCommand struct {
 	limit         int
 	sortBy        string
 	sortOrder     string
+	checkUpdates  bool
 }
 
 func (lc *ListCommand) SetServerDetails(details *config.ServerDetails) *ListCommand {
@@ -65,8 +87,8 @@ func (lc *ListCommand) SetProjectDir(projectDir string) *ListCommand {
 	return lc
 }
 
-func (lc *ListCommand) SetGlobal(useGlobal bool) *ListCommand {
-	lc.global = useGlobal
+func (lc *ListCommand) SetGlobal(isGlobal bool) *ListCommand {
+	lc.global = isGlobal
 	return lc
 }
 
@@ -90,9 +112,33 @@ func (lc *ListCommand) SetSortOrder(sortOrder string) *ListCommand {
 	return lc
 }
 
+func (lc *ListCommand) SetCheckUpdates(v bool) *ListCommand {
+	lc.checkUpdates = v
+	return lc
+}
+
+// ErrSkillsListNoMode is returned when neither --repo nor --agent is set.
+func ErrSkillsListNoMode() error {
+	return fmt.Errorf(
+		"jf skills list requires exactly one of:\n"+
+			"  Registry:  jf skills list --repo <repository-key> [--limit N] [--sort-by updated|downloads]\n"+
+			"  Project:   jf skills list --agent <id> [--project-dir <path>]   (default --project-dir: current directory)\n"+
+			"  Global:    jf skills list --agent <id> --global\n"+
+			"\n"+
+			"Notes:\n"+
+			"  --repo and --agent are mutually exclusive.\n"+
+			"  With --agent, --global and --project-dir are mutually exclusive.\n"+
+			"  With --agent, add --check-updates to compare installs to the registry (needs jf config server).\n"+
+			"\n"+
+			"Supported agents: %s",
+		common.SupportedAgentsList(),
+	)
+}
+
+// Run validates flags and prints the listing.
 func (lc *ListCommand) Run() error {
 	if lc.repoKey == "" && lc.agentName == "" {
-		return fmt.Errorf("either --repo <repository> or --agent <agent-name> must be specified.\nSupported agents: %s", common.SupportedAgentsList())
+		return ErrSkillsListNoMode()
 	}
 	if lc.repoKey != "" && lc.agentName != "" {
 		return fmt.Errorf("--repo and --agent are mutually exclusive; specify only one")
@@ -102,6 +148,9 @@ func (lc *ListCommand) Run() error {
 	}
 
 	if lc.agentName != "" {
+		if lc.checkUpdates && lc.serverDetails == nil {
+			return fmt.Errorf("--check-updates requires a configured Artifactory server (same as other jf skills commands)")
+		}
 		return lc.listLocalSkills()
 	}
 	return lc.listRepoSkills()
@@ -113,21 +162,38 @@ func (lc *ListCommand) listRepoSkills() error {
 		return err
 	}
 
-	results := make([]listResult, 0, len(items))
+	results := make([]repoListRow, 0, len(items))
 	for _, item := range items {
 		name := item.Slug
 		latestVersion := ""
 		if item.LatestVersion != nil {
 			latestVersion = item.LatestVersion.Version
 		}
-		results = append(results, listResult{
+		results = append(results, repoListRow{
 			Name:        name,
 			Version:     latestVersion,
 			Description: item.Summary,
-			Source:      "Repo: " + lc.repoKey,
+			Source:      repoListSourcePrefix + lc.repoKey,
 		})
 	}
-	return lc.printResults(results)
+	return lc.printRepoResults(results)
+}
+
+func skillDisplayPath(skillDirAbs, projectDir string, global bool) string {
+	if !global && projectDir != "" {
+		relativeToProject, err := filepath.Rel(projectDir, skillDirAbs)
+		if err == nil && relativeToProject != "." && !strings.HasPrefix(relativeToProject, "..") {
+			return filepath.ToSlash(relativeToProject)
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		relativeToHome, err := filepath.Rel(home, skillDirAbs)
+		if err == nil && relativeToHome != "." && !strings.HasPrefix(relativeToHome, "..") {
+			return "~/" + filepath.ToSlash(relativeToHome)
+		}
+	}
+	return filepath.ToSlash(skillDirAbs)
 }
 
 func (lc *ListCommand) listLocalSkills() error {
@@ -154,26 +220,52 @@ func (lc *ListCommand) listLocalSkills() error {
 		return fmt.Errorf("failed to read skills directory %s: %w", dir, err)
 	}
 
-	var results []listResult
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		skillDir := filepath.Join(dir, e.Name())
-		meta, err := publish.ParseSkillMeta(skillDir)
-		if err != nil {
-			log.Warn(fmt.Sprintf("Skipping skill '%s':\n %s", e.Name(), err.Error()))
-			continue
-		}
-		results = append(results, listResult{
-			Name:        e.Name(),
-			Version:     meta.Version,
-			Description: meta.Description,
-			Source:      filepath.Join(dir, e.Name()),
-		})
+	projectDir := ""
+	if !lc.global {
+		projectDir = lc.projectDir
 	}
 
-	// Sort by name (only supported sort for local skills)
+	var results []localListRow
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(dir, entry.Name())
+		meta, err := publish.ParseSkillMeta(skillDir)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Skipping skill '%s':\n %s", entry.Name(), err.Error()))
+			continue
+		}
+		manifest, err := common.ReadSkillInfoManifest(skillDir)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Skill '%s': invalid install manifest (%s); treating as missing", entry.Name(), err.Error()))
+			manifest = nil
+		}
+		slugForAPI := entry.Name()
+		if manifest != nil && manifest.Slug != "" && manifest.Slug != entry.Name() {
+			log.Warn(fmt.Sprintf("Manifest slug %q differs from directory name %q; using directory name for registry lookups", manifest.Slug, entry.Name()))
+		}
+		repo := manifestRepoUnknownDisplay
+		if manifest != nil && strings.TrimSpace(manifest.Repo) != "" {
+			repo = manifest.Repo
+		}
+		installedVer := strings.TrimSpace(meta.Version)
+		if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+			installedVer = strings.TrimSpace(manifest.InstalledVersion)
+		}
+		row := localListRow{
+			Name:        entry.Name(),
+			Version:     installedVer,
+			Description: meta.Description,
+			Repo:        repo,
+			Path:        skillDisplayPath(skillDir, projectDir, lc.global),
+		}
+		if lc.checkUpdates {
+			lc.fillUpdateStatus(&row, slugForAPI)
+		}
+		results = append(results, row)
+	}
+
 	desc := strings.ToLower(lc.sortOrder) == sortOrderDesc
 	sort.Slice(results, func(i, j int) bool {
 		ni, nj := strings.ToLower(results[i].Name), strings.ToLower(results[j].Name)
@@ -183,17 +275,54 @@ func (lc *ListCommand) listLocalSkills() error {
 		return ni < nj
 	})
 
-	// Apply --limit
 	if lc.limit > 0 && len(results) > lc.limit {
 		results = results[:lc.limit]
 	}
 
-	return lc.printResults(results)
+	return lc.printLocalResults(results)
 }
 
-func (lc *ListCommand) printResults(results []listResult) error {
+func (lc *ListCommand) fillUpdateStatus(row *localListRow, slug string) {
+	if row.Repo == "" || row.Repo == manifestRepoUnknownDisplay {
+		row.RegistryLatest = emDash
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	versions, err := common.ListVersions(lc.serverDetails, row.Repo, slug)
+	if err != nil || len(versions) == 0 {
+		row.RegistryLatest = emDash
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	available := make([]string, len(versions))
+	for versionIndex, skillVersion := range versions {
+		available[versionIndex] = skillVersion.Version
+	}
+	latest, err := common.LatestVersion(available)
+	if err != nil {
+		row.RegistryLatest = emDash
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	row.RegistryLatest = latest
+	semverComparison, err := common.CompareSemver(row.Version, latest)
+	if err != nil {
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	switch {
+	case semverComparison < 0:
+		row.Status = listCheckStatusBehind
+	case semverComparison == 0:
+		row.Status = listCheckStatusCurrent
+	default:
+		row.Status = listCheckStatusCurrent
+	}
+}
+
+func (lc *ListCommand) printRepoResults(results []repoListRow) error {
 	if results == nil {
-		results = []listResult{}
+		results = []repoListRow{}
 	}
 	if strings.EqualFold(lc.format, "json") {
 		data, err := json.MarshalIndent(results, "", "  ")
@@ -210,6 +339,26 @@ func (lc *ListCommand) printResults(results []listResult) error {
 	return coreutils.PrintTable(results, "Skills", "No skills found", false)
 }
 
+func (lc *ListCommand) printLocalResults(results []localListRow) error {
+	if results == nil {
+		results = []localListRow{}
+	}
+	if strings.EqualFold(lc.format, "json") {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal results: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(results) == 0 {
+		log.Info("No skills found.")
+		return nil
+	}
+	return coreutils.PrintTable(results, "Skills", "No skills found", false)
+}
+
+// RunList is the CLI action for `jf skills list`.
 func RunList(c *components.Context) error {
 	repoKey := c.GetStringFlagValue("repo")
 	agentName := c.GetStringFlagValue("agent")
@@ -218,6 +367,13 @@ func RunList(c *components.Context) error {
 	if c.GetStringFlagValue("format") != "" {
 		format = c.GetStringFlagValue("format")
 	}
+
+	checkUpdates := c.GetBoolFlagValue("check-updates")
+	if checkUpdates && repoKey != "" {
+		return fmt.Errorf("--check-updates is only supported with --agent, not with --repo")
+	}
+
+	isGlobal := c.GetBoolFlagValue("global")
 
 	limit := 0
 	if limitStr := c.GetStringFlagValue("limit"); limitStr != "" {
@@ -232,7 +388,6 @@ func RunList(c *components.Context) error {
 	var sortOrder string
 
 	if repoKey != "" {
-		// --repo: sort-by accepts updated (default) or downloads; sort-order not supported
 		if c.GetStringFlagValue("sort-order") != "" {
 			return fmt.Errorf("--sort-order is not supported with --repo")
 		}
@@ -244,7 +399,6 @@ func RunList(c *components.Context) error {
 			sortBy = rawSortBy
 		}
 	} else {
-		// --agent / --project-dir: sort-by accepts name (default); sort-order asc/desc
 		sortBy = sortByName
 		if rawSortBy := strings.ToLower(c.GetStringFlagValue("sort-by")); rawSortBy != "" {
 			if rawSortBy != sortByName {
@@ -262,9 +416,7 @@ func RunList(c *components.Context) error {
 	}
 
 	projectDir := c.GetStringFlagValue("project-dir")
-	useGlobal := c.GetBoolFlagValue("global")
-	// --agent without --project-dir/--global: use cwd
-	if !useGlobal && projectDir == "" && agentName != "" {
+	if !isGlobal && projectDir == "" && agentName != "" {
 		projectDir = "."
 	}
 	if projectDir != "" {
@@ -279,13 +431,14 @@ func RunList(c *components.Context) error {
 	cmd.SetRepoKey(repoKey).
 		SetAgentName(agentName).
 		SetProjectDir(projectDir).
-		SetGlobal(useGlobal).
+		SetGlobal(isGlobal).
 		SetFormat(format).
 		SetLimit(limit).
 		SetSortBy(sortBy).
-		SetSortOrder(sortOrder)
+		SetSortOrder(sortOrder).
+		SetCheckUpdates(checkUpdates)
 
-	if repoKey != "" {
+	if repoKey != "" || (agentName != "" && checkUpdates) {
 		serverDetails, err := common.GetServerDetails(c)
 		if err != nil {
 			return err

--- a/skills/commands/list/list.go
+++ b/skills/commands/list/list.go
@@ -32,6 +32,7 @@ const (
 	listCheckStatusUnknown = "unknown"
 	listCheckStatusBehind  = "behind"
 	listCheckStatusCurrent = "current"
+	listCheckStatusAhead   = "ahead"
 )
 
 // repoListRow is one row for registry mode (jf skills list --repo).
@@ -282,6 +283,18 @@ func (lc *ListCommand) listLocalSkills() error {
 	return lc.printLocalResults(results)
 }
 
+// checkUpdateStatusFromSemverComparison maps common.CompareSemver numeric result to a list STATUS value.
+func checkUpdateStatusFromSemverComparison(semverComparison int) string {
+	switch {
+	case semverComparison < 0:
+		return listCheckStatusBehind
+	case semverComparison == 0:
+		return listCheckStatusCurrent
+	default:
+		return listCheckStatusAhead
+	}
+}
+
 func (lc *ListCommand) fillUpdateStatus(row *localListRow, slug string) {
 	if row.Repo == "" || row.Repo == manifestRepoUnknownDisplay {
 		row.RegistryLatest = emDash
@@ -310,14 +323,7 @@ func (lc *ListCommand) fillUpdateStatus(row *localListRow, slug string) {
 		row.Status = listCheckStatusUnknown
 		return
 	}
-	switch {
-	case semverComparison < 0:
-		row.Status = listCheckStatusBehind
-	case semverComparison == 0:
-		row.Status = listCheckStatusCurrent
-	default:
-		row.Status = listCheckStatusCurrent
-	}
+	row.Status = checkUpdateStatusFromSemverComparison(semverComparison)
 }
 
 func (lc *ListCommand) printRepoResults(results []repoListRow) error {

--- a/skills/commands/list/list_test.go
+++ b/skills/commands/list/list_test.go
@@ -45,6 +45,7 @@ func TestListCommand_MissingBothFlags(t *testing.T) {
 	cmd := &ListCommand{}
 	err := cmd.Run()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jf skills list requires")
 	assert.Contains(t, err.Error(), "--repo")
 	assert.Contains(t, err.Error(), "--agent")
 }
@@ -78,6 +79,71 @@ func makeSkillDir(t *testing.T, parent, slug, version, description string) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
 }
 
+func TestListLocalSkills_UsesManifestRepo(t *testing.T) {
+	projectRoot := t.TempDir()
+	skillsPath := filepath.Join(projectRoot, ".cursor", "skills")
+	makeSkillDir(t, skillsPath, "web-search", "1.0.3", "ws")
+	man := common.SkillInfoManifest{
+		Repo:             "skills-local",
+		Slug:             "web-search",
+		InstalledVersion: "1.0.3",
+		Scope:            "project",
+		Agent:            "cursor",
+		ProjectDir:       projectRoot,
+	}
+	require.NoError(t, common.WriteSkillInfoManifest(filepath.Join(skillsPath, "web-search"), man))
+
+	captureLog(t)
+	cmd := &ListCommand{agentName: "cursor"}
+	cmd.SetProjectDir(projectRoot).SetFormat("json")
+
+	jsonOut := captureStdout(t, func() {
+		require.NoError(t, cmd.Run())
+	})
+
+	var results []localListRow
+	require.NoError(t, json.Unmarshal(jsonOut, &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, "skills-local", results[0].Repo)
+}
+
+func TestListLocalSkills_InstalledVersionPrefersManifest(t *testing.T) {
+	projectRoot := t.TempDir()
+	skillsPath := filepath.Join(projectRoot, ".cursor", "skills")
+	makeSkillDir(t, skillsPath, "dual-ver", "1.0.0", "desc")
+	require.NoError(t, common.WriteSkillInfoManifest(filepath.Join(skillsPath, "dual-ver"), common.SkillInfoManifest{
+		Repo:             "skills-local",
+		Slug:             "dual-ver",
+		InstalledVersion: "5.0.0",
+		Scope:            "project",
+		Agent:            "cursor",
+		ProjectDir:       projectRoot,
+	}))
+
+	captureLog(t)
+	cmd := &ListCommand{agentName: "cursor"}
+	cmd.SetProjectDir(projectRoot).SetFormat("json")
+
+	jsonOut := captureStdout(t, func() {
+		require.NoError(t, cmd.Run())
+	})
+
+	var results []localListRow
+	require.NoError(t, json.Unmarshal(jsonOut, &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, "5.0.0", results[0].Version)
+}
+
+func TestListCommand_CheckUpdatesRequiresServer(t *testing.T) {
+	cmd := &ListCommand{}
+	cmd.SetAgentName("cursor").
+		SetProjectDir(t.TempDir()).
+		SetCheckUpdates(true)
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--check-updates requires")
+}
+
 func TestListLocalSkills_ReadsVersionFromSKILLMd(t *testing.T) {
 	projectRoot := t.TempDir()
 	skillsPath := filepath.Join(projectRoot, ".cursor", "skills")
@@ -93,15 +159,18 @@ func TestListLocalSkills_ReadsVersionFromSKILLMd(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	assert.Len(t, results, 2)
 
 	// Sorted alphabetically by name (default)
 	assert.Equal(t, "skill-alpha", results[0].Name)
 	assert.Equal(t, "1.0.0", results[0].Version)
+	assert.Equal(t, "(unknown)", results[0].Repo)
+	assert.Equal(t, ".cursor/skills/skill-alpha", results[0].Path)
 	assert.Equal(t, "skill-beta", results[1].Name)
 	assert.Equal(t, "2.3.1", results[1].Version)
+	assert.Equal(t, ".cursor/skills/skill-beta", results[1].Path)
 }
 
 func TestListLocalSkills_SkipsMissingSKILLMd(t *testing.T) {
@@ -120,7 +189,7 @@ func TestListLocalSkills_SkipsMissingSKILLMd(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	assert.Len(t, results, 1)
 	assert.Equal(t, "with-meta", results[0].Name)
@@ -166,7 +235,7 @@ func TestListLocalSkills_LimitApplied(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	assert.Len(t, results, 2)
 }
@@ -187,7 +256,7 @@ func TestListLocalSkills_GlobalDir(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	require.Len(t, results, 1)
 	assert.Equal(t, "global-skill", results[0].Name)
@@ -210,7 +279,7 @@ func TestListLocalSkills_SortAscending(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	require.Len(t, results, 3)
 	assert.Equal(t, "aaa", results[0].Name)
@@ -234,7 +303,7 @@ func TestListLocalSkills_SortDescending(t *testing.T) {
 		require.NoError(t, cmd.Run())
 	})
 
-	var results []listResult
+	var results []localListRow
 	require.NoError(t, json.Unmarshal(jsonOut, &results))
 	require.Len(t, results, 3)
 	assert.Equal(t, "zzz", results[0].Name)
@@ -248,7 +317,7 @@ func TestListLocalSkills_SortDescending(t *testing.T) {
 
 func TestPrintResults_Table(t *testing.T) {
 	cmd := &ListCommand{format: "table"}
-	results := []listResult{
+	results := []repoListRow{
 		{Name: "my-skill", Version: "1.0.0", Description: "A skill", Source: "Repo: repo-a"},
 	}
 
@@ -256,7 +325,7 @@ func TestPrintResults_Table(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := cmd.printResults(results)
+	err := cmd.printRepoResults(results)
 
 	_ = w.Close()
 	os.Stdout = old
@@ -273,15 +342,15 @@ func TestPrintResults_Table(t *testing.T) {
 
 func TestPrintResults_JSON(t *testing.T) {
 	cmd := &ListCommand{format: "json"}
-	results := []listResult{
+	results := []repoListRow{
 		{Name: "skill-a", Version: "2.0.0", Description: "Desc", Source: "/some/path/skill-a"},
 	}
 
 	out := captureStdout(t, func() {
-		require.NoError(t, cmd.printResults(results))
+		require.NoError(t, cmd.printRepoResults(results))
 	})
 
-	var parsed []listResult
+	var parsed []repoListRow
 	require.NoError(t, json.Unmarshal(out, &parsed))
 	assert.Len(t, parsed, 1)
 	assert.Equal(t, "skill-a", parsed[0].Name)
@@ -292,7 +361,7 @@ func TestPrintResults_Empty_Table(t *testing.T) {
 	buf := captureLog(t)
 	cmd := &ListCommand{}
 
-	require.NoError(t, cmd.printResults([]listResult{}))
+	require.NoError(t, cmd.printRepoResults([]repoListRow{}))
 	assert.Contains(t, buf.String(), "No skills found")
 }
 
@@ -300,12 +369,12 @@ func TestPrintResults_Empty_JSON(t *testing.T) {
 	cmd := &ListCommand{}
 	cmd.SetFormat("json")
 
-	var nilResults []listResult
+	var nilResults []repoListRow
 	out := captureStdout(t, func() {
-		require.NoError(t, cmd.printResults(nilResults))
+		require.NoError(t, cmd.printRepoResults(nilResults))
 	})
 
-	var parsed []listResult
+	var parsed []repoListRow
 	require.NoError(t, json.Unmarshal(out, &parsed))
 	assert.Len(t, parsed, 0)
 	assert.Contains(t, string(out), "[]")

--- a/skills/commands/list/list_test.go
+++ b/skills/commands/list/list_test.go
@@ -144,6 +144,21 @@ func TestListCommand_CheckUpdatesRequiresServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "--check-updates requires")
 }
 
+func TestCheckUpdateStatusFromSemverComparison(t *testing.T) {
+	tests := []struct {
+		cmp  int
+		want string
+	}{
+		{-1, listCheckStatusBehind},
+		{0, listCheckStatusCurrent},
+		{1, listCheckStatusAhead},
+		{2, listCheckStatusAhead},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, checkUpdateStatusFromSemverComparison(tt.cmp), "cmp=%d", tt.cmp)
+	}
+}
+
 func TestListLocalSkills_ReadsVersionFromSKILLMd(t *testing.T) {
 	projectRoot := t.TempDir()
 	skillsPath := filepath.Join(projectRoot, ".cursor", "skills")

--- a/skills/commands/publish/publish.go
+++ b/skills/commands/publish/publish.go
@@ -34,6 +34,7 @@ const evidenceLicenseErrFragment = "Enterprise+"
 
 var zipExcludes = map[string]bool{
 	".git":         true,
+	".jfrog":       true,
 	"__pycache__":  true,
 	"node_modules": true,
 	".DS_Store":    true,
@@ -229,8 +230,8 @@ func (pc *PublishCommand) resolveMissingVersion(slug string) (string, error) {
 	}
 
 	versionStrs := make([]string, len(versions))
-	for i, v := range versions {
-		versionStrs[i] = v.Version
+	for versionIndex, skillVersion := range versions {
+		versionStrs[versionIndex] = skillVersion.Version
 	}
 
 	if len(versionStrs) > 0 {

--- a/skills/commands/publish/publish_test.go
+++ b/skills/commands/publish/publish_test.go
@@ -339,6 +339,9 @@ func TestZipSkillFolder(t *testing.T) {
 	require.NoError(t, os.MkdirAll(subDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(subDir, "helper.py"), []byte("pass"), 0644))
 
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".jfrog"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".jfrog", "skill-info.json"), []byte(`{"schemaVersion":1}`), 0644))
+
 	// Create excludable files
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.pyc"), []byte("compiled"), 0644))
 
@@ -349,6 +352,13 @@ func TestZipSkillFolder(t *testing.T) {
 	info, err := os.Stat(zipPath)
 	require.NoError(t, err)
 	assert.True(t, info.Size() > 0)
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	for _, f := range r.File {
+		assert.False(t, strings.HasPrefix(filepath.ToSlash(f.Name), ".jfrog"), "zip must not include .jfrog: %s", f.Name)
+	}
 }
 
 func TestComputeSHA256(t *testing.T) {
@@ -373,6 +383,7 @@ func TestShouldExclude(t *testing.T) {
 		{"git dir", ".git", true, true},
 		{"pycache", "__pycache__", true, true},
 		{"node_modules", "node_modules", true, true},
+		{"jfrog dir", ".jfrog", true, true},
 		{"pyc file", "module.pyc", false, true},
 		{"normal file", "main.py", false, false},
 		{"ds store", ".DS_Store", false, true},
@@ -623,6 +634,8 @@ func TestCollectFiles_ExcludesCorrectly(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("x"), 0644))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "__pycache__"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "__pycache__", "mod.pyc"), []byte("x"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".jfrog"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".jfrog", "skill-info.json"), []byte("{}"), 0644))
 
 	files, _, err := collectFiles(dir)
 	require.NoError(t, err)
@@ -633,6 +646,7 @@ func TestCollectFiles_ExcludesCorrectly(t *testing.T) {
 		assert.NotContains(t, f.relPath, ".pyc", "should exclude .pyc files")
 		assert.NotContains(t, f.relPath, ".DS_Store", "should exclude .DS_Store")
 		assert.NotContains(t, f.relPath, "__pycache__", "should exclude __pycache__")
+		assert.NotContains(t, f.relPath, ".jfrog", "should exclude .jfrog")
 	}
 	assert.Contains(t, names, "SKILL.md")
 	assert.Contains(t, names, "main.py")

--- a/skills/commands/publish/skill_info_meta.go
+++ b/skills/commands/publish/skill_info_meta.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 // ReadInstalledSkillVersion returns the version string for an installed skill directory.
@@ -13,9 +14,8 @@ import (
 func ReadInstalledSkillVersion(skillDir string) (string, error) {
 	manifest, err := common.ReadSkillInfoManifest(skillDir)
 	if err != nil {
-		return "", fmt.Errorf("read skill info manifest: %w", err)
-	}
-	if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+		log.Warn(fmt.Sprintf("Invalid skill-info manifest under %s (%v); using SKILL.md for installed version.", skillDir, err))
+	} else if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
 		return strings.TrimSpace(manifest.InstalledVersion), nil
 	}
 	meta, err := ParseSkillMeta(skillDir)

--- a/skills/commands/publish/skill_info_meta.go
+++ b/skills/commands/publish/skill_info_meta.go
@@ -1,0 +1,26 @@
+package publish
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+)
+
+// ReadInstalledSkillVersion returns the version string for an installed skill directory.
+// It prefers .jfrog/skill-info.json (installedVersion) when present and non-empty,
+// otherwise the version from SKILL.md front matter.
+func ReadInstalledSkillVersion(skillDir string) (string, error) {
+	manifest, err := common.ReadSkillInfoManifest(skillDir)
+	if err != nil {
+		return "", fmt.Errorf("read skill info manifest: %w", err)
+	}
+	if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+		return strings.TrimSpace(manifest.InstalledVersion), nil
+	}
+	meta, err := ParseSkillMeta(skillDir)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(meta.Version), nil
+}

--- a/skills/commands/publish/skill_info_meta_test.go
+++ b/skills/commands/publish/skill_info_meta_test.go
@@ -1,6 +1,7 @@
 package publish
 
 import (
+	"bytes"
 	"errors"
 	"io/fs"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +42,24 @@ func TestReadInstalledSkillVersion_FallsBackToSkillMd(t *testing.T) {
 	v, err := ReadInstalledSkillVersion(dir)
 	require.NoError(t, err)
 	assert.Equal(t, "3.1.4", v)
+}
+
+func TestReadInstalledSkillVersion_CorruptManifestFallsBackToSkillMd(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := log.GetLogger()
+	log.SetLogger(log.NewLogger(log.INFO, buf))
+	t.Cleanup(func() { log.SetLogger(prev) })
+
+	dir := filepath.Join(t.TempDir(), "corrupt-manifest")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".jfrog"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".jfrog", "skill-info.json"), []byte("{not json"), 0o644))
+	skillMd := "---\nname: corrupt-manifest\nversion: 9.8.7\ndescription: x\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMd), 0o644))
+
+	v, err := ReadInstalledSkillVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "9.8.7", v)
+	assert.Contains(t, buf.String(), "Invalid skill-info manifest")
 }
 
 func TestReadInstalledSkillVersion_ManifestEmptyUsesMeta(t *testing.T) {

--- a/skills/commands/publish/skill_info_meta_test.go
+++ b/skills/commands/publish/skill_info_meta_test.go
@@ -1,0 +1,91 @@
+package publish
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInstalledSkillVersion_PrefersManifest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "my-skill")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	skillMd := "---\nname: my-skill\nversion: 1.0.0\ndescription: x\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMd), 0o644))
+
+	require.NoError(t, common.WriteSkillInfoManifest(dir, common.SkillInfoManifest{
+		Repo:             "r",
+		Slug:             "my-skill",
+		InstalledVersion: "2.0.0",
+		Scope:            "project",
+		Agent:            "cursor",
+	}))
+
+	v, err := ReadInstalledSkillVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", v)
+}
+
+func TestReadInstalledSkillVersion_FallsBackToSkillMd(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "only-meta")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	skillMd := "---\nname: only-meta\nversion: 3.1.4\ndescription: x\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMd), 0o644))
+
+	v, err := ReadInstalledSkillVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "3.1.4", v)
+}
+
+func TestReadInstalledSkillVersion_ManifestEmptyUsesMeta(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "empty-manifest-ver")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	skillMd := "---\nname: empty-manifest-ver\nversion: 0.1.0\ndescription: x\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMd), 0o644))
+	require.NoError(t, common.WriteSkillInfoManifest(dir, common.SkillInfoManifest{
+		Repo:             "r",
+		Slug:             "empty-manifest-ver",
+		InstalledVersion: "   ",
+		Scope:            "project",
+		Agent:            "cursor",
+	}))
+
+	v, err := ReadInstalledSkillVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "0.1.0", v)
+}
+
+func TestReadInstalledSkillVersion_NoVersionField(t *testing.T) {
+	dir := skillDirForVersionTest(t, "no-ver", "---\nname: no-ver\ndescription: No version here\n---\n")
+	version, err := ReadInstalledSkillVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "", version, "empty version when SKILL.md has no version field")
+}
+
+func TestReadInstalledSkillVersion_NotInstalled(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent-skill")
+	_, err := ReadInstalledSkillVersion(missing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "missing SKILL.md must surface fs.ErrNotExist")
+}
+
+func TestReadInstalledSkillVersion_InvalidFrontmatter(t *testing.T) {
+	dir := skillDirForVersionTest(t, "bad-skill", "# No frontmatter at all\n")
+	_, err := ReadInstalledSkillVersion(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse SKILL.md")
+}
+
+func skillDirForVersionTest(t *testing.T, slug, skillMD string) string {
+	t.Helper()
+	base := t.TempDir()
+	dir := filepath.Join(base, slug)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0o644))
+	return dir
+}

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -14,11 +14,11 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-type preflight struct {
-	target       common.AgentTarget
-	installedVer string
-	upToDate     bool
-	failure      string
+type preUpdate struct {
+	agentTarget            common.AgentTarget
+	installedVersion       string
+	alreadyAtTargetVersion bool
+	failureReason          string
 }
 
 // RunUpdate is the CLI action for `jf skills update`.
@@ -65,7 +65,7 @@ func RunUpdate(c *components.Context) error {
 		return err
 	}
 
-	checks := preflightTargets(targets, targetVersion, force, quiet)
+	checks := preUpdateTargets(targets, targetVersion, force, quiet)
 	results, updatable := initialResultsAndUpdatable(checks, targetVersion)
 
 	if dryRun {
@@ -88,21 +88,23 @@ func RunUpdate(c *components.Context) error {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	ic := install.NewInstallCommand().
+	cmd := install.NewInstallCommand().
 		SetServerDetails(serverDetails).
 		SetRepoKey(repoKey).
 		SetSlug(slug).
 		SetVersion(targetVersion).
 		SetQuiet(quiet).
-		SetSuppressSummary(true)
+		SetSuppressSummary(true).
+		SetProjectDir(projectDirAbs).
+		SetGlobal(isGlobal)
 
-	unzipDir, err := ic.FetchAndExtractTo(tmpDir)
+	unzipDir, err := cmd.FetchAndExtractTo(tmpDir)
 	if err != nil {
 		return err
 	}
 
-	for _, check := range updatable {
-		results = append(results, updateOneWithPrepared(unzipDir, ic, check))
+	for _, preUpdateCheck := range updatable {
+		results = append(results, updateOneSkill(unzipDir, cmd, preUpdateCheck))
 	}
 
 	if err := install.PrintSummary(slug, targetVersion, results, format); err != nil {
@@ -111,101 +113,103 @@ func RunUpdate(c *components.Context) error {
 	return finalError(results)
 }
 
-func preflightTargets(targets []common.AgentTarget, targetVersion string, force, quiet bool) []preflight {
-	out := make([]preflight, 0, len(targets))
-	for _, target := range targets {
-		p := preflight{target: target}
-		installedVer, err := readInstalledVersion(target.DestinationDir)
+func preUpdateTargets(targets []common.AgentTarget, targetVersion string, force, quiet bool) []preUpdate {
+	out := make([]preUpdate, 0, len(targets))
+	for _, agentTarget := range targets {
+		record := preUpdate{agentTarget: agentTarget}
+		installedVersion, err := publish.ReadInstalledSkillVersion(agentTarget.DestinationDir)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				p.failure = fmt.Sprintf("skill not installed at %s; run 'jf skills install' first", target.DestinationDir)
+				record.failureReason = fmt.Sprintf("skill not installed at %s; run 'jf skills install' first", agentTarget.DestinationDir)
 			} else {
-				p.failure = err.Error()
+				record.failureReason = err.Error()
 			}
 			if !quiet {
-				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", target.Agent.Name, target.DestinationDir, p.failure))
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", agentTarget.Agent.Name, agentTarget.DestinationDir, record.failureReason))
 			}
-			out = append(out, p)
+			out = append(out, record)
 			continue
 		}
-		p.installedVer = installedVer
-		if installedVer == targetVersion && !force {
-			p.upToDate = true
+		record.installedVersion = installedVersion
+		if installedVersion == targetVersion && !force {
+			record.alreadyAtTargetVersion = true
 			if !quiet {
-				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: already at version %s (use --force to re-download)", target.Agent.Name, target.DestinationDir, targetVersion))
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: already at version %s (use --force to re-download)", agentTarget.Agent.Name, agentTarget.DestinationDir, targetVersion))
 			}
 		}
-		out = append(out, p)
+		out = append(out, record)
 	}
 	return out
 }
 
-func initialResultsAndUpdatable(checks []preflight, targetVersion string) ([]install.SummaryRow, []preflight) {
+func initialResultsAndUpdatable(checks []preUpdate, targetVersion string) ([]install.SummaryRow, []preUpdate) {
 	results := make([]install.SummaryRow, 0, len(checks))
-	updatable := make([]preflight, 0, len(checks))
-	for _, chk := range checks {
+	updatable := make([]preUpdate, 0, len(checks))
+	for _, preUpdateCheck := range checks {
 		switch {
-		case chk.failure != "":
-			results = append(results, summaryRowFor(chk.target, install.SummaryStatusFailed, chk.failure))
-		case chk.upToDate:
-			results = append(results, summaryRowFor(chk.target, install.SummaryStatusUpToDate, fmt.Sprintf("version already %s; use --force to reinstall", targetVersion)))
+		case preUpdateCheck.failureReason != "":
+			results = append(results, summaryRowFor(preUpdateCheck.agentTarget, install.SummaryStatusFailed, preUpdateCheck.failureReason))
+		case preUpdateCheck.alreadyAtTargetVersion:
+			results = append(results, summaryRowFor(preUpdateCheck.agentTarget, install.SummaryStatusSkipped, fmt.Sprintf("version already %s; use --force to reinstall", targetVersion)))
 		default:
-			updatable = append(updatable, chk)
+			updatable = append(updatable, preUpdateCheck)
 		}
 	}
 	return results, updatable
 }
 
-func summaryRowFor(target common.AgentTarget, status, detail string) install.SummaryRow {
+func summaryRowFor(agentTarget common.AgentTarget, status, detail string) install.SummaryRow {
 	return install.SummaryRow{
-		Agent:  target.Agent.Name,
-		Scope:  string(target.Scope),
-		Path:   target.DestinationDir,
+		Agent:  agentTarget.Agent.Name,
+		Scope:  string(agentTarget.Scope),
+		Path:   agentTarget.DestinationDir,
 		Status: status,
 		Detail: detail,
 	}
 }
 
-func logDryRun(slug, targetVersion string, checks []preflight) {
-	for _, c := range checks {
+func logDryRun(slug, targetVersion string, checks []preUpdate) {
+	for _, preUpdateCheck := range checks {
 		switch {
-		case c.failure != "":
-			log.Info(fmt.Sprintf("[dry-run] Would skip %s at %s: %s", slug, c.target.DestinationDir, c.failure))
-		case c.upToDate:
-			log.Info(fmt.Sprintf("[dry-run] Skill '%s' already at v%s at %s", slug, targetVersion, c.target.DestinationDir))
-		case c.installedVer == "":
-			log.Info(fmt.Sprintf("[dry-run] Would install skill '%s' v%s to %s", slug, targetVersion, c.target.DestinationDir))
+		case preUpdateCheck.failureReason != "":
+			log.Info(fmt.Sprintf("[dry-run] Would skip %s at %s: %s", slug, preUpdateCheck.agentTarget.DestinationDir, preUpdateCheck.failureReason))
+		case preUpdateCheck.alreadyAtTargetVersion:
+			log.Info(fmt.Sprintf("[dry-run] Skill '%s' already at v%s at %s", slug, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
+		case preUpdateCheck.installedVersion == "":
+			log.Info(fmt.Sprintf("[dry-run] Would install skill '%s' v%s to %s", slug, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
 		default:
-			log.Info(fmt.Sprintf("[dry-run] Would update skill '%s' from v%s -> v%s at %s", slug, c.installedVer, targetVersion, c.target.DestinationDir))
+			log.Info(fmt.Sprintf("[dry-run] Would update skill '%s' from v%s -> v%s at %s", slug, preUpdateCheck.installedVersion, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
 		}
 	}
 }
 
-func updateOneWithPrepared(unzipDir string, ic *install.InstallCommand, check preflight) install.SummaryRow {
-	target := check.target
-	slugBase := filepath.Base(target.DestinationDir)
-	parent := filepath.Dir(target.DestinationDir)
+// updateOneSkill updates a single install target using the already-fetched tree in unzipDir:
+// it renames the live install aside, copies from unzipDir, restores the backup on failure, then removes the backup on success.
+func updateOneSkill(unzipDir string, installCommand *install.InstallCommand, check preUpdate) install.SummaryRow {
+	agentTarget := check.agentTarget
+	slugBase := filepath.Base(agentTarget.DestinationDir)
+	parent := filepath.Dir(agentTarget.DestinationDir)
 
 	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
 	if err != nil {
-		return summaryRowFor(target, install.SummaryStatusFailed, err.Error())
+		return summaryRowFor(agentTarget, install.SummaryStatusFailed, err.Error())
 	}
-	if err := os.Rename(target.DestinationDir, backupPath); err != nil {
-		return summaryRowFor(target, install.SummaryStatusFailed, fmt.Sprintf("could not move current skill aside for update: %s", err.Error()))
+	if err := os.Rename(agentTarget.DestinationDir, backupPath); err != nil {
+		return summaryRowFor(agentTarget, install.SummaryStatusFailed, fmt.Sprintf("could not move current skill aside for update: %s", err.Error()))
 	}
 
-	rows := ic.CopyExtractedToAgentTargets(unzipDir, []common.AgentTarget{target})
+	rows := installCommand.CopyExtractedToAgentTargets(unzipDir, []common.AgentTarget{agentTarget})
 	if len(rows) != 1 {
-		_ = os.RemoveAll(target.DestinationDir)
-		if restoreErr := os.Rename(backupPath, target.DestinationDir); restoreErr != nil {
-			return summaryRowFor(target, install.SummaryStatusFailed, fmt.Sprintf("internal error: unexpected copy result count; restore failed: %s", restoreErr.Error()))
+		_ = os.RemoveAll(agentTarget.DestinationDir)
+		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
+			return summaryRowFor(agentTarget, install.SummaryStatusFailed, fmt.Sprintf("internal error: unexpected copy result count; restore failed: %s", restoreErr.Error()))
 		}
-		return summaryRowFor(target, install.SummaryStatusFailed, "internal error: unexpected copy result count")
+		return summaryRowFor(agentTarget, install.SummaryStatusFailed, "internal error: unexpected copy result count")
 	}
 	row := rows[0]
 	if row.Status != install.SummaryStatusOK {
-		_ = os.RemoveAll(target.DestinationDir)
-		if restoreErr := os.Rename(backupPath, target.DestinationDir); restoreErr != nil {
+		_ = os.RemoveAll(agentTarget.DestinationDir)
+		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
 			row.Detail = fmt.Sprintf("%s; could not restore previous install: %s", row.Detail, restoreErr.Error())
 		}
 		return row
@@ -215,15 +219,15 @@ func updateOneWithPrepared(unzipDir string, ic *install.InstallCommand, check pr
 		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
 	}
 
-	return summaryRowFor(target, install.SummaryStatusOK, install.SummaryDetailOKInstall)
+	return summaryRowFor(agentTarget, install.SummaryStatusOK, install.SummaryDetailOKInstall)
 }
 
 func finalError(results []install.SummaryRow) error {
 	if len(results) == 0 {
 		return nil
 	}
-	for _, r := range results {
-		if r.Status != install.SummaryStatusFailed {
+	for _, result := range results {
+		if result.Status != install.SummaryStatusFailed {
 			return nil
 		}
 	}
@@ -231,8 +235,12 @@ func finalError(results []install.SummaryRow) error {
 }
 
 func reserveUpdateBackupPath(installBase, slug string) (string, error) {
-	pattern := fmt.Sprintf(".%s.jfrog-update-backup-*", slug)
-	d, err := os.MkdirTemp(installBase, pattern)
+	backupRoot := filepath.Join(installBase, ".skill-backup")
+	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
+		return "", fmt.Errorf("could not create .skill-backup directory: %w", err)
+	}
+	pattern := slug + "-backup-*"
+	d, err := os.MkdirTemp(backupRoot, pattern)
 	if err != nil {
 		return "", fmt.Errorf("could not reserve update backup path: %w", err)
 	}
@@ -240,12 +248,4 @@ func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 		return "", fmt.Errorf("could not prepare update backup path: %w", err)
 	}
 	return d, nil
-}
-
-func readInstalledVersion(skillDir string) (string, error) {
-	meta, err := publish.ParseSkillMeta(skillDir)
-	if err != nil {
-		return "", err
-	}
-	return meta.Version, nil
 }

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -217,6 +217,9 @@ func updateOneSkill(unzipDir string, installCommand *install.InstallCommand, che
 
 	if err := os.RemoveAll(backupPath); err != nil {
 		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
+	} else {
+		backupRoot := filepath.Join(parent, ".skill-backup")
+		_ = os.Remove(backupRoot)
 	}
 
 	return summaryRowFor(agentTarget, install.SummaryStatusOK, install.SummaryDetailOKInstall)
@@ -236,6 +239,7 @@ func finalError(results []install.SummaryRow) error {
 
 func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 	backupRoot := filepath.Join(installBase, ".skill-backup")
+	// #nosec G301 -- update backup dir under user skill tree; permissive mode matches install copy behavior for tooling access.
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
 		return "", fmt.Errorf("could not create .skill-backup directory: %w", err)
 	}

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -14,10 +14,17 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+type preflight struct {
+	target       common.AgentTarget
+	installedVer string
+	upToDate     bool
+	failure      string
+}
+
 // RunUpdate is the CLI action for `jf skills update`.
 func RunUpdate(c *components.Context) error {
 	if c.GetNumberOfArgs() < 1 {
-		return fmt.Errorf("usage: jf skills update <slug> [--path <dir>] [--repo <repo>] [options]")
+		return fmt.Errorf("usage: jf skills update <slug> (--agent <name[,name...]> [--global] [--project-dir <dir>]] | --path <dir>) [--repo <repo>] [--version <ver>] [--dry-run] [--force] [--format <table|json>]")
 	}
 
 	slug := c.GetArgumentAt(0)
@@ -25,93 +32,204 @@ func RunUpdate(c *components.Context) error {
 		return err
 	}
 
-	installBase := c.GetStringFlagValue("path")
-	if installBase == "" {
-		installBase = "."
+	absoluteInstallBaseDir, specs, projectDirAbs, isGlobal, err := common.ValidateInstallFlags(c)
+	if err != nil {
+		return err
 	}
-	targetVersion := c.GetStringFlagValue("version")
-	dryRun := c.GetBoolFlagValue("dry-run")
-	force := c.GetBoolFlagValue("force")
-	quiet := common.IsQuiet(c)
 
 	serverDetails, err := common.GetServerDetails(c)
 	if err != nil {
 		return err
 	}
-
+	quiet := common.IsQuiet(c)
 	repoKey, err := common.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet)
 	if err != nil {
 		return err
 	}
 
-	if err := validateInstallBase(installBase); err != nil {
-		return err
+	requestedVersion := c.GetStringFlagValue("version")
+	dryRun := c.GetBoolFlagValue("dry-run")
+	force := c.GetBoolFlagValue("force")
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
 	}
 
-	skillDir := filepath.Join(installBase, slug)
-
-	currentVersion, err := readInstalledVersion(skillDir)
+	targets, err := common.ResolveAgentTargets(slug, absoluteInstallBaseDir, specs, projectDirAbs, isGlobal)
 	if err != nil {
 		return err
 	}
 
-	targetVersion, err = common.ResolveSkillVersion(serverDetails, repoKey, slug, targetVersion, quiet)
+	targetVersion, err := common.ResolveSkillVersion(serverDetails, repoKey, slug, requestedVersion, quiet)
 	if err != nil {
 		return err
 	}
 
-	if currentVersion == targetVersion && !force {
-		log.Info(fmt.Sprintf("Skill '%s' is already at version '%s'. Use --force to re-download.", slug, currentVersion))
-		return nil
-	}
+	checks := preflightTargets(targets, targetVersion, force, quiet)
+	results, updatable := initialResultsAndUpdatable(checks, targetVersion)
 
 	if dryRun {
-		if currentVersion == "" {
-			log.Info(fmt.Sprintf("[dry-run] Would install skill '%s' v%s to %s", slug, targetVersion, skillDir))
-		} else {
-			log.Info(fmt.Sprintf("[dry-run] Would update skill '%s' from v%s -> v%s at %s", slug, currentVersion, targetVersion, skillDir))
+		logDryRun(slug, targetVersion, checks)
+		return install.PrintSummary(slug, targetVersion, results, format)
+	}
+
+	if len(updatable) == 0 {
+		if err := install.PrintSummary(slug, targetVersion, results, format); err != nil {
+			return err
 		}
-		return nil
+		return finalError(results)
 	}
 
-	backupPath, err := reserveUpdateBackupPath(installBase, slug)
+	tmpDir, err := os.MkdirTemp("", "skill-update-*")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	if err := os.Rename(skillDir, backupPath); err != nil {
-		return fmt.Errorf("could not move current skill aside for update: %w", err)
-	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
-	cmd := install.NewInstallCommand().
+	ic := install.NewInstallCommand().
 		SetServerDetails(serverDetails).
 		SetRepoKey(repoKey).
 		SetSlug(slug).
 		SetVersion(targetVersion).
-		SetInstallPath(installBase).
-		SetQuiet(quiet)
+		SetQuiet(quiet).
+		SetSuppressSummary(true)
 
-	runErr := cmd.Run()
-	if runErr != nil {
-		_ = os.RemoveAll(skillDir)
-		if rerr := os.Rename(backupPath, skillDir); rerr != nil {
-			return fmt.Errorf("update failed (%w); could not restore previous install at %s: %w", runErr, skillDir, rerr)
+	unzipDir, err := ic.FetchAndExtractTo(tmpDir)
+	if err != nil {
+		return err
+	}
+
+	for _, check := range updatable {
+		results = append(results, updateOneWithPrepared(unzipDir, ic, check))
+	}
+
+	if err := install.PrintSummary(slug, targetVersion, results, format); err != nil {
+		return err
+	}
+	return finalError(results)
+}
+
+func preflightTargets(targets []common.AgentTarget, targetVersion string, force, quiet bool) []preflight {
+	out := make([]preflight, 0, len(targets))
+	for _, target := range targets {
+		p := preflight{target: target}
+		installedVer, err := readInstalledVersion(target.DestinationDir)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				p.failure = fmt.Sprintf("skill not installed at %s; run 'jf skills install' first", target.DestinationDir)
+			} else {
+				p.failure = err.Error()
+			}
+			if !quiet {
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", target.Agent.Name, target.DestinationDir, p.failure))
+			}
+			out = append(out, p)
+			continue
 		}
-		return runErr
+		p.installedVer = installedVer
+		if installedVer == targetVersion && !force {
+			p.upToDate = true
+			if !quiet {
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: already at version %s (use --force to re-download)", target.Agent.Name, target.DestinationDir, targetVersion))
+			}
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func initialResultsAndUpdatable(checks []preflight, targetVersion string) ([]install.SummaryRow, []preflight) {
+	results := make([]install.SummaryRow, 0, len(checks))
+	updatable := make([]preflight, 0, len(checks))
+	for _, chk := range checks {
+		switch {
+		case chk.failure != "":
+			results = append(results, summaryRowFor(chk.target, install.SummaryStatusFailed, chk.failure))
+		case chk.upToDate:
+			results = append(results, summaryRowFor(chk.target, install.SummaryStatusUpToDate, fmt.Sprintf("version already %s; use --force to reinstall", targetVersion)))
+		default:
+			updatable = append(updatable, chk)
+		}
+	}
+	return results, updatable
+}
+
+func summaryRowFor(target common.AgentTarget, status, detail string) install.SummaryRow {
+	return install.SummaryRow{
+		Agent:  target.Agent.Name,
+		Scope:  string(target.Scope),
+		Path:   target.DestinationDir,
+		Status: status,
+		Detail: detail,
+	}
+}
+
+func logDryRun(slug, targetVersion string, checks []preflight) {
+	for _, c := range checks {
+		switch {
+		case c.failure != "":
+			log.Info(fmt.Sprintf("[dry-run] Would skip %s at %s: %s", slug, c.target.DestinationDir, c.failure))
+		case c.upToDate:
+			log.Info(fmt.Sprintf("[dry-run] Skill '%s' already at v%s at %s", slug, targetVersion, c.target.DestinationDir))
+		case c.installedVer == "":
+			log.Info(fmt.Sprintf("[dry-run] Would install skill '%s' v%s to %s", slug, targetVersion, c.target.DestinationDir))
+		default:
+			log.Info(fmt.Sprintf("[dry-run] Would update skill '%s' from v%s -> v%s at %s", slug, c.installedVer, targetVersion, c.target.DestinationDir))
+		}
+	}
+}
+
+func updateOneWithPrepared(unzipDir string, ic *install.InstallCommand, check preflight) install.SummaryRow {
+	target := check.target
+	slugBase := filepath.Base(target.DestinationDir)
+	parent := filepath.Dir(target.DestinationDir)
+
+	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
+	if err != nil {
+		return summaryRowFor(target, install.SummaryStatusFailed, err.Error())
+	}
+	if err := os.Rename(target.DestinationDir, backupPath); err != nil {
+		return summaryRowFor(target, install.SummaryStatusFailed, fmt.Sprintf("could not move current skill aside for update: %s", err.Error()))
+	}
+
+	rows := ic.CopyExtractedToAgentTargets(unzipDir, []common.AgentTarget{target})
+	if len(rows) != 1 {
+		_ = os.RemoveAll(target.DestinationDir)
+		if restoreErr := os.Rename(backupPath, target.DestinationDir); restoreErr != nil {
+			return summaryRowFor(target, install.SummaryStatusFailed, fmt.Sprintf("internal error: unexpected copy result count; restore failed: %s", restoreErr.Error()))
+		}
+		return summaryRowFor(target, install.SummaryStatusFailed, "internal error: unexpected copy result count")
+	}
+	row := rows[0]
+	if row.Status != install.SummaryStatusOK {
+		_ = os.RemoveAll(target.DestinationDir)
+		if restoreErr := os.Rename(backupPath, target.DestinationDir); restoreErr != nil {
+			row.Detail = fmt.Sprintf("%s; could not restore previous install: %s", row.Detail, restoreErr.Error())
+		}
+		return row
 	}
 
 	if err := os.RemoveAll(backupPath); err != nil {
 		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
 	}
 
-	if currentVersion == "" {
-		log.Info(fmt.Sprintf("Skill '%s' update completed: version '%s' at %s", slug, targetVersion, skillDir))
-	} else {
-		log.Info(fmt.Sprintf("Skill '%s' update completed: version '%s' -> '%s' at %s", slug, currentVersion, targetVersion, skillDir))
-	}
-	return nil
+	return summaryRowFor(target, install.SummaryStatusOK, install.SummaryDetailOKInstall)
 }
 
-// reserveUpdateBackupPath returns a non-existent path under installBase used to hold the previous skill tree during update.
+func finalError(results []install.SummaryRow) error {
+	if len(results) == 0 {
+		return nil
+	}
+	for _, r := range results {
+		if r.Status != install.SummaryStatusFailed {
+			return nil
+		}
+	}
+	return fmt.Errorf("update failed for all targets (see summary above)")
+}
+
 func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 	pattern := fmt.Sprintf(".%s.jfrog-update-backup-*", slug)
 	d, err := os.MkdirTemp(installBase, pattern)
@@ -124,25 +242,10 @@ func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 	return d, nil
 }
 
-func validateInstallBase(path string) error {
-	if err := common.ValidateExistingDir(path); err != nil {
-		return fmt.Errorf("install path %q: %w", path, err)
-	}
-	return nil
-}
-
 func readInstalledVersion(skillDir string) (string, error) {
 	meta, err := publish.ParseSkillMeta(skillDir)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf(
-				"skill '%s' is not installed at '%s'.\n"+
-					"To install it, run: jf skills install %s --path %s",
-				filepath.Base(skillDir), filepath.Dir(skillDir),
-				filepath.Base(skillDir), filepath.Dir(skillDir),
-			)
-		}
-		return "", fmt.Errorf("could not read installed skill metadata from %s: %w", skillDir, err)
+		return "", err
 	}
 	return meta.Version, nil
 }

--- a/skills/commands/update/update.go
+++ b/skills/commands/update/update.go
@@ -14,6 +14,9 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// skillBackupDirName is the directory under the skills parent where update backups are stored.
+const skillBackupDirName = ".skill-backup"
+
 type preUpdate struct {
 	agentTarget            common.AgentTarget
 	installedVersion       string
@@ -218,7 +221,7 @@ func updateOneSkill(unzipDir string, installCommand *install.InstallCommand, che
 	if err := os.RemoveAll(backupPath); err != nil {
 		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
 	} else {
-		backupRoot := filepath.Join(parent, ".skill-backup")
+		backupRoot := filepath.Join(parent, skillBackupDirName)
 		_ = os.Remove(backupRoot)
 	}
 
@@ -238,10 +241,10 @@ func finalError(results []install.SummaryRow) error {
 }
 
 func reserveUpdateBackupPath(installBase, slug string) (string, error) {
-	backupRoot := filepath.Join(installBase, ".skill-backup")
+	backupRoot := filepath.Join(installBase, skillBackupDirName)
 	// #nosec G301 -- update backup dir under user skill tree; permissive mode matches install copy behavior for tooling access.
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
-		return "", fmt.Errorf("could not create .skill-backup directory: %w", err)
+		return "", fmt.Errorf("could not create %s directory: %w", skillBackupDirName, err)
 	}
 	pattern := slug + "-backup-*"
 	d, err := os.MkdirTemp(backupRoot, pattern)

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -154,12 +154,12 @@ func TestUpdateOneSkill_SuccessRemovesBackup(t *testing.T) {
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	assert.ElementsMatch(t, []string{"web", ".skill-backup"}, names)
+	assert.ElementsMatch(t, []string{"web"}, names)
 
 	backupRoot := filepath.Join(filepath.Dir(dir), ".skill-backup")
-	backupEntries, err := os.ReadDir(backupRoot)
-	require.NoError(t, err)
-	require.Empty(t, backupEntries, "reserved backup path should be removed after successful update")
+	_, statErr := os.Stat(backupRoot)
+	require.Error(t, statErr)
+	assert.True(t, os.IsNotExist(statErr), ".skill-backup should be removed when empty after successful update")
 	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "2.0.0")

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -26,7 +26,7 @@ func TestReserveUpdateBackupPath(t *testing.T) {
 	base := t.TempDir()
 	p, err := reserveUpdateBackupPath(base, "skill-a")
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(base, ".skill-backup"), filepath.Dir(p))
+	require.Equal(t, filepath.Join(base, skillBackupDirName), filepath.Dir(p))
 	assert.Contains(t, filepath.Base(p), "skill-a-backup-")
 	_, err = os.Stat(p)
 	require.True(t, errors.Is(err, fs.ErrNotExist), "reserved path must not exist until rename")
@@ -156,10 +156,10 @@ func TestUpdateOneSkill_SuccessRemovesBackup(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"web"}, names)
 
-	backupRoot := filepath.Join(filepath.Dir(dir), ".skill-backup")
+	backupRoot := filepath.Join(filepath.Dir(dir), skillBackupDirName)
 	_, statErr := os.Stat(backupRoot)
 	require.Error(t, statErr)
-	assert.True(t, os.IsNotExist(statErr), ".skill-backup should be removed when empty after successful update")
+	assert.True(t, os.IsNotExist(statErr), skillBackupDirName+" should be removed when empty after successful update")
 	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "2.0.0")

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -13,37 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadInstalledVersion_Found(t *testing.T) {
-	dir := skillDir(t, "web-search", `---
-name: web-search
-version: 1.2.3
----
-`)
-	version, err := readInstalledVersion(dir)
-	require.NoError(t, err)
-	assert.Equal(t, "1.2.3", version)
-}
-
-func TestReadInstalledVersion_NoVersionField(t *testing.T) {
-	dir := skillDir(t, "web-search", `---
-name: web-search
-description: No version here
----
-`)
-	version, err := readInstalledVersion(dir)
-	require.NoError(t, err)
-	assert.Equal(t, "", version, "empty version when SKILL.md has no version field")
-}
-
-func TestReadInstalledVersion_NotInstalled(t *testing.T) {
-	base := t.TempDir()
-	missing := filepath.Join(base, "nonexistent-skill")
-
-	_, err := readInstalledVersion(missing)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, fs.ErrNotExist), "missing SKILL.md must surface fs.ErrNotExist for preflight")
-}
-
 func TestValidateExistingDir_NotADirectory(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "not-a-dir")
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
@@ -53,77 +22,91 @@ func TestValidateExistingDir_NotADirectory(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a directory")
 }
 
-func TestReadInstalledVersion_InvalidFrontmatter(t *testing.T) {
-	dir := skillDir(t, "bad-skill", "# No frontmatter at all\n")
-	_, err := readInstalledVersion(dir)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse SKILL.md")
-}
-
 func TestReserveUpdateBackupPath(t *testing.T) {
 	base := t.TempDir()
 	p, err := reserveUpdateBackupPath(base, "skill-a")
 	require.NoError(t, err)
-	assert.Contains(t, p, ".skill-a.jfrog-update-backup-")
-	_, statErr := os.Stat(p)
-	require.True(t, errors.Is(statErr, fs.ErrNotExist), "reserved path must not exist until rename")
+	require.Equal(t, filepath.Join(base, ".skill-backup"), filepath.Dir(p))
+	assert.Contains(t, filepath.Base(p), "skill-a-backup-")
+	_, err = os.Stat(p)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "reserved path must not exist until rename")
 }
 
-func TestPreflightTargets_NotInstalled(t *testing.T) {
+func TestPreUpdateTargets_NotInstalled(t *testing.T) {
 	base := t.TempDir()
 	target := common.AgentTarget{
 		Agent:          common.AgentSpec{Name: "cursor"},
 		Scope:          common.ScopeProject,
 		DestinationDir: filepath.Join(base, "missing"),
 	}
-	checks := preflightTargets([]common.AgentTarget{target}, "1.0.0", false, true)
+	checks := preUpdateTargets([]common.AgentTarget{target}, "1.0.0", false, true)
 	require.Len(t, checks, 1)
-	assert.Contains(t, checks[0].failure, "not installed")
+	assert.Contains(t, checks[0].failureReason, "not installed")
 }
 
-func TestPreflightTargets_UpToDate(t *testing.T) {
-	dir := skillDir(t, "web", "---\nname: web\nversion: 2.0.0\n---\n")
+func TestPreUpdateTargets_UpToDate(t *testing.T) {
+	dir := skillDir(t, "---\nname: web\nversion: 2.0.0\n---\n")
 	target := common.AgentTarget{
 		Agent:          common.AgentSpec{Name: "cursor"},
 		Scope:          common.ScopeProject,
 		DestinationDir: dir,
 	}
-	checks := preflightTargets([]common.AgentTarget{target}, "2.0.0", false, true)
+	checks := preUpdateTargets([]common.AgentTarget{target}, "2.0.0", false, true)
 	require.Len(t, checks, 1)
-	assert.True(t, checks[0].upToDate)
-	assert.Equal(t, "2.0.0", checks[0].installedVer)
+	assert.True(t, checks[0].alreadyAtTargetVersion)
+	assert.Equal(t, "2.0.0", checks[0].installedVersion)
 }
 
-func TestPreflightTargets_ForceOverridesUpToDate(t *testing.T) {
-	dir := skillDir(t, "web", "---\nname: web\nversion: 2.0.0\n---\n")
+func TestPreUpdateTargets_UpToDate_UsesManifestVersion(t *testing.T) {
+	dir := skillDir(t, "---\nname: web\nversion: 1.0.0\n---\n")
+	require.NoError(t, common.WriteSkillInfoManifest(dir, common.SkillInfoManifest{
+		Repo:             "r",
+		Slug:             "web",
+		InstalledVersion: "2.0.0",
+		Scope:            "project",
+		Agent:            "cursor",
+	}))
 	target := common.AgentTarget{
 		Agent:          common.AgentSpec{Name: "cursor"},
 		Scope:          common.ScopeProject,
 		DestinationDir: dir,
 	}
-	checks := preflightTargets([]common.AgentTarget{target}, "2.0.0", true, true)
+	checks := preUpdateTargets([]common.AgentTarget{target}, "2.0.0", false, true)
 	require.Len(t, checks, 1)
-	assert.False(t, checks[0].upToDate)
+	assert.True(t, checks[0].alreadyAtTargetVersion)
+	assert.Equal(t, "2.0.0", checks[0].installedVersion)
+}
+
+func TestPreUpdateTargets_ForceOverridesUpToDate(t *testing.T) {
+	dir := skillDir(t, "---\nname: web\nversion: 2.0.0\n---\n")
+	target := common.AgentTarget{
+		Agent:          common.AgentSpec{Name: "cursor"},
+		Scope:          common.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preUpdateTargets([]common.AgentTarget{target}, "2.0.0", true, true)
+	require.Len(t, checks, 1)
+	assert.False(t, checks[0].alreadyAtTargetVersion)
 }
 
 func TestInitialResultsAndUpdatable_Mixed(t *testing.T) {
-	checks := []preflight{
-		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a1"}, Scope: common.ScopeProject, DestinationDir: "/x/a1"}, failure: "not installed"},
-		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a2"}, Scope: common.ScopeProject, DestinationDir: "/x/a2"}, upToDate: true, installedVer: "1.0.0"},
-		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a3"}, Scope: common.ScopeProject, DestinationDir: "/x/a3"}, installedVer: "1.0.0"},
+	checks := []preUpdate{
+		{agentTarget: common.AgentTarget{Agent: common.AgentSpec{Name: "a1"}, Scope: common.ScopeProject, DestinationDir: "/x/a1"}, failureReason: "not installed"},
+		{agentTarget: common.AgentTarget{Agent: common.AgentSpec{Name: "a2"}, Scope: common.ScopeProject, DestinationDir: "/x/a2"}, alreadyAtTargetVersion: true, installedVersion: "1.0.0"},
+		{agentTarget: common.AgentTarget{Agent: common.AgentSpec{Name: "a3"}, Scope: common.ScopeProject, DestinationDir: "/x/a3"}, installedVersion: "1.0.0"},
 	}
 	results, updatable := initialResultsAndUpdatable(checks, "2.0.0")
 	require.Len(t, results, 2)
 	require.Len(t, updatable, 1)
 	assert.Equal(t, install.SummaryStatusFailed, results[0].Status)
-	assert.Equal(t, install.SummaryStatusUpToDate, results[1].Status)
-	assert.Equal(t, "a3", updatable[0].target.Agent.Name)
+	assert.Equal(t, install.SummaryStatusSkipped, results[1].Status)
+	assert.Equal(t, "a3", updatable[0].agentTarget.Agent.Name)
 }
 
 func TestFinalError_AllOK(t *testing.T) {
 	results := []install.SummaryRow{
 		{Status: install.SummaryStatusOK},
-		{Status: install.SummaryStatusUpToDate},
+		{Status: install.SummaryStatusSkipped},
 	}
 	require.NoError(t, finalError(results))
 }
@@ -146,38 +129,46 @@ func TestFinalError_AllFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed for all targets")
 }
 
-func TestUpdateOneWithPrepared_SuccessRemovesBackup(t *testing.T) {
-	dir := skillDir(t, "web", "---\nname: web\nversion: 1.0.0\n---\n")
-	check := preflight{
-		target: common.AgentTarget{
+func TestUpdateOneSkill_SuccessRemovesBackup(t *testing.T) {
+	dir := skillDir(t, "---\nname: web\nversion: 1.0.0\n---\n")
+	check := preUpdate{
+		agentTarget: common.AgentTarget{
 			Agent:          common.AgentSpec{Name: "cursor"},
 			Scope:          common.ScopeProject,
 			DestinationDir: dir,
 		},
-		installedVer: "1.0.0",
+		installedVersion: "1.0.0",
 	}
 
 	src := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: web\nversion: 2.0.0\n---\n"), 0o644))
 
-	ic := install.NewInstallCommand()
-	row := updateOneWithPrepared(src, ic, check)
+	installCommand := install.NewInstallCommand()
+	row := updateOneSkill(src, installCommand, check)
 	assert.Equal(t, install.SummaryStatusOK, row.Status)
 	assert.Equal(t, install.SummaryDetailOKInstall, row.Detail)
 
 	entries, err := os.ReadDir(filepath.Dir(dir))
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "web", entries[0].Name())
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.ElementsMatch(t, []string{"web", ".skill-backup"}, names)
+
+	backupRoot := filepath.Join(filepath.Dir(dir), ".skill-backup")
+	backupEntries, err := os.ReadDir(backupRoot)
+	require.NoError(t, err)
+	require.Empty(t, backupEntries, "reserved backup path should be removed after successful update")
 	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "2.0.0")
 }
 
-func skillDir(t *testing.T, slug, skillMD string) string {
+func skillDir(t *testing.T, skillMD string) string {
 	t.Helper()
 	base := t.TempDir()
-	dir := filepath.Join(base, slug)
+	dir := filepath.Join(base, "web")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0o644))
 	return dir

--- a/skills/commands/update/update_test.go
+++ b/skills/commands/update/update_test.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-artifactory/skills/commands/install"
+	"github.com/jfrog/jfrog-cli-artifactory/skills/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// ── readInstalledVersion ─────────────────────────────────────────────────────
 
 func TestReadInstalledVersion_Found(t *testing.T) {
 	dir := skillDir(t, "web-search", `---
@@ -41,21 +41,14 @@ func TestReadInstalledVersion_NotInstalled(t *testing.T) {
 
 	_, err := readInstalledVersion(missing)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "is not installed at")
-	assert.Contains(t, err.Error(), "jf skills install")
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "missing SKILL.md must surface fs.ErrNotExist for preflight")
 }
 
-func TestRunUpdate_PathDoesNotExist(t *testing.T) {
-	err := validateInstallBase("/nonexistent/path/xyz")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "install path")
-}
-
-func TestValidateInstallBase_NotADirectory(t *testing.T) {
+func TestValidateExistingDir_NotADirectory(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "not-a-dir")
-	require.NoError(t, os.WriteFile(file, []byte("x"), 0644))
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
 
-	err := validateInstallBase(file)
+	err := common.ValidateExistingDir(file)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
 }
@@ -64,10 +57,8 @@ func TestReadInstalledVersion_InvalidFrontmatter(t *testing.T) {
 	dir := skillDir(t, "bad-skill", "# No frontmatter at all\n")
 	_, err := readInstalledVersion(dir)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not read installed skill metadata")
+	assert.Contains(t, err.Error(), "failed to parse SKILL.md")
 }
-
-// ── reserveUpdateBackupPath ──────────────────────────────────────────────────
 
 func TestReserveUpdateBackupPath(t *testing.T) {
 	base := t.TempDir()
@@ -78,13 +69,116 @@ func TestReserveUpdateBackupPath(t *testing.T) {
 	require.True(t, errors.Is(statErr, fs.ErrNotExist), "reserved path must not exist until rename")
 }
 
-// ── helpers ──────────────────────────────────────────────────────────────────
+func TestPreflightTargets_NotInstalled(t *testing.T) {
+	base := t.TempDir()
+	target := common.AgentTarget{
+		Agent:          common.AgentSpec{Name: "cursor"},
+		Scope:          common.ScopeProject,
+		DestinationDir: filepath.Join(base, "missing"),
+	}
+	checks := preflightTargets([]common.AgentTarget{target}, "1.0.0", false, true)
+	require.Len(t, checks, 1)
+	assert.Contains(t, checks[0].failure, "not installed")
+}
+
+func TestPreflightTargets_UpToDate(t *testing.T) {
+	dir := skillDir(t, "web", "---\nname: web\nversion: 2.0.0\n---\n")
+	target := common.AgentTarget{
+		Agent:          common.AgentSpec{Name: "cursor"},
+		Scope:          common.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preflightTargets([]common.AgentTarget{target}, "2.0.0", false, true)
+	require.Len(t, checks, 1)
+	assert.True(t, checks[0].upToDate)
+	assert.Equal(t, "2.0.0", checks[0].installedVer)
+}
+
+func TestPreflightTargets_ForceOverridesUpToDate(t *testing.T) {
+	dir := skillDir(t, "web", "---\nname: web\nversion: 2.0.0\n---\n")
+	target := common.AgentTarget{
+		Agent:          common.AgentSpec{Name: "cursor"},
+		Scope:          common.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preflightTargets([]common.AgentTarget{target}, "2.0.0", true, true)
+	require.Len(t, checks, 1)
+	assert.False(t, checks[0].upToDate)
+}
+
+func TestInitialResultsAndUpdatable_Mixed(t *testing.T) {
+	checks := []preflight{
+		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a1"}, Scope: common.ScopeProject, DestinationDir: "/x/a1"}, failure: "not installed"},
+		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a2"}, Scope: common.ScopeProject, DestinationDir: "/x/a2"}, upToDate: true, installedVer: "1.0.0"},
+		{target: common.AgentTarget{Agent: common.AgentSpec{Name: "a3"}, Scope: common.ScopeProject, DestinationDir: "/x/a3"}, installedVer: "1.0.0"},
+	}
+	results, updatable := initialResultsAndUpdatable(checks, "2.0.0")
+	require.Len(t, results, 2)
+	require.Len(t, updatable, 1)
+	assert.Equal(t, install.SummaryStatusFailed, results[0].Status)
+	assert.Equal(t, install.SummaryStatusUpToDate, results[1].Status)
+	assert.Equal(t, "a3", updatable[0].target.Agent.Name)
+}
+
+func TestFinalError_AllOK(t *testing.T) {
+	results := []install.SummaryRow{
+		{Status: install.SummaryStatusOK},
+		{Status: install.SummaryStatusUpToDate},
+	}
+	require.NoError(t, finalError(results))
+}
+
+func TestFinalError_PartialSuccess(t *testing.T) {
+	results := []install.SummaryRow{
+		{Status: install.SummaryStatusFailed},
+		{Status: install.SummaryStatusOK},
+	}
+	require.NoError(t, finalError(results))
+}
+
+func TestFinalError_AllFailed(t *testing.T) {
+	results := []install.SummaryRow{
+		{Status: install.SummaryStatusFailed},
+		{Status: install.SummaryStatusFailed},
+	}
+	err := finalError(results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed for all targets")
+}
+
+func TestUpdateOneWithPrepared_SuccessRemovesBackup(t *testing.T) {
+	dir := skillDir(t, "web", "---\nname: web\nversion: 1.0.0\n---\n")
+	check := preflight{
+		target: common.AgentTarget{
+			Agent:          common.AgentSpec{Name: "cursor"},
+			Scope:          common.ScopeProject,
+			DestinationDir: dir,
+		},
+		installedVer: "1.0.0",
+	}
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: web\nversion: 2.0.0\n---\n"), 0o644))
+
+	ic := install.NewInstallCommand()
+	row := updateOneWithPrepared(src, ic, check)
+	assert.Equal(t, install.SummaryStatusOK, row.Status)
+	assert.Equal(t, install.SummaryDetailOKInstall, row.Detail)
+
+	entries, err := os.ReadDir(filepath.Dir(dir))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "web", entries[0].Name())
+	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "2.0.0")
+}
 
 func skillDir(t *testing.T, slug, skillMD string) string {
 	t.Helper()
 	base := t.TempDir()
 	dir := filepath.Join(base, slug)
-	require.NoError(t, os.MkdirAll(dir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0644))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0o644))
 	return dir
 }

--- a/skills/common/agents.go
+++ b/skills/common/agents.go
@@ -26,7 +26,7 @@ type AgentSpec struct {
 	FromConfig bool
 }
 
-// Agents is built-in defaults; merged with ~/.jfrog/agents/agent_config.json.
+// Agents is built-in defaults; merged with ~/.jfrog/agents/agent-config.json.
 // Reference: https://github.com/vercel-labs/skills/pull/76/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172
 var Agents = map[string]AgentConfig{
 	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},

--- a/skills/common/install_targets.go
+++ b/skills/common/install_targets.go
@@ -76,12 +76,12 @@ func ValidateInstallFlags(c *components.Context) (absoluteInstallBaseDir string,
 
 	specs = make([]AgentSpec, 0, len(agentNames))
 	for _, name := range agentNames {
-		spec, resolveErr := ResolveAgent(registry, name)
+		agentSpec, resolveErr := ResolveAgent(registry, name)
 		if resolveErr != nil {
 			err = resolveErr
 			return
 		}
-		specs = append(specs, spec)
+		specs = append(specs, agentSpec)
 	}
 
 	if isGlobal && projectDir != "" {
@@ -94,17 +94,17 @@ func ValidateInstallFlags(c *components.Context) (absoluteInstallBaseDir string,
 		if dir == "" {
 			dir = "."
 		}
-		abs, absErr := filepath.Abs(dir)
-		if absErr != nil {
-			err = fmt.Errorf("invalid --project-dir %q: %w", dir, absErr)
+		absoluteProjectDir, resolveErr := filepath.Abs(dir)
+		if resolveErr != nil {
+			err = fmt.Errorf("invalid --project-dir %q: %w", dir, resolveErr)
 			return
 		}
-		info, statErr := os.Stat(abs)
+		info, statErr := os.Stat(absoluteProjectDir)
 		if statErr != nil || !info.IsDir() {
 			err = fmt.Errorf("--project-dir %q is not an existing directory", dir)
 			return
 		}
-		projectDirAbs = abs
+		projectDirAbs = absoluteProjectDir
 	}
 	return
 }

--- a/skills/common/install_targets.go
+++ b/skills/common/install_targets.go
@@ -1,0 +1,148 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+)
+
+// PathAgentName is the synthetic agent name used when --path selects a single target.
+const PathAgentName = "(path)"
+
+// ScopeMode identifies the install/update target scope.
+type ScopeMode string
+
+const (
+	ScopeProject ScopeMode = "project"
+	ScopeGlobal  ScopeMode = "global"
+	ScopePath    ScopeMode = "path"
+)
+
+// AgentTarget pairs an agent spec with the resolved absolute destination directory (includes slug).
+type AgentTarget struct {
+	Agent          AgentSpec
+	Scope          ScopeMode
+	DestinationDir string
+}
+
+// ValidateInstallFlags validates `--path | (--agent[,--project-dir | --global])` for install/update.
+// absoluteInstallBaseDir is non-empty when --path was supplied; otherwise specs are resolved from --agent.
+func ValidateInstallFlags(c *components.Context) (absoluteInstallBaseDir string, specs []AgentSpec, projectDirAbs string, isGlobal bool, err error) {
+	pathInstallBase := strings.TrimSpace(c.GetStringFlagValue("path"))
+	rawAgents := strings.TrimSpace(c.GetStringFlagValue("agent"))
+	isGlobal = c.GetBoolFlagValue("global")
+	projectDir := strings.TrimSpace(c.GetStringFlagValue("project-dir"))
+
+	if pathInstallBase != "" {
+		if rawAgents != "" {
+			err = fmt.Errorf("--path cannot be combined with --agent")
+			return
+		}
+		if isGlobal {
+			err = fmt.Errorf("--path cannot be combined with --global")
+			return
+		}
+		if projectDir != "" {
+			err = fmt.Errorf("--path cannot be combined with --project-dir")
+			return
+		}
+		if err = ValidateExistingDir(pathInstallBase); err != nil {
+			err = fmt.Errorf("--path: %w", err)
+			return
+		}
+		absoluteInstallBaseDir, err = filepath.Abs(pathInstallBase)
+		if err != nil {
+			err = fmt.Errorf("invalid --path %q: %w", pathInstallBase, err)
+		}
+		return
+	}
+
+	registry, err := LoadAgentRegistry()
+	if err != nil {
+		return
+	}
+	if rawAgents == "" {
+		err = fmt.Errorf("--agent is required unless --path is set. Supported agents: %s", AgentNames(registry))
+		return
+	}
+
+	agentNames, err := ParseAgentList(rawAgents)
+	if err != nil {
+		return
+	}
+
+	specs = make([]AgentSpec, 0, len(agentNames))
+	for _, name := range agentNames {
+		spec, resolveErr := ResolveAgent(registry, name)
+		if resolveErr != nil {
+			err = resolveErr
+			return
+		}
+		specs = append(specs, spec)
+	}
+
+	if isGlobal && projectDir != "" {
+		err = fmt.Errorf("--global and --project-dir are mutually exclusive, please choose either --global or --project-dir")
+		return
+	}
+
+	if !isGlobal {
+		dir := projectDir
+		if dir == "" {
+			dir = "."
+		}
+		abs, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			err = fmt.Errorf("invalid --project-dir %q: %w", dir, absErr)
+			return
+		}
+		info, statErr := os.Stat(abs)
+		if statErr != nil || !info.IsDir() {
+			err = fmt.Errorf("--project-dir %q is not an existing directory", dir)
+			return
+		}
+		projectDirAbs = abs
+	}
+	return
+}
+
+// ResolveAgentTargets resolves per-agent install destinations.
+// When path is non-empty, a single ScopePath target is returned.
+func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs string, isGlobal bool) ([]AgentTarget, error) {
+	if path != "" {
+		base, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid install path %q: %w", path, err)
+		}
+		return []AgentTarget{{
+			Agent:          AgentSpec{Name: PathAgentName},
+			Scope:          ScopePath,
+			DestinationDir: filepath.Join(base, slug),
+		}}, nil
+	}
+
+	scope := ScopeProject
+	if isGlobal {
+		scope = ScopeGlobal
+	}
+	if scope == ScopeProject && projectDirAbs == "" {
+		return nil, fmt.Errorf("project directory is required for project-scoped install")
+	}
+
+	targets := make([]AgentTarget, 0, len(agents))
+	for _, agent := range agents {
+		base, err := ResolveAgentInstallDir(agent, projectDirAbs, isGlobal)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, AgentTarget{
+			Agent:          agent,
+			Scope:          scope,
+			DestinationDir: filepath.Join(base, slug),
+		})
+	}
+	return targets, nil
+}

--- a/skills/common/install_targets_test.go
+++ b/skills/common/install_targets_test.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAgentTargets_PathMode(t *testing.T) {
+	base := t.TempDir()
+	targets, err := ResolveAgentTargets("my-skill", base, nil, "", false)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(base, "my-skill"), targets[0].DestinationDir)
+	assert.Equal(t, PathAgentName, targets[0].Agent.Name)
+	assert.Equal(t, ScopePath, targets[0].Scope)
+}
+
+func TestValidateExistingDir_InvalidPath(t *testing.T) {
+	err := ValidateExistingDir("/nonexistent/path/that/does/not/exist")
+	require.Error(t, err)
+}

--- a/skills/common/install_targets_test.go
+++ b/skills/common/install_targets_test.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,4 +23,109 @@ func TestResolveAgentTargets_PathMode(t *testing.T) {
 func TestValidateExistingDir_InvalidPath(t *testing.T) {
 	err := ValidateExistingDir("/nonexistent/path/that/does/not/exist")
 	require.Error(t, err)
+}
+
+func newInstallTestContext() *components.Context {
+	ctx := &components.Context{}
+	ctx.PrintCommandHelp = func(string) error { return nil }
+	return ctx
+}
+
+func TestValidateInstallFlags_Errors(t *testing.T) {
+	validPath := t.TempDir()
+	projectDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		setup   func(*components.Context)
+		wantSub string
+	}{
+		{
+			name: "path with agent",
+			setup: func(c *components.Context) {
+				c.AddStringFlag("path", validPath)
+				c.AddStringFlag("agent", "cursor")
+			},
+			wantSub: "--path cannot be combined with --agent",
+		},
+		{
+			name: "path with global",
+			setup: func(c *components.Context) {
+				c.AddStringFlag("path", validPath)
+				c.AddBoolFlag("global", true)
+			},
+			wantSub: "--path cannot be combined with --global",
+		},
+		{
+			name: "path with project-dir",
+			setup: func(c *components.Context) {
+				c.AddStringFlag("path", validPath)
+				c.AddStringFlag("project-dir", projectDir)
+			},
+			wantSub: "--path cannot be combined with --project-dir",
+		},
+		{
+			name:    "missing agent without path",
+			setup:   func(*components.Context) {},
+			wantSub: "--agent is required",
+		},
+		{
+			name: "global and project-dir together",
+			setup: func(c *components.Context) {
+				c.AddStringFlag("agent", "cursor")
+				c.AddBoolFlag("global", true)
+				c.AddStringFlag("project-dir", projectDir)
+			},
+			wantSub: "mutually exclusive",
+		},
+		{
+			name: "path not a directory",
+			setup: func(c *components.Context) {
+				missing := filepath.Join(t.TempDir(), "nope")
+				c.AddStringFlag("path", missing)
+			},
+			wantSub: "--path:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newInstallTestContext()
+			tt.setup(c)
+			_, _, _, _, err := ValidateInstallFlags(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantSub)
+		})
+	}
+}
+
+func TestValidateInstallFlags_PathModeOK(t *testing.T) {
+	validPath := t.TempDir()
+	c := newInstallTestContext()
+	c.AddStringFlag("path", validPath)
+
+	absPath, specs, projectDirAbs, isGlobal, err := ValidateInstallFlags(c)
+	require.NoError(t, err)
+	wantAbs, err := filepath.Abs(validPath)
+	require.NoError(t, err)
+	assert.Equal(t, wantAbs, absPath)
+	assert.Empty(t, specs)
+	assert.Empty(t, projectDirAbs)
+	assert.False(t, isGlobal)
+}
+
+func TestValidateInstallFlags_AgentProjectOK(t *testing.T) {
+	projectDir := t.TempDir()
+	c := newInstallTestContext()
+	c.AddStringFlag("agent", "cursor")
+	c.AddStringFlag("project-dir", projectDir)
+
+	absPath, specs, projectDirAbs, isGlobal, err := ValidateInstallFlags(c)
+	require.NoError(t, err)
+	assert.Empty(t, absPath)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "cursor", strings.ToLower(specs[0].Name))
+	wantProj, err := filepath.Abs(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, wantProj, projectDirAbs)
+	assert.False(t, isGlobal)
 }

--- a/skills/common/semver.go
+++ b/skills/common/semver.go
@@ -46,6 +46,30 @@ func LatestVersion(versions []string) (string, error) {
 	return parsed[len(parsed)-1].Raw, nil
 }
 
+// CompareSemver compares two semver strings using the same parsing rules as LatestVersion.
+// Returns negative if firstVersion < secondVersion, zero if equal, positive if firstVersion > secondVersion.
+// Non-parseable values return an error.
+func CompareSemver(firstVersion, secondVersion string) (int, error) {
+	firstVersionParts, err := parseSemver(strings.TrimSpace(firstVersion))
+	if err != nil {
+		return 0, fmt.Errorf("compare semver: invalid first version %q: %w", firstVersion, err)
+	}
+	secondVersionParts, err := parseSemver(strings.TrimSpace(secondVersion))
+	if err != nil {
+		return 0, fmt.Errorf("compare semver: invalid second version %q: %w", secondVersion, err)
+	}
+	if firstVersionParts.Major != secondVersionParts.Major {
+		return firstVersionParts.Major - secondVersionParts.Major, nil
+	}
+	if firstVersionParts.Minor != secondVersionParts.Minor {
+		return firstVersionParts.Minor - secondVersionParts.Minor, nil
+	}
+	if firstVersionParts.Patch != secondVersionParts.Patch {
+		return firstVersionParts.Patch - secondVersionParts.Patch, nil
+	}
+	return 0, nil
+}
+
 // NextMinorVersion takes a semver string and returns the next minor version
 // with patch reset to 0 (e.g. "1.2.3" -> "1.3.0").
 func NextMinorVersion(version string) (string, error) {

--- a/skills/common/semver_test.go
+++ b/skills/common/semver_test.go
@@ -64,6 +64,24 @@ func TestLatestVersion(t *testing.T) {
 	}
 }
 
+func TestCompareSemver(t *testing.T) {
+	t.Parallel()
+	cmp, err := CompareSemver("1.0.0", "1.0.5")
+	require.NoError(t, err)
+	assert.Less(t, cmp, 0)
+
+	cmp, err = CompareSemver("1.0.5", "1.0.5")
+	require.NoError(t, err)
+	assert.Zero(t, cmp)
+
+	cmp, err = CompareSemver("2.0.0", "1.9.9")
+	require.NoError(t, err)
+	assert.Greater(t, cmp, 0)
+
+	_, err = CompareSemver("notsemver", "1.0.0")
+	assert.Error(t, err)
+}
+
 func TestNextMinorVersion(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/skills/common/skill_info_manifest.go
+++ b/skills/common/skill_info_manifest.go
@@ -48,6 +48,7 @@ func WriteSkillInfoManifest(skillDir string, manifest SkillInfoManifest) error {
 		return fmt.Errorf("create .jfrog under skill dir: %w", err)
 	}
 	path := filepath.Join(dir, skillInfoJSON)
+	// #nosec G306 -- manifest lives under user-owned skill dir; mode matches install/list expectations for CLI metadata.
 	if err := os.WriteFile(path, data, 0640); err != nil {
 		return fmt.Errorf("write skill info manifest: %w", err)
 	}
@@ -58,6 +59,7 @@ func WriteSkillInfoManifest(skillDir string, manifest SkillInfoManifest) error {
 // A missing file returns (nil, nil).
 func ReadSkillInfoManifest(skillDir string) (*SkillInfoManifest, error) {
 	path := SkillInfoManifestPath(skillDir)
+	// #nosec G304 -- path is skill install directory joined with fixed .jfrog/skill-info.json segments.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/skills/common/skill_info_manifest.go
+++ b/skills/common/skill_info_manifest.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	jfrogSkillDirName = ".jfrog"
+
+	// skillInfoJSON is the CLI manifest filename under .jfrog/.
+	skillInfoJSON = "skill-info.json"
+)
+
+// SkillInfoManifestSchemaVersion is bumped when the JSON shape changes incompatibly.
+const SkillInfoManifestSchemaVersion = 1
+
+// SkillInfoManifest is CLI-owned metadata for an installed skill (single source of truth for list/update).
+type SkillInfoManifest struct {
+	SchemaVersion    int    `json:"schemaVersion"`
+	Repo             string `json:"repo"`
+	Slug             string `json:"slug"`
+	InstalledVersion string `json:"installedVersion"`
+	Scope            string `json:"scope"`
+	Agent            string `json:"agent"`
+	ProjectDir       string `json:"projectDir,omitempty"`
+}
+
+// SkillInfoManifestPath returns the path to the manifest under a skill install directory (.jfrog/skill-info.json).
+func SkillInfoManifestPath(skillDir string) string {
+	return filepath.Join(skillDir, jfrogSkillDirName, skillInfoJSON)
+}
+
+// WriteSkillInfoManifest writes the manifest under skillDir (.jfrog/skill-info.json).
+func WriteSkillInfoManifest(skillDir string, manifest SkillInfoManifest) error {
+	if manifest.SchemaVersion == 0 {
+		manifest.SchemaVersion = SkillInfoManifestSchemaVersion
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal skill info manifest: %w", err)
+	}
+	dir := filepath.Join(skillDir, jfrogSkillDirName)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("create .jfrog under skill dir: %w", err)
+	}
+	path := filepath.Join(dir, skillInfoJSON)
+	if err := os.WriteFile(path, data, 0640); err != nil {
+		return fmt.Errorf("write skill info manifest: %w", err)
+	}
+	return nil
+}
+
+// ReadSkillInfoManifest reads .jfrog/skill-info.json when present.
+// A missing file returns (nil, nil).
+func ReadSkillInfoManifest(skillDir string) (*SkillInfoManifest, error) {
+	path := SkillInfoManifestPath(skillDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read skill manifest: %w", err)
+	}
+	var manifest SkillInfoManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse skill manifest %s: %w", path, err)
+	}
+	return &manifest, nil
+}

--- a/skills/common/skill_info_manifest_test.go
+++ b/skills/common/skill_info_manifest_test.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReadSkillInfoManifest(t *testing.T) {
+	skillDir := filepath.Join(t.TempDir(), "my-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o750))
+
+	manifest := SkillInfoManifest{
+		Repo:             "skills-local",
+		Slug:             "my-skill",
+		InstalledVersion: "1.0.3",
+		Scope:            "project",
+		Agent:            "cursor",
+		ProjectDir:       "/abs/project",
+	}
+	require.NoError(t, WriteSkillInfoManifest(skillDir, manifest))
+
+	assert.Equal(t, "skill-info.json", filepath.Base(SkillInfoManifestPath(skillDir)))
+
+	got, err := ReadSkillInfoManifest(skillDir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, SkillInfoManifestSchemaVersion, got.SchemaVersion)
+	assert.Equal(t, "skills-local", got.Repo)
+	assert.Equal(t, "my-skill", got.Slug)
+	assert.Equal(t, "1.0.3", got.InstalledVersion)
+	assert.Equal(t, "project", got.Scope)
+	assert.Equal(t, "cursor", got.Agent)
+	assert.Equal(t, "/abs/project", got.ProjectDir)
+}
+
+func TestReadSkillInfoManifest_MissingReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ReadSkillInfoManifest(dir)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}


### PR DESCRIPTION
### Overview
Improve "skills list" and "skills update" command

**Improvement in SKILLS LIST**
- For every install inside skills, a file is created ./jfrog/skill-info.json, which contains information of (repo, version, slug, etc)
- For --check-updates, cli will check skill-info.json version to get the version info, repo & calls that particular repo to get the latest version


**Improvement in SKILLS UPDATE**
- supports --agent, --project-dir/--global
- Supports --path <direct_path> , when --path is given no need to provide --agent, --project-dir/--global
- Loads meta-data from skill-info.json to get version, fall back to SKILL.md if skill-info.json is not present
- multi-agent update (--agent takes multiple agents seperated by comma (,))

**Improvement in SKILLS Install**
- During installation of skill, all its meta data will be stored in .jfrog/skill-info.json , this file will be used by list, update, to know REPO from which it is downloaded, VERSION (no need to write version number inside SKILL.md) & other info

**RTECO-1011 is parent task of RTECO-1077 & RTECO-1078**
Since changes of both RTECO-1078 & 1077 are present in this PR, used RTECO-1011 in PR title

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
