### PR TITLE
feat(agent/plugins): add delete commands (RTECO-1269)

### DIFF
--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -19,7 +19,7 @@ func TestGetCommands_HasPluginsAndSkillsNamespaces(t *testing.T) {
 		assert.NotNil(t, sub.Action, "plugins subcommand %q must have an Action", sub.Name)
 		pluginsNames = append(pluginsNames, sub.Name)
 	}
-	assert.ElementsMatch(t, []string{"publish", "install", "delete"}, pluginsNames)
+	assert.ElementsMatch(t, []string{"publish", "install", "delete", "list"}, pluginsNames)
 
 	skills := commands[1]
 	assert.Equal(t, "skills", skills.Name)

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/delete"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/list"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/publish"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
@@ -35,6 +36,12 @@ func GetSubCommands() []components.Command {
 			Description: "Delete a specific agent plugin version from Artifactory.",
 			Arguments:   getDeleteArguments(),
 			Action:      delete.RunDelete,
+		},
+		{
+			Name:        "list",
+			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsList),
+			Description: "List agent plugins from Artifactory (--repo) or locally installed (--harness).",
+			Action:      list.RunList,
 		},
 	}
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -14,7 +14,7 @@ func TestGetSubCommands_HasPublishAndInstall(t *testing.T) {
 	for _, cmd := range commands {
 		names = append(names, cmd.Name)
 	}
-	assert.ElementsMatch(t, []string{"publish", "install", "delete"}, names)
+	assert.ElementsMatch(t, []string{"publish", "install", "delete", "list"}, names)
 
 	byName := make(map[string]components.Command, len(commands))
 	for _, cmd := range commands {
@@ -39,4 +39,8 @@ func TestGetSubCommands_HasPublishAndInstall(t *testing.T) {
 	require.Len(t, del.Arguments, 1)
 	assert.Equal(t, "slug", del.Arguments[0].Name)
 	assert.Contains(t, del.Description, "Delete a specific agent plugin version")
+
+	lst := byName["list"]
+	assert.NotNil(t, lst.Action)
+	assert.Contains(t, lst.Description, "List agent plugins")
 }

--- a/agent/plugins/commands/list/list.go
+++ b/agent/plugins/commands/list/list.go
@@ -1,0 +1,419 @@
+package list
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	pluginscommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	sortByName      = "name"
+	sortByUpdated   = "updated"
+	sortByDownloads = "downloads"
+	sortOrderAsc    = "asc"
+	sortOrderDesc   = "desc"
+	emDash          = "—"
+
+	manifestRepoUnknownDisplay = "(unknown)"
+	repoListSourcePrefix       = "Repo: "
+
+	listCheckStatusUnknown = "unknown"
+	listCheckStatusBehind  = "behind"
+	listCheckStatusCurrent = "current"
+	listCheckStatusAhead   = "ahead"
+)
+
+// repoListRow is one row for registry mode (jf agent plugins list --repo).
+type repoListRow struct {
+	Name    string `json:"name" col-name:"NAME"`
+	Version string `json:"version" col-name:"VERSION"`
+	Source  string `json:"source" col-name:"SOURCE"`
+}
+
+// localListRow is one row for local mode (jf agent plugins list --harness).
+type localListRow struct {
+	Name           string `json:"name" col-name:"PLUGIN"`
+	Version        string `json:"version" col-name:"INSTALLED"`
+	Description    string `json:"description" col-name:"DESCRIPTION"`
+	Repo           string `json:"repo" col-name:"REPO"`
+	Path           string `json:"path" col-name:"PATH"`
+	RegistryLatest string `json:"registryLatest,omitempty" col-name:"REGISTRY LATEST" omitempty:"true"`
+	Status         string `json:"status,omitempty" col-name:"STATUS" omitempty:"true"`
+}
+
+// ListCommand lists agent plugins from Artifactory or from a local agent install directory.
+type ListCommand struct {
+	serverDetails *config.ServerDetails
+	repoKey       string
+	agentName     string
+	projectDir    string
+	global        bool
+	format        string
+	limit         int
+	sortBy        string
+	sortOrder     string
+	checkUpdates  bool
+}
+
+func (lc *ListCommand) SetServerDetails(details *config.ServerDetails) *ListCommand {
+	lc.serverDetails = details
+	return lc
+}
+
+func (lc *ListCommand) SetRepoKey(repoKey string) *ListCommand {
+	lc.repoKey = repoKey
+	return lc
+}
+
+func (lc *ListCommand) SetAgentName(agentName string) *ListCommand {
+	lc.agentName = agentName
+	return lc
+}
+
+func (lc *ListCommand) SetProjectDir(projectDir string) *ListCommand {
+	lc.projectDir = projectDir
+	return lc
+}
+
+func (lc *ListCommand) SetGlobal(isGlobal bool) *ListCommand {
+	lc.global = isGlobal
+	return lc
+}
+
+func (lc *ListCommand) SetFormat(format string) *ListCommand {
+	lc.format = format
+	return lc
+}
+
+func (lc *ListCommand) SetLimit(limit int) *ListCommand {
+	lc.limit = limit
+	return lc
+}
+
+func (lc *ListCommand) SetSortBy(sortBy string) *ListCommand {
+	lc.sortBy = sortBy
+	return lc
+}
+
+func (lc *ListCommand) SetSortOrder(sortOrder string) *ListCommand {
+	lc.sortOrder = sortOrder
+	return lc
+}
+
+func (lc *ListCommand) SetCheckUpdates(v bool) *ListCommand {
+	lc.checkUpdates = v
+	return lc
+}
+
+func (lc *ListCommand) Run() error {
+	if lc.repoKey == "" && lc.agentName == "" {
+		return fmt.Errorf(
+			"jf agent plugins list requires exactly one of:\n"+
+				"  Registry: jf agent plugins list --repo <repository-key> [--limit N] [--sort-by updated|downloads]\n"+
+				"  Local:    jf agent plugins list --harness <name> [--project-dir <path>]\n"+
+				"  Global:   jf agent plugins list --harness <name> --global\n\n"+
+				"Supported agents: %s",
+			agentcommon.SupportedAgentsList(pluginscommon.Agents, agentcommon.PluginsAgentsKey),
+		)
+	}
+	if lc.repoKey != "" && lc.agentName != "" {
+		return fmt.Errorf("--repo and --harness are mutually exclusive; specify only one")
+	}
+	if lc.global && lc.projectDir != "" {
+		return fmt.Errorf("--global and --project-dir are mutually exclusive, please choose either --global or --project-dir")
+	}
+	if lc.checkUpdates && lc.repoKey != "" {
+		return fmt.Errorf("--check-updates is only supported with --harness, not with --repo")
+	}
+
+	if lc.agentName != "" {
+		parsed, err := pluginscommon.ParseHarnessForList(lc.agentName)
+		if err != nil {
+			return err
+		}
+		lc.agentName = parsed
+		if lc.checkUpdates && lc.serverDetails == nil {
+			return fmt.Errorf("--check-updates requires a configured Artifactory server (same as other jf agent plugins commands)")
+		}
+		return lc.listLocalPlugins()
+	}
+	return lc.listRepoPlugins()
+}
+
+func (lc *ListCommand) listRepoPlugins() error {
+	items, err := pluginscommon.ListPlugins(lc.serverDetails, lc.repoKey, lc.limit, lc.sortBy)
+	if err != nil {
+		return err
+	}
+
+	results := make([]repoListRow, 0, len(items))
+	for _, item := range items {
+		results = append(results, repoListRow{
+			Name:    item.Slug,
+			Version: item.LatestVersion,
+			Source:  repoListSourcePrefix + lc.repoKey,
+		})
+	}
+	return lc.printRepoResults(results)
+}
+
+func (lc *ListCommand) listLocalPlugins() error {
+	registry, err := agentcommon.LoadAgentRegistry(pluginscommon.Agents, agentcommon.PluginsAgentsKey)
+	if err != nil {
+		return err
+	}
+	spec, err := agentcommon.ResolveAgent(registry, lc.agentName, pluginscommon.RegistryHelp)
+	if err != nil {
+		return err
+	}
+
+	dir, err := agentcommon.ResolveAgentInstallDir(spec, lc.projectDir, lc.global)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Info(fmt.Sprintf("No plugins directory found for agent %q (expected: %s)", lc.agentName, dir))
+			return nil
+		}
+		return fmt.Errorf("failed to read plugins directory %s: %w", dir, err)
+	}
+
+	projectDir := ""
+	if !lc.global {
+		projectDir = lc.projectDir
+	}
+
+	var results []localListRow
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pluginDir := filepath.Join(dir, entry.Name())
+		meta, err := pluginscommon.ReadPluginMeta(pluginDir)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", entry.Name(), err.Error()))
+			continue
+		}
+		manifest, err := agentcommon.ReadInstallInfoManifest(pluginDir, pluginscommon.PluginInfoManifestFile)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Plugin '%s': invalid install manifest (%s); treating as missing", entry.Name(), err.Error()))
+			manifest = nil
+		}
+
+		repo := manifestRepoUnknownDisplay
+		if manifest != nil && strings.TrimSpace(manifest.Repo) != "" {
+			repo = manifest.Repo
+		}
+		installedVer := strings.TrimSpace(meta.Version)
+		if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+			installedVer = strings.TrimSpace(manifest.InstalledVersion)
+		}
+
+		row := localListRow{
+			Name:        entry.Name(),
+			Version:     installedVer,
+			Description: meta.Description,
+			Repo:        repo,
+			Path:        pluginDisplayPath(pluginDir, projectDir, lc.global),
+		}
+		if lc.checkUpdates {
+			lc.fillUpdateStatus(&row)
+		}
+		results = append(results, row)
+	}
+
+	desc := strings.ToLower(lc.sortOrder) == sortOrderDesc
+	sort.Slice(results, func(i, j int) bool {
+		ni, nj := strings.ToLower(results[i].Name), strings.ToLower(results[j].Name)
+		if desc {
+			return ni > nj
+		}
+		return ni < nj
+	})
+
+	if lc.limit > 0 && len(results) > lc.limit {
+		results = results[:lc.limit]
+	}
+
+	return lc.printLocalResults(results)
+}
+
+func pluginDisplayPath(pluginDirAbs, projectDir string, global bool) string {
+	if !global && projectDir != "" {
+		rel, err := filepath.Rel(projectDir, pluginDirAbs)
+		if err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		rel, err := filepath.Rel(home, pluginDirAbs)
+		if err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			return "~/" + filepath.ToSlash(rel)
+		}
+	}
+	return filepath.ToSlash(pluginDirAbs)
+}
+
+func (lc *ListCommand) fillUpdateStatus(row *localListRow) {
+	if row.Repo == "" || row.Repo == manifestRepoUnknownDisplay {
+		row.RegistryLatest = emDash
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	latest, err := pluginscommon.ResolveLatestPluginVersion(lc.serverDetails, row.Repo, row.Name)
+	if err != nil {
+		row.RegistryLatest = emDash
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	row.RegistryLatest = latest
+	cmp, err := agentcommon.CompareSemver(row.Version, latest)
+	if err != nil {
+		row.Status = listCheckStatusUnknown
+		return
+	}
+	switch {
+	case cmp < 0:
+		row.Status = listCheckStatusBehind
+	case cmp == 0:
+		row.Status = listCheckStatusCurrent
+	default:
+		row.Status = listCheckStatusAhead
+	}
+}
+
+func (lc *ListCommand) printRepoResults(results []repoListRow) error {
+	if results == nil {
+		results = []repoListRow{}
+	}
+	if strings.EqualFold(lc.format, "json") {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal results: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(results) == 0 {
+		log.Info("No plugins found.")
+		return nil
+	}
+	return coreutils.PrintTable(results, "Plugins", "No plugins found", false)
+}
+
+func (lc *ListCommand) printLocalResults(results []localListRow) error {
+	if results == nil {
+		results = []localListRow{}
+	}
+	if strings.EqualFold(lc.format, "json") {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal results: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(results) == 0 {
+		log.Info("No plugins found.")
+		return nil
+	}
+	return coreutils.PrintTable(results, "Plugins", "No plugins found", false)
+}
+
+// RunList is the CLI action for `jf agent plugins list`.
+func RunList(c *components.Context) error {
+	repoKey := c.GetStringFlagValue("repo")
+	agentName := strings.TrimSpace(c.GetStringFlagValue("harness"))
+
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+
+	checkUpdates := c.GetBoolFlagValue("check-updates")
+	isGlobal := c.GetBoolFlagValue("global")
+
+	limit := 0
+	if limitStr := c.GetStringFlagValue("limit"); limitStr != "" {
+		var err error
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil || limit <= 0 {
+			return fmt.Errorf("--limit must be a positive integer, got: %q", limitStr)
+		}
+	}
+
+	var sortBy, sortOrder string
+	if repoKey != "" {
+		sortBy = sortByUpdated
+		if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
+			if raw != sortByUpdated && raw != sortByDownloads {
+				return fmt.Errorf("--sort-by for --repo accepts 'updated' or 'downloads', got: %q", raw)
+			}
+			sortBy = raw
+		}
+	} else {
+		sortBy = sortByName
+		sortOrder = sortOrderAsc
+		if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
+			if raw != sortByName {
+				return fmt.Errorf("--sort-by for --harness only accepts 'name', got: %q", raw)
+			}
+			sortBy = raw
+		}
+		if raw := strings.ToLower(c.GetStringFlagValue("sort-order")); raw != "" {
+			if raw != sortOrderAsc && raw != sortOrderDesc {
+				return fmt.Errorf("--sort-order must be 'asc' or 'desc', got: %q", raw)
+			}
+			sortOrder = raw
+		}
+	}
+
+	projectDir := c.GetStringFlagValue("project-dir")
+	if !isGlobal && projectDir == "" && agentName != "" {
+		projectDir = "."
+	}
+	if projectDir != "" {
+		abs, err := filepath.Abs(projectDir)
+		if err != nil {
+			return fmt.Errorf("invalid --project-dir path %q: %w", projectDir, err)
+		}
+		projectDir = abs
+	}
+
+	cmd := &ListCommand{}
+	cmd.SetRepoKey(repoKey).
+		SetAgentName(agentName).
+		SetProjectDir(projectDir).
+		SetGlobal(isGlobal).
+		SetFormat(format).
+		SetLimit(limit).
+		SetSortBy(sortBy).
+		SetSortOrder(sortOrder).
+		SetCheckUpdates(checkUpdates)
+
+	if repoKey != "" || (agentName != "" && checkUpdates) {
+		serverDetails, err := agentcommon.GetServerDetails(c)
+		if err != nil {
+			return err
+		}
+		cmd.SetServerDetails(serverDetails)
+	}
+
+	return cmd.Run()
+}

--- a/agent/plugins/commands/list/list.go
+++ b/agent/plugins/commands/list/list.go
@@ -305,7 +305,7 @@ func pluginDisplayPath(pluginDirAbs, projectDir string, global bool) string {
 	if err == nil && home != "" {
 		rel, err := filepath.Rel(home, pluginDirAbs)
 		if err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-			return "~/" + filepath.ToSlash(rel)
+			return "$HOME/" + filepath.ToSlash(rel)
 		}
 	}
 	return filepath.ToSlash(pluginDirAbs)

--- a/agent/plugins/commands/list/list.go
+++ b/agent/plugins/commands/list/list.go
@@ -57,7 +57,7 @@ type localListRow struct {
 type ListCommand struct {
 	serverDetails *config.ServerDetails
 	repoKey       string
-	agentName     string
+	agentNames    []string
 	projectDir    string
 	global        bool
 	format        string
@@ -77,8 +77,8 @@ func (lc *ListCommand) SetRepoKey(repoKey string) *ListCommand {
 	return lc
 }
 
-func (lc *ListCommand) SetAgentName(agentName string) *ListCommand {
-	lc.agentName = agentName
+func (lc *ListCommand) SetAgentNames(names []string) *ListCommand {
+	lc.agentNames = names
 	return lc
 }
 
@@ -118,17 +118,17 @@ func (lc *ListCommand) SetCheckUpdates(v bool) *ListCommand {
 }
 
 func (lc *ListCommand) Run() error {
-	if lc.repoKey == "" && lc.agentName == "" {
+	if lc.repoKey == "" && len(lc.agentNames) == 0 {
 		return fmt.Errorf(
 			"jf agent plugins list requires exactly one of:\n"+
-				"  Registry: jf agent plugins list --repo <repository-key> [--limit N] [--sort-by updated|downloads]\n"+
-				"  Local:    jf agent plugins list --harness <name> [--project-dir <path>]\n"+
-				"  Global:   jf agent plugins list --harness <name> --global\n\n"+
+				"  Registry: jf agent plugins list --repo <repository-key> [--limit N]\n"+
+				"  Local:    jf agent plugins list --harness <name[,name...]> [--project-dir <path>]\n"+
+				"  Global:   jf agent plugins list --harness <name[,name...]> --global\n\n"+
 				"Supported agents: %s",
 			agentcommon.SupportedAgentsList(pluginscommon.Agents, agentcommon.PluginsAgentsKey),
 		)
 	}
-	if lc.repoKey != "" && lc.agentName != "" {
+	if lc.repoKey != "" && len(lc.agentNames) > 0 {
 		return fmt.Errorf("--repo and --harness are mutually exclusive; specify only one")
 	}
 	if lc.global && lc.projectDir != "" {
@@ -137,60 +137,93 @@ func (lc *ListCommand) Run() error {
 	if lc.checkUpdates && lc.repoKey != "" {
 		return fmt.Errorf("--check-updates is only supported with --harness, not with --repo")
 	}
+	if lc.checkUpdates && lc.serverDetails == nil {
+		return fmt.Errorf("--check-updates requires a configured Artifactory server (same as other jf agent plugins commands)")
+	}
 
-	if lc.agentName != "" {
-		parsed, err := pluginscommon.ParseHarnessForList(lc.agentName)
-		if err != nil {
-			return err
-		}
-		lc.agentName = parsed
-		if lc.checkUpdates && lc.serverDetails == nil {
-			return fmt.Errorf("--check-updates requires a configured Artifactory server (same as other jf agent plugins commands)")
-		}
+	if len(lc.agentNames) > 0 {
 		return lc.listLocalPlugins()
 	}
 	return lc.listRepoPlugins()
 }
 
 func (lc *ListCommand) listRepoPlugins() error {
-	items, err := pluginscommon.ListPlugins(lc.serverDetails, lc.repoKey, lc.limit, lc.sortBy)
+	pluginEntries, err := pluginscommon.ListPlugins(lc.serverDetails, lc.repoKey, lc.limit)
 	if err != nil {
 		return err
 	}
 
-	results := make([]repoListRow, 0, len(items))
-	for _, item := range items {
-		results = append(results, repoListRow{
-			Name:    item.Slug,
-			Version: item.LatestVersion,
+	rows := make([]repoListRow, 0, len(pluginEntries))
+	for _, entry := range pluginEntries {
+		rows = append(rows, repoListRow{
+			Name:    entry.Slug,
+			Version: entry.LatestVersion,
 			Source:  repoListSourcePrefix + lc.repoKey,
 		})
 	}
-	return lc.printRepoResults(results)
+	return lc.printRepoResults(rows)
 }
 
+// listLocalPlugins lists installed plugins for each harness in lc.agentNames.
+// For multiple harnesses, each gets its own labelled table.
 func (lc *ListCommand) listLocalPlugins() error {
 	registry, err := agentcommon.LoadAgentRegistry(pluginscommon.Agents, agentcommon.PluginsAgentsKey)
 	if err != nil {
 		return err
 	}
-	spec, err := agentcommon.ResolveAgent(registry, lc.agentName, pluginscommon.RegistryHelp)
+
+	// For JSON with multiple harnesses, collect into a map keyed by harness name.
+	if strings.EqualFold(lc.format, "json") && len(lc.agentNames) > 1 {
+		allResults := make(map[string][]localListRow, len(lc.agentNames))
+		for _, agentName := range lc.agentNames {
+			rows, err := lc.buildPluginRowsForHarness(registry, agentName)
+			if err != nil {
+				return err
+			}
+			if rows == nil {
+				rows = []localListRow{}
+			}
+			allResults[agentName] = rows
+		}
+		data, err := json.MarshalIndent(allResults, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal results: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	for _, agentName := range lc.agentNames {
+		rows, err := lc.buildPluginRowsForHarness(registry, agentName)
+		if err != nil {
+			return err
+		}
+		if err := lc.printLocalResults(rows, agentName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildPluginRowsForHarness resolves the install dir for agentName and builds a sorted, limited row slice.
+func (lc *ListCommand) buildPluginRowsForHarness(registry map[string]agentcommon.AgentSpec, agentName string) ([]localListRow, error) {
+	spec, err := agentcommon.ResolveAgent(registry, agentName, pluginscommon.RegistryHelp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	dir, err := agentcommon.ResolveAgentInstallDir(spec, lc.projectDir, lc.global)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.Info(fmt.Sprintf("No plugins directory found for agent %q (expected: %s)", lc.agentName, dir))
-			return nil
+			log.Info(fmt.Sprintf("No plugins directory found for agent %q (expected: %s)", agentName, dir))
+			return nil, nil
 		}
-		return fmt.Errorf("failed to read plugins directory %s: %w", dir, err)
+		return nil, fmt.Errorf("failed to read plugins directory %s: %w", dir, err)
 	}
 
 	projectDir := ""
@@ -198,59 +231,67 @@ func (lc *ListCommand) listLocalPlugins() error {
 		projectDir = lc.projectDir
 	}
 
-	var results []localListRow
+	var rows []localListRow
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		pluginDir := filepath.Join(dir, entry.Name())
-		meta, err := pluginscommon.ReadPluginMeta(pluginDir)
-		if err != nil {
-			log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", entry.Name(), err.Error()))
-			continue
+		row, ok := lc.buildRowForPlugin(filepath.Join(dir, entry.Name()), entry.Name(), projectDir)
+		if ok {
+			rows = append(rows, row)
 		}
-		manifest, err := agentcommon.ReadInstallInfoManifest(pluginDir, pluginscommon.PluginInfoManifestFile)
-		if err != nil {
-			log.Warn(fmt.Sprintf("Plugin '%s': invalid install manifest (%s); treating as missing", entry.Name(), err.Error()))
-			manifest = nil
-		}
-
-		repo := manifestRepoUnknownDisplay
-		if manifest != nil && strings.TrimSpace(manifest.Repo) != "" {
-			repo = manifest.Repo
-		}
-		installedVer := strings.TrimSpace(meta.Version)
-		if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
-			installedVer = strings.TrimSpace(manifest.InstalledVersion)
-		}
-
-		row := localListRow{
-			Name:        entry.Name(),
-			Version:     installedVer,
-			Description: meta.Description,
-			Repo:        repo,
-			Path:        pluginDisplayPath(pluginDir, projectDir, lc.global),
-		}
-		if lc.checkUpdates {
-			lc.fillUpdateStatus(&row)
-		}
-		results = append(results, row)
 	}
 
 	desc := strings.ToLower(lc.sortOrder) == sortOrderDesc
-	sort.Slice(results, func(i, j int) bool {
-		ni, nj := strings.ToLower(results[i].Name), strings.ToLower(results[j].Name)
+	sort.Slice(rows, func(i, j int) bool {
+		ni, nj := strings.ToLower(rows[i].Name), strings.ToLower(rows[j].Name)
 		if desc {
 			return ni > nj
 		}
 		return ni < nj
 	})
 
-	if lc.limit > 0 && len(results) > lc.limit {
-		results = results[:lc.limit]
+	if lc.limit > 0 && len(rows) > lc.limit {
+		rows = rows[:lc.limit]
+	}
+	return rows, nil
+}
+
+// buildRowForPlugin reads plugin.json and install manifest for a single plugin directory.
+// Returns (row, true) on success, (zero, false) if the plugin should be skipped.
+func (lc *ListCommand) buildRowForPlugin(pluginDir, name, projectDir string) (localListRow, bool) {
+	meta, err := pluginscommon.ReadPluginMeta(pluginDir)
+	if err != nil {
+		log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", name, err.Error()))
+		return localListRow{}, false
 	}
 
-	return lc.printLocalResults(results)
+	manifest, err := agentcommon.ReadInstallInfoManifest(pluginDir, pluginscommon.PluginInfoManifestFile)
+	if err != nil {
+		log.Warn(fmt.Sprintf("Plugin '%s': invalid install manifest (%s); treating as missing", name, err.Error()))
+		manifest = nil
+	}
+
+	repo := manifestRepoUnknownDisplay
+	if manifest != nil && strings.TrimSpace(manifest.Repo) != "" {
+		repo = manifest.Repo
+	}
+	installedVer := strings.TrimSpace(meta.Version)
+	if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+		installedVer = strings.TrimSpace(manifest.InstalledVersion)
+	}
+
+	row := localListRow{
+		Name:        name,
+		Version:     installedVer,
+		Description: meta.Description,
+		Repo:        repo,
+		Path:        pluginDisplayPath(pluginDir, projectDir, lc.global),
+	}
+	if lc.checkUpdates {
+		lc.fillUpdateStatus(&row)
+	}
+	return row, true
 }
 
 func pluginDisplayPath(pluginDirAbs, projectDir string, global bool) string {
@@ -298,94 +339,74 @@ func (lc *ListCommand) fillUpdateStatus(row *localListRow) {
 	}
 }
 
-func (lc *ListCommand) printRepoResults(results []repoListRow) error {
-	if results == nil {
-		results = []repoListRow{}
-	}
+func (lc *ListCommand) printRepoResults(rows []repoListRow) error {
 	if strings.EqualFold(lc.format, "json") {
-		data, err := json.MarshalIndent(results, "", "  ")
+		if rows == nil {
+			rows = []repoListRow{}
+		}
+		data, err := json.MarshalIndent(rows, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal results: %w", err)
 		}
 		fmt.Println(string(data))
 		return nil
 	}
-	if len(results) == 0 {
+	if len(rows) == 0 {
 		log.Info("No plugins found.")
 		return nil
 	}
-	return coreutils.PrintTable(results, "Plugins", "No plugins found", false)
+	return coreutils.PrintTable(rows, "Plugins", "No plugins found", false)
 }
 
-func (lc *ListCommand) printLocalResults(results []localListRow) error {
-	if results == nil {
-		results = []localListRow{}
-	}
+// printLocalResults prints one harness's plugin rows. When multiple harnesses are listed,
+// agentName is used as a section label above the table.
+func (lc *ListCommand) printLocalResults(rows []localListRow, agentName string) error {
 	if strings.EqualFold(lc.format, "json") {
-		data, err := json.MarshalIndent(results, "", "  ")
+		if rows == nil {
+			rows = []localListRow{}
+		}
+		data, err := json.MarshalIndent(rows, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal results: %w", err)
 		}
 		fmt.Println(string(data))
 		return nil
 	}
-	if len(results) == 0 {
+	if len(lc.agentNames) > 1 {
+		log.Output(fmt.Sprintf("\n%s", agentName))
+	}
+	if len(rows) == 0 {
 		log.Info("No plugins found.")
 		return nil
 	}
-	return coreutils.PrintTable(results, "Plugins", "No plugins found", false)
+	return coreutils.PrintTable(rows, "Plugins", "No plugins found", false)
 }
 
 // RunList is the CLI action for `jf agent plugins list`.
 func RunList(c *components.Context) error {
 	repoKey := c.GetStringFlagValue("repo")
-	agentName := strings.TrimSpace(c.GetStringFlagValue("harness"))
+	rawHarness := strings.TrimSpace(c.GetStringFlagValue("harness"))
 
 	format := "table"
-	if c.GetStringFlagValue("format") != "" {
-		format = c.GetStringFlagValue("format")
+	if v := c.GetStringFlagValue("format"); v != "" {
+		format = v
 	}
 
-	checkUpdates := c.GetBoolFlagValue("check-updates")
+	limit, err := parseLimitFlag(c)
+	if err != nil {
+		return err
+	}
+
+	sortBy, sortOrder, err := parseSortConfig(c, repoKey)
+	if err != nil {
+		return err
+	}
+
 	isGlobal := c.GetBoolFlagValue("global")
-
-	limit := 0
-	if limitStr := c.GetStringFlagValue("limit"); limitStr != "" {
-		var err error
-		limit, err = strconv.Atoi(limitStr)
-		if err != nil || limit <= 0 {
-			return fmt.Errorf("--limit must be a positive integer, got: %q", limitStr)
-		}
-	}
-
-	var sortBy, sortOrder string
-	if repoKey != "" {
-		sortBy = sortByUpdated
-		if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
-			if raw != sortByUpdated && raw != sortByDownloads {
-				return fmt.Errorf("--sort-by for --repo accepts 'updated' or 'downloads', got: %q", raw)
-			}
-			sortBy = raw
-		}
-	} else {
-		sortBy = sortByName
-		sortOrder = sortOrderAsc
-		if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
-			if raw != sortByName {
-				return fmt.Errorf("--sort-by for --harness only accepts 'name', got: %q", raw)
-			}
-			sortBy = raw
-		}
-		if raw := strings.ToLower(c.GetStringFlagValue("sort-order")); raw != "" {
-			if raw != sortOrderAsc && raw != sortOrderDesc {
-				return fmt.Errorf("--sort-order must be 'asc' or 'desc', got: %q", raw)
-			}
-			sortOrder = raw
-		}
-	}
+	checkUpdates := c.GetBoolFlagValue("check-updates")
 
 	projectDir := c.GetStringFlagValue("project-dir")
-	if !isGlobal && projectDir == "" && agentName != "" {
+	if !isGlobal && projectDir == "" && rawHarness != "" {
 		projectDir = "."
 	}
 	if projectDir != "" {
@@ -396,9 +417,17 @@ func RunList(c *components.Context) error {
 		projectDir = abs
 	}
 
+	var agentNames []string
+	if rawHarness != "" {
+		agentNames, err = pluginscommon.ParseHarnessList(rawHarness)
+		if err != nil {
+			return err
+		}
+	}
+
 	cmd := &ListCommand{}
 	cmd.SetRepoKey(repoKey).
-		SetAgentName(agentName).
+		SetAgentNames(agentNames).
 		SetProjectDir(projectDir).
 		SetGlobal(isGlobal).
 		SetFormat(format).
@@ -407,7 +436,7 @@ func RunList(c *components.Context) error {
 		SetSortOrder(sortOrder).
 		SetCheckUpdates(checkUpdates)
 
-	if repoKey != "" || (agentName != "" && checkUpdates) {
+	if repoKey != "" || (len(agentNames) > 0 && checkUpdates) {
 		serverDetails, err := agentcommon.GetServerDetails(c)
 		if err != nil {
 			return err
@@ -416,4 +445,45 @@ func RunList(c *components.Context) error {
 	}
 
 	return cmd.Run()
+}
+
+func parseLimitFlag(c *components.Context) (int, error) {
+	limitStr := c.GetStringFlagValue("limit")
+	if limitStr == "" {
+		return 0, nil
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		return 0, fmt.Errorf("--limit must be a positive integer, got: %q", limitStr)
+	}
+	return limit, nil
+}
+
+func parseSortConfig(c *components.Context, repoKey string) (sortBy, sortOrder string, err error) {
+	if repoKey != "" {
+		sortBy = sortByUpdated
+		if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
+			if raw != sortByUpdated && raw != sortByDownloads {
+				return "", "", fmt.Errorf("--sort-by for --repo accepts 'updated' or 'downloads', got: %q", raw)
+			}
+			sortBy = raw
+		}
+		return sortBy, "", nil
+	}
+
+	sortBy = sortByName
+	sortOrder = sortOrderAsc
+	if raw := strings.ToLower(c.GetStringFlagValue("sort-by")); raw != "" {
+		if raw != sortByName {
+			return "", "", fmt.Errorf("--sort-by for --harness only accepts 'name', got: %q", raw)
+		}
+		sortBy = raw
+	}
+	if raw := strings.ToLower(c.GetStringFlagValue("sort-order")); raw != "" {
+		if raw != sortOrderAsc && raw != sortOrderDesc {
+			return "", "", fmt.Errorf("--sort-order must be 'asc' or 'desc', got: %q", raw)
+		}
+		sortOrder = raw
+	}
+	return sortBy, sortOrder, nil
 }

--- a/agent/plugins/commands/list/list_test.go
+++ b/agent/plugins/commands/list/list_test.go
@@ -1,0 +1,35 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand_NoMode(t *testing.T) {
+	cmd := &ListCommand{}
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "jf agent plugins list requires")
+}
+
+func TestListCommand_BothModes(t *testing.T) {
+	cmd := &ListCommand{repoKey: "my-repo", agentName: "claude"}
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestListCommand_GlobalAndProjectDir(t *testing.T) {
+	cmd := &ListCommand{agentName: "claude", global: true, projectDir: "/some/path"}
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestListCommand_CheckUpdatesWithRepo(t *testing.T) {
+	cmd := &ListCommand{repoKey: "my-repo", checkUpdates: true}
+	err := cmd.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--check-updates")
+}

--- a/agent/plugins/commands/list/list_test.go
+++ b/agent/plugins/commands/list/list_test.go
@@ -14,14 +14,14 @@ func TestListCommand_NoMode(t *testing.T) {
 }
 
 func TestListCommand_BothModes(t *testing.T) {
-	cmd := &ListCommand{repoKey: "my-repo", agentName: "claude"}
+	cmd := &ListCommand{repoKey: "my-repo", agentNames: []string{"claude"}}
 	err := cmd.Run()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestListCommand_GlobalAndProjectDir(t *testing.T) {
-	cmd := &ListCommand{agentName: "claude", global: true, projectDir: "/some/path"}
+	cmd := &ListCommand{agentNames: []string{"claude"}, global: true, projectDir: "/some/path"}
 	err := cmd.Run()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -26,6 +26,18 @@ var RegistryHelp = agentcommon.AgentRegistryHelpExample{
 	ExampleGlobalDir:  "~/.my-agent/plugins",
 }
 
+// ParseHarnessForList parses --harness for list: exactly one name; commas are rejected.
+func ParseHarnessForList(raw string) (string, error) {
+	names, err := ParseHarnessList(raw)
+	if err != nil {
+		return "", err
+	}
+	if len(names) != 1 {
+		return "", fmt.Errorf("--harness for list accepts one harness name, not a comma-separated list: %q", raw)
+	}
+	return names[0], nil
+}
+
 // ParseHarnessList parses comma-separated harness names (trim, lowercase, reject empty/duplicates).
 func ParseHarnessList(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -26,18 +26,6 @@ var RegistryHelp = agentcommon.AgentRegistryHelpExample{
 	ExampleGlobalDir:  "~/.my-agent/plugins",
 }
 
-// ParseHarnessForList parses --harness for list: exactly one name; commas are rejected.
-func ParseHarnessForList(raw string) (string, error) {
-	names, err := ParseHarnessList(raw)
-	if err != nil {
-		return "", err
-	}
-	if len(names) != 1 {
-		return "", fmt.Errorf("--harness for list accepts one harness name, not a comma-separated list: %q", raw)
-	}
-	return names[0], nil
-}
-
 // ParseHarnessList parses comma-separated harness names (trim, lowercase, reject empty/duplicates).
 func ParseHarnessList(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {

--- a/agent/plugins/common/metadata.go
+++ b/agent/plugins/common/metadata.go
@@ -86,8 +86,9 @@ func mergePluginManifestPaths(fromConfig []string) []string {
 // ValidateAndResolvePluginMeta, Version is the final publish version and
 // ManifestVersion holds the on-disk consensus before --version.
 type PluginMeta struct {
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Name        string `json:"name"`
+	Version     string `json:"version,omitempty"`
+	Description string `json:"description,omitempty"`
 	// ManifestVersion is the consensus version from plugin.json files only (before --version).
 	ManifestVersion string `json:"-"`
 }

--- a/agent/plugins/common/plugins_api.go
+++ b/agent/plugins/common/plugins_api.go
@@ -1,0 +1,71 @@
+package common
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// PluginListItem is a single entry returned by ListPlugins.
+type PluginListItem struct {
+	Slug          string
+	LatestVersion string
+}
+
+// ListPlugins lists all plugin slugs in repoKey by reading the root folder's children,
+// resolves the latest version for each, sorts by name, and applies limit.
+func ListPlugins(serverDetails *config.ServerDetails, repoKey string, limit int, _ string) ([]PluginListItem, error) {
+	if serverDetails == nil {
+		return nil, fmt.Errorf("server details are required to list plugins")
+	}
+	if strings.TrimSpace(repoKey) == "" {
+		return nil, fmt.Errorf("repository is required to list plugins")
+	}
+
+	serviceManager, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := serviceManager.FolderInfo(repoKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list plugins in repository '%s': %w", repoKey, err)
+	}
+
+	items := make([]PluginListItem, 0, len(info.Children))
+	for _, child := range info.Children {
+		if !child.Folder {
+			continue
+		}
+		slug := strings.TrimPrefix(child.Uri, "/")
+		if slug == "" {
+			continue
+		}
+		latest, err := ResolveLatestPluginVersion(serverDetails, repoKey, slug)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Could not resolve latest version for plugin '%s': %s", slug, err.Error()))
+			latest = ""
+		}
+		items = append(items, PluginListItem{Slug: slug, LatestVersion: latest})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Slug) < strings.ToLower(items[j].Slug)
+	})
+
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+
+	return items, nil
+}
+
+// ReadPluginMeta reads the primary plugin.json under pluginDir and returns the parsed PluginMeta.
+func ReadPluginMeta(pluginDir string) (PluginMeta, error) {
+	_, meta, err := findPrimaryPluginManifest(pluginDir)
+	return meta, err
+}

--- a/agent/plugins/common/plugins_api.go
+++ b/agent/plugins/common/plugins_api.go
@@ -18,7 +18,7 @@ type PluginListItem struct {
 
 // ListPlugins lists all plugin slugs in repoKey by reading the root folder's children,
 // resolves the latest version for each, sorts by name, and applies limit.
-func ListPlugins(serverDetails *config.ServerDetails, repoKey string, limit int, _ string) ([]PluginListItem, error) {
+func ListPlugins(serverDetails *config.ServerDetails, repoKey string, limit int) ([]PluginListItem, error) {
 	if serverDetails == nil {
 		return nil, fmt.Errorf("server details are required to list plugins")
 	}
@@ -36,13 +36,13 @@ func ListPlugins(serverDetails *config.ServerDetails, repoKey string, limit int,
 		return nil, fmt.Errorf("failed to list plugins in repository '%s': %w", repoKey, err)
 	}
 
-	items := make([]PluginListItem, 0, len(info.Children))
+	pluginEntries := make([]PluginListItem, 0, len(info.Children))
 	for _, child := range info.Children {
 		if !child.Folder {
 			continue
 		}
 		slug := strings.TrimPrefix(child.Uri, "/")
-		if slug == "" {
+		if slug == "" || strings.HasPrefix(slug, ".") {
 			continue
 		}
 		latest, err := ResolveLatestPluginVersion(serverDetails, repoKey, slug)
@@ -50,18 +50,18 @@ func ListPlugins(serverDetails *config.ServerDetails, repoKey string, limit int,
 			log.Warn(fmt.Sprintf("Could not resolve latest version for plugin '%s': %s", slug, err.Error()))
 			latest = ""
 		}
-		items = append(items, PluginListItem{Slug: slug, LatestVersion: latest})
+		pluginEntries = append(pluginEntries, PluginListItem{Slug: slug, LatestVersion: latest})
 	}
 
-	sort.Slice(items, func(i, j int) bool {
-		return strings.ToLower(items[i].Slug) < strings.ToLower(items[j].Slug)
+	sort.Slice(pluginEntries, func(i, j int) bool {
+		return strings.ToLower(pluginEntries[i].Slug) < strings.ToLower(pluginEntries[j].Slug)
 	})
 
-	if limit > 0 && len(items) > limit {
-		items = items[:limit]
+	if limit > 0 && len(pluginEntries) > limit {
+		pluginEntries = pluginEntries[:limit]
 	}
 
-	return items, nil
+	return pluginEntries, nil
 }
 
 // ReadPluginMeta reads the primary plugin.json under pluginDir and returns the parsed PluginMeta.

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -515,6 +515,7 @@ const (
 	AgentPluginsPublish = "agent-plugins-publish"
 	AgentPluginsInstall = "agent-plugins-install"
 	AgentPluginsDelete  = "agent-plugins-delete"
+	AgentPluginsList    = "agent-plugins-list"
 
 	// Agent namespace-specific flags (shared by skills and agent-plugins commands)
 	version    = "version"
@@ -890,6 +891,9 @@ var commandFlags = map[string][]string{
 	},
 	AgentPluginsDelete: {
 		url, user, password, accessToken, serverId, repo, version, dryRun,
+	},
+	AgentPluginsList: {
+		url, user, password, accessToken, serverId, repo, harness, projectDir, agentGlobal, agentFormat, agentLimit, agentSortBy, agentSortOrder, agentCheckUpdates,
 	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
## Summary

- Add `jf agent plugins list` with full parity to `jf agent skills list` — both `--repo` (Artifactory registry) and `--harness` (locally installed) modes, including `--check-updates`, `--format`, `--limit`, `--sort-by`, `--sort-order` flags

## Usage

```bash
# List plugins in Artifactory registry
jf agent plugins list --repo agents-local1

# List locally installed plugins
jf agent plugins list --harness claude
jf agent plugins list --harness claude --check-updates --server-id bukaiplugins3
```
