### PR TITLE
Fix: Return error when jfrog server is not configured

### DIFF
--- a/agent/common/server.go
+++ b/agent/common/server.go
@@ -24,6 +24,9 @@ func GetServerDetails(commandContext *components.Context) (*config.ServerDetails
 	if err != nil {
 		return nil, fmt.Errorf("no default server configured. Use 'jf config add' or provide --url and --access-token flags: %w", err)
 	}
+	if details == nil {
+		return nil, fmt.Errorf("no default server configured. Use 'jf config add' or provide --url and --access-token flags")
+	}
 	if details.ArtifactoryUrl == "" && details.Url == "" {
 		return nil, fmt.Errorf("no Artifactory URL configured")
 	}

--- a/agent/common/server_test.go
+++ b/agent/common/server_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeArtifactoryUrl_AppendsArtifactoryPath(t *testing.T) {
@@ -39,4 +41,14 @@ func TestHasServerConfigFlags(t *testing.T) {
 
 	ctx.AddStringFlag("url", "https://acme.jfrog.io")
 	assert.True(t, hasServerConfigFlags(ctx))
+}
+
+func TestGetServerDetails_NoConfiguredServer(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(coreutils.HomeDir, dir)
+
+	ctx := &components.Context{}
+	_, err := GetServerDetails(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no default server configured")
 }

--- a/ide/common/base.go
+++ b/ide/common/base.go
@@ -21,6 +21,9 @@ func GetServerDetails(c *components.Context) (*config.ServerDetails, error) {
 	if err != nil {
 		return nil, fmt.Errorf("no default server configured")
 	}
+	if rtDetails == nil {
+		return nil, fmt.Errorf("no default server configured. Use 'jf config add' or provide --url and --access-token flags")
+	}
 	if rtDetails.ArtifactoryUrl == "" && rtDetails.Url == "" {
 		return nil, fmt.Errorf("no Artifactory URL configured")
 	}

--- a/skills/common/server.go
+++ b/skills/common/server.go
@@ -22,6 +22,9 @@ func GetServerDetails(c *components.Context) (*config.ServerDetails, error) {
 	if err != nil {
 		return nil, fmt.Errorf("no default server configured. Use 'jf config add' or provide --url and --access-token flags: %w", err)
 	}
+	if details == nil {
+		return nil, fmt.Errorf("no default server configured. Use 'jf config add' or provide --url and --access-token flags")
+	}
 	if details.ArtifactoryUrl == "" && details.Url == "" {
 		return nil, fmt.Errorf("no Artifactory URL configured")
 	}


### PR DESCRIPTION
GetDefaultServerConf() can return nil with no error when jf config has no servers. Guard
GetServerDetails in skills, agent, and IDE code paths and return a clear config error instead of
panicking.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
