### PR TITLE
Updated logic for extracting repository key in case of reverse proxy scenario

### DIFF
--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -113,7 +113,7 @@ func (pc *PushCommand) Run() error {
 		return err
 	}
 	if !toCollect && pc.IsDetailedSummary() {
-		repo, err := pc.image.ExtractArtifactoryRepoKey()
+		repo, err := pc.GetRepo()
 		if err != nil {
 			return err
 		}

--- a/artifactory/commands/container/push_test.go
+++ b/artifactory/commands/container/push_test.go
@@ -1,0 +1,208 @@
+package container_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	container "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container"
+	ocicontainer "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/ocicontainer"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPushCommandPointingAt returns a PushCommand wired to talk to testServer.
+// The final image tag is "<host:port>/<imagePathWithTag>" so the HEAD request
+// issued by GetRepo lands on testServer. imagePathWithTag must already include
+// any desired tag (or be left untagged to exercise the implicit ":latest"
+// defaulting in GetImageLongNameWithTag).
+func newPushCommandPointingAt(t *testing.T, testServer *httptest.Server, imagePathWithTag string) *container.PushCommand {
+	t.Helper()
+	parsed, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	pc := container.NewPushCommand(ocicontainer.DockerClient)
+	pc.SetImageTag(parsed.Host + "/" + imagePathWithTag)
+	pc.SetServerDetails(&config.ServerDetails{ArtifactoryUrl: testServer.URL + "/"})
+	return pc
+}
+
+func TestPushCommand_GetRepo(t *testing.T) {
+	// --- Scenarios that mirror the previous TestExtractArtifactoryRepoKey cases ---
+
+	t.Run("returns repo from X-Artifactory-Docker-Registry header for nested image path", func(t *testing.T) {
+		// Mirrors original "valid image name": <registry>/<repo>/<image>:<tag>.
+		const expectedRepo = "my-repo"
+		var hits int32
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			assert.Equal(t, http.MethodHead, r.Method)
+			assert.Equal(t, "/v2/my-repo/my-image/manifests/latest", r.URL.Path)
+			w.Header().Set("X-Artifactory-Docker-Registry", expectedRepo)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "my-repo/my-image:latest")
+		gotRepo, err := pc.GetRepo()
+		require.NoError(t, err)
+		assert.Equal(t, expectedRepo, gotRepo)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "expected exactly one HEAD request to Artifactory")
+	})
+
+	t.Run("returns repo for image without explicit tag (defaults to :latest)", func(t *testing.T) {
+		// Mirrors original "valid name with no tag": <registry>/<repo>/<image>.
+		// GetImageLongNameWithTag should append ":latest" before building the URL.
+		const expectedRepo = "my-repo"
+		var hits int32
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			assert.Equal(t, "/v2/my-repo/my-image/manifests/latest", r.URL.Path,
+				"a missing tag should default to :latest")
+			w.Header().Set("X-Artifactory-Docker-Registry", expectedRepo)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "my-repo/my-image")
+		gotRepo, err := pc.GetRepo()
+		require.NoError(t, err)
+		assert.Equal(t, expectedRepo, gotRepo)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&hits))
+	})
+
+	t.Run("returns \"is missing '/'\" error for empty image name", func(t *testing.T) {
+		// Mirrors original "error from GetImageLongName (empty)".
+		// validateTag rejects the image before any HTTP call is attempted, so no
+		// httptest server is required.
+		pc := container.NewPushCommand(ocicontainer.DockerClient)
+		pc.SetImageTag("")
+		pc.SetServerDetails(&config.ServerDetails{ArtifactoryUrl: "http://unused.example/"})
+
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "is missing '/'")
+	})
+
+	t.Run("returns \"is missing '/'\" error for image name without any slash", func(t *testing.T) {
+		// Mirrors original "invalid format with no slash" — pc.GetRepo no longer
+		// produces an "invalid image name format" error (that lived in the
+		// removed string-parsing helper), but validateTag still rejects any image
+		// name that has no '/' separator at all.
+		pc := container.NewPushCommand(ocicontainer.DockerClient)
+		pc.SetImageTag("registry-only-no-slash")
+		pc.SetServerDetails(&config.ServerDetails{ArtifactoryUrl: "http://unused.example/"})
+
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "is missing '/'")
+	})
+
+	// --- New: reverse-proxy scenario (RTECO-1295) ---
+
+	t.Run("reverse proxy: repo key is in registry hostname, not in image path", func(t *testing.T) {
+		// When Artifactory is fronted by a reverse proxy / subdomain layout, the
+		// repo key sits in the FRONT of the registry URL (e.g.
+		// docker-local.artifactory.example.com/myimage:1.0) instead of being the
+		// first path segment after the registry. The image string contains no
+		// nested repo segment to parse, so pc.GetRepo() must rely on the
+		// X-Artifactory-Docker-Registry response header to discover the repo.
+		const expectedRepo = "docker-local"
+		var hits int32
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			assert.Equal(t, http.MethodHead, r.Method)
+			// Note the absence of a repo segment in the path — only /v2/<image>/manifests/<tag>.
+			assert.Equal(t, "/v2/myimage/manifests/1.0", r.URL.Path)
+			w.Header().Set("X-Artifactory-Docker-Registry", expectedRepo)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "myimage:1.0")
+		gotRepo, err := pc.GetRepo()
+		require.NoError(t, err)
+		assert.Equal(t, expectedRepo, gotRepo,
+			"reverse-proxy repo key must come from the response header, not from parsing the image path")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&hits))
+	})
+
+	// --- pc.GetRepo()-specific behaviours not covered before ---
+
+	t.Run("returns descriptive error on 403 forbidden", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "my-repo/my-image:latest")
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "403")
+		assert.Contains(t, err.Error(), "Possible causes include")
+	})
+
+	t.Run("returns error on non-OK status without docker registry header", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "missing-repo/missing-image:latest")
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "error while getting docker repository name")
+	})
+
+	t.Run("returns error when X-Artifactory-Docker-Registry header is missing", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "my-repo/my-image:latest")
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "X-Artifactory-Docker-Registry")
+	})
+
+	t.Run("uses cached repo without making any HTTP call", func(t *testing.T) {
+		const cachedRepo = "preset-repo"
+		var hits int32
+
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer testServer.Close()
+
+		pc := newPushCommandPointingAt(t, testServer, "my-repo/my-image:latest")
+		pc.SetRepo(cachedRepo)
+
+		gotRepo, err := pc.GetRepo()
+		require.NoError(t, err)
+		assert.Equal(t, cachedRepo, gotRepo)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&hits), "cached path should not contact Artifactory")
+	})
+
+	t.Run("returns error when image is not initialized", func(t *testing.T) {
+		pc := container.NewPushCommand(ocicontainer.DockerClient)
+		pc.SetServerDetails(&config.ServerDetails{ArtifactoryUrl: "http://unused.example/"})
+
+		gotRepo, err := pc.GetRepo()
+		require.Error(t, err)
+		assert.Empty(t, gotRepo)
+		assert.Contains(t, err.Error(), "container image not initialized")
+	})
+}

--- a/artifactory/commands/ocicontainer/image.go
+++ b/artifactory/commands/ocicontainer/image.go
@@ -222,17 +222,3 @@ func getStatusForbiddenErrorMessage() string {
 		"\nPlease verify the above factors to resolve the issue."
 	return errorMessage
 }
-
-// ExtractArtifactoryRepoKey parses the repository key from the image's long name,
-// which is expected to be in the format "<repo-key>/<image-name>:<image-tag>".
-func (image *Image) ExtractArtifactoryRepoKey() (string, error) {
-	imageName, err := image.GetImageLongName()
-	if err != nil {
-		return "", err
-	}
-	repoName, _, ok := strings.Cut(imageName, "/")
-	if ok {
-		return repoName, nil
-	}
-	return "", errorutils.CheckErrorf("invalid image name format. Got '%s'", imageName)
-}

--- a/artifactory/commands/ocicontainer/image_test.go
+++ b/artifactory/commands/ocicontainer/image_test.go
@@ -1,7 +1,6 @@
 package ocicontainer
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,64 +276,5 @@ func TestBuildRemoteRepoUrl(t *testing.T) {
 
 		actualRepo := buildRequestUrl(longImageName, imageTag, containerRegistryUrl, v.isSecure)
 		assert.Equal(t, v.expectedRepo, actualRepo)
-	}
-}
-
-func TestExtractArtifactoryRepoKey(t *testing.T) {
-	testCases := []struct {
-		name        string
-		image       *Image
-		wantKey     string
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:    "valid image name",
-			image:   &Image{name: "my-registry:port/my-repo/my-image:latest"},
-			wantKey: "my-repo",
-			wantErr: false,
-		},
-		{
-			name:        "invalid format with no slash",
-			image:       &Image{name: "my-registry:port/my-image-no-repo:latest"},
-			wantKey:     "",
-			wantErr:     true,
-			errContains: "invalid image name format",
-		},
-		{
-			name:        "error from GetImageLongName (empty)",
-			image:       &Image{name: ""},
-			wantKey:     "",
-			wantErr:     true,
-			errContains: "is missing '/'",
-		},
-		{
-			name:    "valid name with no tag",
-			image:   &Image{name: "my-registry:port/my-repo/my-image"},
-			wantKey: "my-repo",
-			wantErr: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotKey, err := tc.image.ExtractArtifactoryRepoKey()
-			if tc.wantErr {
-				if err == nil {
-					t.Errorf("ExtractArtifactoryRepoKey() expected an error, but got nil")
-					return
-				}
-				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-					t.Errorf("ExtractArtifactoryRepoKey() error = %q, want error containing %q", err, tc.errContains)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("ExtractArtifactoryRepoKey() returned unexpected error: %v", err)
-				}
-				if gotKey != tc.wantKey {
-					t.Errorf("ExtractArtifactoryRepoKey() = %q, want %q", gotKey, tc.wantKey)
-				}
-			}
-		})
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
What: Updated logic for extracting repository key so that reverse proxy scenarios can also be handled. 