### PR TITLE
Add delete Subcommand to jf agent plugins for Removing Plugin Versions from Artifactory

### DIFF
--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -19,7 +19,7 @@ func TestGetCommands_HasPluginsAndSkillsNamespaces(t *testing.T) {
 		assert.NotNil(t, sub.Action, "plugins subcommand %q must have an Action", sub.Name)
 		pluginsNames = append(pluginsNames, sub.Name)
 	}
-	assert.ElementsMatch(t, []string{"publish", "install"}, pluginsNames)
+	assert.ElementsMatch(t, []string{"publish", "install", "delete"}, pluginsNames)
 
 	skills := commands[1]
 	assert.Equal(t, "skills", skills.Name)

--- a/agent/common/storage.go
+++ b/agent/common/storage.go
@@ -9,7 +9,28 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 )
+
+// DeleteVersion deletes the entire version directory for a package (plugin, skill, etc.)
+// at {artURL}{repoKey}/{slug}/{version}/ using an HTTP DELETE request.
+func DeleteVersion(serverDetails *config.ServerDetails, repoKey, slug, version string) error {
+	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	if err != nil {
+		return fmt.Errorf("failed to create service manager for deletion: %w", err)
+	}
+	artURL := clientutils.AddTrailingSlashIfNeeded(sm.GetConfig().GetServiceDetails().GetUrl())
+	deletePath := fmt.Sprintf("%s%s/%s/%s/", artURL, repoKey, slug, version)
+	httpDetails := sm.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	resp, body, err := sm.Client().SendDelete(deletePath, nil, &httpDetails)
+	if err != nil {
+		return fmt.Errorf("failed to delete %s/%s/%s: %w", repoKey, slug, version, err)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("failed to delete %s/%s/%s: HTTP %d — %s", repoKey, slug, version, resp.StatusCode, string(body))
+	}
+	return nil
+}
 
 // ErrVersionExistenceUnknown indicates the version path could not be checked (e.g. network
 // error or an Artifactory response whose HTTP status could not be read). Callers should not

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -1,13 +1,14 @@
 package cli
 
 import (
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/delete"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/publish"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 )
 
-// GetSubCommands returns leaf commands for `jf agent plugins` (publish, install, …).
+// GetSubCommands returns leaf commands for `jf agent plugins` (publish, install, delete, …).
 func GetSubCommands() []components.Command {
 	return []components.Command{
 		{
@@ -28,6 +29,13 @@ func GetSubCommands() []components.Command {
 			Arguments: getInstallArguments(),
 			Action:    install.RunInstall,
 		},
+		{
+			Name:        "delete",
+			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsDelete),
+			Description: "Delete a specific agent plugin version from Artifactory.",
+			Arguments:   getDeleteArguments(),
+			Action:      delete.RunDelete,
+		},
 	}
 }
 
@@ -45,6 +53,15 @@ func getInstallArguments() []components.Argument {
 		{
 			Name:        "slug",
 			Description: "Slug (name) of the plugin to install.",
+		},
+	}
+}
+
+func getDeleteArguments() []components.Argument {
+	return []components.Argument{
+		{
+			Name:        "slug",
+			Description: "Plugin name/slug to delete.",
 		},
 	}
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -3,27 +3,40 @@ package cli
 import (
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetSubCommands_HasPublishAndInstall(t *testing.T) {
 	commands := GetSubCommands()
-	require.Len(t, commands, 2)
+	names := make([]string, 0, len(commands))
+	for _, cmd := range commands {
+		names = append(names, cmd.Name)
+	}
+	assert.ElementsMatch(t, []string{"publish", "install", "delete"}, names)
 
-	publish := commands[0]
-	assert.Equal(t, "publish", publish.Name)
+	byName := make(map[string]components.Command, len(commands))
+	for _, cmd := range commands {
+		byName[cmd.Name] = cmd
+	}
+
+	publish := byName["publish"]
 	assert.NotNil(t, publish.Action)
 	require.Len(t, publish.Arguments, 1)
 	assert.Equal(t, "path", publish.Arguments[0].Name)
 	assert.Contains(t, publish.Description, "Publish an agent plugin to Artifactory")
 	assert.Contains(t, publish.Description, "Signs and attaches evidence")
 
-	installCmd := commands[1]
-	assert.Equal(t, "install", installCmd.Name)
+	installCmd := byName["install"]
 	assert.NotNil(t, installCmd.Action)
 	require.Len(t, installCmd.Arguments, 1)
 	assert.Equal(t, "slug", installCmd.Arguments[0].Name)
 	assert.Contains(t, installCmd.Description, "Install an agent plugin from Artifactory")
-	assert.Contains(t, installCmd.Description, "marketplace")
+
+	del := byName["delete"]
+	assert.NotNil(t, del.Action)
+	require.Len(t, del.Arguments, 1)
+	assert.Equal(t, "slug", del.Arguments[0].Name)
+	assert.Contains(t, del.Description, "Delete a specific agent plugin version")
 }

--- a/agent/plugins/commands/delete/delete.go
+++ b/agent/plugins/commands/delete/delete.go
@@ -1,0 +1,114 @@
+package delete
+
+import (
+	"fmt"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	pluginscommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// DeleteCommand deletes a specific agent plugin version from a repository.
+type DeleteCommand struct {
+	serverDetails *config.ServerDetails
+	repoKey       string
+	slug          string
+	version       string
+	dryRun        bool
+}
+
+func NewDeleteCommand() *DeleteCommand {
+	return &DeleteCommand{}
+}
+
+func (dc *DeleteCommand) SetServerDetails(details *config.ServerDetails) *DeleteCommand {
+	dc.serverDetails = details
+	return dc
+}
+
+func (dc *DeleteCommand) SetRepoKey(repoKey string) *DeleteCommand {
+	dc.repoKey = repoKey
+	return dc
+}
+
+func (dc *DeleteCommand) SetSlug(slug string) *DeleteCommand {
+	dc.slug = slug
+	return dc
+}
+
+func (dc *DeleteCommand) SetVersion(version string) *DeleteCommand {
+	dc.version = version
+	return dc
+}
+
+func (dc *DeleteCommand) SetDryRun(dryRun bool) *DeleteCommand {
+	dc.dryRun = dryRun
+	return dc
+}
+
+func (dc *DeleteCommand) ServerDetails() (*config.ServerDetails, error) {
+	return dc.serverDetails, nil
+}
+
+func (dc *DeleteCommand) CommandName() string {
+	return "plugins_delete"
+}
+
+func (dc *DeleteCommand) Run() error {
+	if dc.version == "" {
+		return fmt.Errorf("--version is required for delete")
+	}
+
+	deletePath := fmt.Sprintf("%s/%s/%s/", dc.repoKey, dc.slug, dc.version)
+
+	if dc.dryRun {
+		if dc.serverDetails != nil {
+			exists, err := agentcommon.PackageVersionExists(dc.serverDetails, dc.repoKey, dc.slug, dc.version)
+			if err != nil {
+				return fmt.Errorf("failed to verify plugin existence: %w", err)
+			}
+			if !exists {
+				return fmt.Errorf("plugin '%s' v%s not found in repository '%s'", dc.slug, dc.version, dc.repoKey)
+			}
+		}
+		log.Info(fmt.Sprintf("[DRY RUN] Would delete plugin '%s' v%s from '%s' (path: %s)", dc.slug, dc.version, dc.repoKey, deletePath))
+		return nil
+	}
+
+	if err := agentcommon.DeleteVersion(dc.serverDetails, dc.repoKey, dc.slug, dc.version); err != nil {
+		return err
+	}
+
+	log.Info(fmt.Sprintf("Plugin '%s' v%s deleted from '%s'.", dc.slug, dc.version, dc.repoKey))
+	return nil
+}
+
+// RunDelete is the CLI action for `jf agent plugins delete`.
+func RunDelete(c *components.Context) error {
+	if c.GetNumberOfArgs() < 1 {
+		return fmt.Errorf("usage: jf agent plugins delete <slug> --version <version> [--repo <repo>] [options]")
+	}
+
+	slug := c.GetArgumentAt(0)
+
+	serverDetails, err := agentcommon.GetServerDetails(c)
+	if err != nil {
+		return err
+	}
+
+	repoKey, err := agentcommon.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), agentcommon.IsQuiet(c), pluginscommon.RepoOptions())
+	if err != nil {
+		return err
+	}
+
+	cmd := NewDeleteCommand().
+		SetServerDetails(serverDetails).
+		SetRepoKey(repoKey).
+		SetSlug(slug).
+		SetVersion(c.GetStringFlagValue("version")).
+		SetDryRun(c.GetBoolFlagValue("dry-run"))
+
+	return cmd.Run()
+}

--- a/agent/plugins/commands/delete/delete_test.go
+++ b/agent/plugins/commands/delete/delete_test.go
@@ -1,0 +1,27 @@
+package delete
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteCommand_MissingVersion(t *testing.T) {
+	cmd := NewDeleteCommand().
+		SetSlug("test-plugin").
+		SetRepoKey("repo")
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--version is required")
+}
+
+func TestDeleteCommand_DryRun(t *testing.T) {
+	cmd := NewDeleteCommand().
+		SetSlug("test-plugin").
+		SetRepoKey("repo").
+		SetVersion("1.0.0").
+		SetDryRun(true)
+	// Dry run with no server should succeed without any network call.
+	err := cmd.Run()
+	assert.NoError(t, err)
+}

--- a/agent/skills/common/xray_gate.go
+++ b/agent/skills/common/xray_gate.go
@@ -66,7 +66,7 @@ func CheckXrayGate(params XrayGateParams) error {
 		log.Info(fmt.Sprintf("[SUCCESS] Skill \"%s\" v%s passed security scan.", params.Slug, params.Version))
 		return nil
 	case services.SkillXrayStatusBlocked:
-		return handleBlocked(sm, params)
+		return handleBlocked(params)
 	case services.SkillXrayStatusScanInProgress:
 		return pollUntilDone(sm, params)
 	default:
@@ -140,7 +140,7 @@ func pollUntilDone(sm artifactory.ArtifactoryServicesManager, params XrayGatePar
 				return nil
 			case services.SkillXrayStatusBlocked:
 				stopSpinner()
-				return handleBlocked(sm, params)
+				return handleBlocked(params)
 			case services.SkillXrayStatusScanInProgress:
 				continue
 			default:
@@ -152,7 +152,7 @@ func pollUntilDone(sm artifactory.ArtifactoryServicesManager, params XrayGatePar
 	}
 }
 
-func handleBlocked(sm artifactory.ArtifactoryServicesManager, params XrayGateParams) error {
+func handleBlocked(params XrayGateParams) error {
 	log.Error(fmt.Sprintf("[VIOLATION] Skill \"%s\" v%s identified as malicious.", params.Slug, params.Version))
 	if params.AutoDeleteOnFailure {
 		deletePath := fmt.Sprintf("%s/%s/%s/", params.RepoKey, params.Slug, params.Version)

--- a/agent/skills/common/xray_gate.go
+++ b/agent/skills/common/xray_gate.go
@@ -167,13 +167,8 @@ func handleBlocked(sm artifactory.ArtifactoryServicesManager, params XrayGatePar
 }
 
 // DeleteSkillVersion deletes the entire version directory for a skill.
-// Creates its own service manager. For callers that already have one, use deleteSkillVersionWithManager.
 func DeleteSkillVersion(serverDetails *config.ServerDetails, repoKey, slug, version string) error {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
-	if err != nil {
-		return fmt.Errorf("failed to create service manager for deletion: %w", err)
-	}
-	return deleteSkillVersionWithManager(sm, repoKey, slug, version)
+	return agentcommon.DeleteVersion(serverDetails, repoKey, slug, version)
 }
 
 func deleteSkillVersionWithManager(sm artifactory.ArtifactoryServicesManager, repoKey, slug, version string) error {

--- a/agent/skills/common/xray_gate.go
+++ b/agent/skills/common/xray_gate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/progressbar"
 	"github.com/jfrog/jfrog-client-go/artifactory"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -157,7 +156,7 @@ func handleBlocked(sm artifactory.ArtifactoryServicesManager, params XrayGatePar
 	log.Error(fmt.Sprintf("[VIOLATION] Skill \"%s\" v%s identified as malicious.", params.Slug, params.Version))
 	if params.AutoDeleteOnFailure {
 		deletePath := fmt.Sprintf("%s/%s/%s/", params.RepoKey, params.Slug, params.Version)
-		if err := deleteSkillVersionWithManager(sm, params.RepoKey, params.Slug, params.Version); err != nil {
+		if err := agentcommon.DeleteVersion(params.ServerDetails, params.RepoKey, params.Slug, params.Version); err != nil {
 			log.Error(fmt.Sprintf("Failed to delete malicious skill artifact '%s' from '%s': %s", deletePath, params.RepoKey, err.Error()))
 		} else {
 			log.Info(fmt.Sprintf("Malicious artifact deleted: %s", deletePath))
@@ -171,23 +170,6 @@ func DeleteSkillVersion(serverDetails *config.ServerDetails, repoKey, slug, vers
 	return agentcommon.DeleteVersion(serverDetails, repoKey, slug, version)
 }
 
-func deleteSkillVersionWithManager(sm artifactory.ArtifactoryServicesManager, repoKey, slug, version string) error {
-	if sm == nil {
-		return fmt.Errorf("service manager is nil")
-	}
-	artURL := clientutils.AddTrailingSlashIfNeeded(sm.GetConfig().GetServiceDetails().GetUrl())
-	deletePath := fmt.Sprintf("%s%s/%s/%s/", artURL, repoKey, slug, version)
-	httpDetails := sm.GetConfig().GetServiceDetails().CreateHttpClientDetails()
-
-	resp, body, err := sm.Client().SendDelete(deletePath, nil, &httpDetails)
-	if err != nil {
-		return fmt.Errorf("failed to delete %s/%s/%s: %w", repoKey, slug, version, err)
-	}
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("failed to delete %s/%s/%s: HTTP %d — %s", repoKey, slug, version, resp.StatusCode, string(body))
-	}
-	return nil
-}
 
 func resolveTimeout() time.Duration {
 	if v := os.Getenv(envScanTimeout); v != "" {

--- a/agent/skills/common/xray_gate_test.go
+++ b/agent/skills/common/xray_gate_test.go
@@ -43,7 +43,7 @@ func TestHandleBlocked_NoAutoDelete(t *testing.T) {
 		Version:             "1.0.0",
 		AutoDeleteOnFailure: false,
 	}
-	err := handleBlocked(nil, params)
+	err := handleBlocked(params)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "blocked by Xray security scan")
 }

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -514,6 +514,7 @@ const (
 	// Agent plugin commands keys
 	AgentPluginsPublish = "agent-plugins-publish"
 	AgentPluginsInstall = "agent-plugins-install"
+	AgentPluginsDelete  = "agent-plugins-delete"
 
 	// Agent namespace-specific flags (shared by skills and agent-plugins commands)
 	version    = "version"
@@ -894,6 +895,9 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet, dryRun, agentForce,
 	},
 	SkillsDelete: {
+		url, user, password, accessToken, serverId, repo, version, dryRun,
+	},
+	AgentPluginsDelete: {
 		url, user, password, accessToken, serverId, repo, version, dryRun,
 	},
 	SkillsSearch: {

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -888,6 +888,9 @@ var commandFlags = map[string][]string{
 	AgentPluginsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
 	},
+	AgentPluginsDelete: {
+		url, user, password, accessToken, serverId, repo, version, dryRun,
+	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
 	},
@@ -895,9 +898,6 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet, dryRun, agentForce,
 	},
 	SkillsDelete: {
-		url, user, password, accessToken, serverId, repo, version, dryRun,
-	},
-	AgentPluginsDelete: {
 		url, user, password, accessToken, serverId, repo, version, dryRun,
 	},
 	SkillsSearch: {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
## Summary

  - Add `jf agent plugins delete <slug> --version <version>` command to delete a specific agent plugin version from Artifactory
  - Extract shared HTTP DELETE logic into `agentcommon.DeleteVersion` in `agent/common/storage.go` so both skills and plugins reuse it
  - Refactor `DeleteSkillVersion` in `agent/skills/common/xray_gate.go` to delegate to the shared utility

  ## Usage

  ```bash
  # Delete a specific plugin version
  jf agent plugins delete <slug> --version <version> --repo <repo>

  # Preview what would be deleted without making any changes
  jf agent plugins delete <slug> --version <version> --repo <repo> --dry-run
```
  Repo can also be set via JFROG_AGENT_PLUGINS_REPO env var.