### PR TITLE
RTECO-1268 - Implement plugins update command

### DIFF
--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -19,7 +19,7 @@ func TestGetCommands_HasPluginsAndSkillsNamespaces(t *testing.T) {
 		assert.NotNil(t, sub.Action, "plugins subcommand %q must have an Action", sub.Name)
 		pluginsNames = append(pluginsNames, sub.Name)
 	}
-	assert.ElementsMatch(t, []string{"publish", "install"}, pluginsNames)
+	assert.ElementsMatch(t, []string{"publish", "install", "update"}, pluginsNames)
 
 	skills := commands[1]
 	assert.Equal(t, "skills", skills.Name)

--- a/agent/common/discover.go
+++ b/agent/common/discover.go
@@ -12,25 +12,45 @@ import (
 // install directories contain a .jfrog/<manifestFileName>. A missing installDir
 // returns an empty slice with no error so callers can treat "no harness install root yet"
 // as "nothing installed".
+//
+// Discovery checks each immediate child directory of installDir for a regular file at
+// <installDir>/<slug>/.jfrog/<manifestFileName> (see installInfoManifestPath).
+//
+// Example (manifestFileName = "plugin-info.json", installDir = ".claude/plugins"):
+//
+//	.claude/plugins/
+//	  web-search/                    -> discovered (slug "web-search")
+//	    .jfrog/plugin-info.json
+//	  legacy/                        -> skipped (no .jfrog/plugin-info.json)
+//	    plugin.json
+//
+// Returns []string{"web-search"}.
 func DiscoverInstalledSlugs(installDir, manifestFileName string) ([]string, error) {
-	entries, err := os.ReadDir(installDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read install dir %s: %w", installDir, err)
+	// ReadDir may return a non-nil error together with entries read before the failure; scan those too.
+	entries, readErr := os.ReadDir(installDir)
+	if readErr != nil && errors.Is(readErr, os.ErrNotExist) {
+		return nil, nil
 	}
+	slugs := slugsFromInstallDirEntries(installDir, manifestFileName, entries)
+	if readErr != nil {
+		return slugs, fmt.Errorf("read install dir %s: %w", installDir, readErr)
+	}
+	return slugs, nil
+}
+
+func slugsFromInstallDirEntries(installDir, manifestFileName string, entries []os.DirEntry) []string {
 	slugs := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
-			manifestPath := filepath.Join(installDir, entry.Name(), jfrogInstallDirName, manifestFileName)
-		    info, err := os.Stat(manifestPath)
-		    if err != nil || info.IsDir() {
-			    continue
-		    }
-		    slugs = append(slugs, entry.Name())
+		if !entry.IsDir() {
+			continue
 		}
+		manifestPath := filepath.Join(installDir, entry.Name(), jfrogInstallDirName, manifestFileName)
+		info, err := os.Stat(manifestPath)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		slugs = append(slugs, entry.Name())
 	}
 	sort.Strings(slugs)
-	return slugs, nil
+	return slugs
 }

--- a/agent/common/discover.go
+++ b/agent/common/discover.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// DiscoverInstalledSlugs returns the sorted slugs installed under installDir whose
+// install directories contain a .jfrog/<manifestFileName>. A missing installDir
+// returns an empty slice with no error so callers can treat "no harness install root yet"
+// as "nothing installed".
+func DiscoverInstalledSlugs(installDir, manifestFileName string) ([]string, error) {
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read install dir %s: %w", installDir, err)
+	}
+	slugs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(installDir, entry.Name(), jfrogInstallDirName, manifestFileName)
+		info, err := os.Stat(manifestPath)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		slugs = append(slugs, entry.Name())
+	}
+	sort.Strings(slugs)
+	return slugs, nil
+}

--- a/agent/common/discover.go
+++ b/agent/common/discover.go
@@ -22,15 +22,14 @@ func DiscoverInstalledSlugs(installDir, manifestFileName string) ([]string, erro
 	}
 	slugs := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+		if entry.IsDir() {
+			manifestPath := filepath.Join(installDir, entry.Name(), jfrogInstallDirName, manifestFileName)
+		    info, err := os.Stat(manifestPath)
+		    if err != nil || info.IsDir() {
+			    continue
+		    }
+		    slugs = append(slugs, entry.Name())
 		}
-		manifestPath := filepath.Join(installDir, entry.Name(), jfrogInstallDirName, manifestFileName)
-		info, err := os.Stat(manifestPath)
-		if err != nil || info.IsDir() {
-			continue
-		}
-		slugs = append(slugs, entry.Name())
 	}
 	sort.Strings(slugs)
 	return slugs, nil

--- a/agent/common/discover_test.go
+++ b/agent/common/discover_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverInstalledSlugs_MissingDir(t *testing.T) {
+	got, err := DiscoverInstalledSlugs(filepath.Join(t.TempDir(), "nope"), "plugin-info.json")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDiscoverInstalledSlugs_FiltersToInstalled(t *testing.T) {
+	base := t.TempDir()
+
+	installed := filepath.Join(base, "alpha", jfrogInstallDirName)
+	require.NoError(t, os.MkdirAll(installed, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(installed, "plugin-info.json"), []byte(`{}`), 0o644))
+
+	uninstalled := filepath.Join(base, "beta")
+	require.NoError(t, os.MkdirAll(uninstalled, 0o755))
+
+	wrongManifest := filepath.Join(base, "gamma", jfrogInstallDirName)
+	require.NoError(t, os.MkdirAll(wrongManifest, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wrongManifest, "skill-info.json"), []byte(`{}`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(base, "loose-file"), []byte("not a dir"), 0o644))
+
+	got, err := DiscoverInstalledSlugs(base, "plugin-info.json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha"}, got)
+}
+
+func TestDiscoverInstalledSlugs_SortsOutput(t *testing.T) {
+	base := t.TempDir()
+	for _, slug := range []string{"zeta", "alpha", "mu"} {
+		dir := filepath.Join(base, slug, jfrogInstallDirName)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin-info.json"), []byte(`{}`), 0o644))
+	}
+	got, err := DiscoverInstalledSlugs(base, "plugin-info.json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "mu", "zeta"}, got)
+}

--- a/agent/common/install_summary.go
+++ b/agent/common/install_summary.go
@@ -44,7 +44,7 @@ func InstallFailureRow(agentName, scope, destinationDir string, err error) Summa
 }
 
 // UpdateAllSummaryRow is one row in a combined install/update summary for update --all.
-// Table columns (struct field order): Agent, Name, Scope, Path, Status, Detail.
+// Table columns (struct field order): Agent, Name, Scope, Path, Status, Detail, Version.
 type UpdateAllSummaryRow struct {
 	Agent   string `json:"agent" col-name:"Agent"`
 	Name    string `json:"name" col-name:"Name"`
@@ -52,7 +52,7 @@ type UpdateAllSummaryRow struct {
 	Path    string `json:"path" col-name:"Path"`
 	Status  string `json:"status" col-name:"Status"`
 	Detail  string `json:"detail" col-name:"Detail"`
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" col-name:"Version"`
 }
 
 // AppendUpdateAllSummaryRows copies per-target summary rows into a combined --all summary.

--- a/agent/common/install_summary.go
+++ b/agent/common/install_summary.go
@@ -43,6 +43,60 @@ func InstallFailureRow(agentName, scope, destinationDir string, err error) Summa
 	}
 }
 
+// UpdateAllSummaryRow is one row in a combined install/update summary for update --all.
+// Table columns (struct field order): Agent, Name, Scope, Path, Status, Detail.
+type UpdateAllSummaryRow struct {
+	Agent   string `json:"agent" col-name:"Agent"`
+	Name    string `json:"name" col-name:"Name"`
+	Scope   string `json:"scope" col-name:"Scope"`
+	Path    string `json:"path" col-name:"Path"`
+	Status  string `json:"status" col-name:"Status"`
+	Detail  string `json:"detail" col-name:"Detail"`
+	Version string `json:"version,omitempty"`
+}
+
+// AppendUpdateAllSummaryRows copies per-target summary rows into a combined --all summary.
+func AppendUpdateAllSummaryRows(dest []UpdateAllSummaryRow, name, version string, rows []SummaryRow) []UpdateAllSummaryRow {
+	for _, row := range rows {
+		dest = append(dest, UpdateAllSummaryRow{
+			Agent:   row.Agent,
+			Name:    name,
+			Scope:   row.Scope,
+			Path:    row.Path,
+			Status:  row.Status,
+			Detail:  row.Detail,
+			Version: version,
+		})
+	}
+	return dest
+}
+
+type updateAllSummaryJSON struct {
+	Results []UpdateAllSummaryRow `json:"results"`
+}
+
+// PrintUpdateAllSummary renders one table or JSON blob for update --all across many packages.
+func PrintUpdateAllSummary(entityLabel string, results []UpdateAllSummaryRow, format string) error {
+	if len(results) == 0 {
+		return nil
+	}
+	if strings.EqualFold(format, "json") {
+		payload := updateAllSummaryJSON{Results: results}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal update-all summary: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	log.Info(entityLabel + " update summary (--all):")
+	emptyMsg := "No " + strings.ToLower(entityLabel) + "s updated"
+	if err := coreutils.PrintTable(results, "Updated", emptyMsg, false); err != nil {
+		log.Warn("Failed to render update-all summary: " + err.Error())
+	}
+	return nil
+}
+
 // PrintInstallSummary renders a table or JSON summary of an install/update run.
 // entityLabel is used in the table heading (e.g. "Skill" or "Plugin").
 func PrintInstallSummary(entityLabel, slug, version string, results []SummaryRow, format string) error {

--- a/agent/common/install_summary_test.go
+++ b/agent/common/install_summary_test.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendUpdateAllSummaryRows(t *testing.T) {
+	rows := []SummaryRow{
+		{Agent: "cursor", Scope: "project", Path: "/a/foo", Status: SummaryStatusOK, Detail: SummaryDetailOKInstall},
+		{Agent: "cursor", Scope: "project", Path: "/a/bar", Status: SummaryStatusSkipped, Detail: "already at version"},
+	}
+	combined := AppendUpdateAllSummaryRows(nil, "foo", "1.0.0", rows)
+	require.Len(t, combined, 2)
+	assert.Equal(t, "cursor", combined[0].Agent)
+	assert.Equal(t, "foo", combined[0].Name)
+	assert.Equal(t, "project", combined[0].Scope)
+	assert.Equal(t, "/a/foo", combined[0].Path)
+	assert.Equal(t, "1.0.0", combined[0].Version)
+	assert.Equal(t, "foo", combined[1].Name)
+	assert.Equal(t, "/a/bar", combined[1].Path)
+}
+
+func TestPrintUpdateAllSummary_Empty(t *testing.T) {
+	require.NoError(t, PrintUpdateAllSummary("Plugin", nil, "table"))
+}

--- a/agent/common/install_summary_test.go
+++ b/agent/common/install_summary_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,102 @@ func TestAppendUpdateAllSummaryRows(t *testing.T) {
 	assert.Equal(t, "/a/bar", combined[1].Path)
 }
 
+func TestAppendUpdateAllSummaryRows_PreservesFailedRows(t *testing.T) {
+	rows := []SummaryRow{
+		{
+			Agent:  "claude",
+			Scope:  "global",
+			Path:   "/home/.claude/plugins/web",
+			Status: SummaryStatusFailed,
+			Detail: "download failed: connection reset",
+		},
+		{
+			Agent:  "cursor",
+			Scope:  "project",
+			Path:   "/proj/.cursor/plugins/web",
+			Status: SummaryStatusFailed,
+			Detail: "plugin not installed at /proj/.cursor/plugins/web; run 'jf agent plugins install' first",
+		},
+	}
+	combined := AppendUpdateAllSummaryRows(nil, "web", "2.0.0", rows)
+	require.Len(t, combined, 2)
+
+	assert.Equal(t, "web", combined[0].Name)
+	assert.Equal(t, "2.0.0", combined[0].Version)
+	assert.Equal(t, SummaryStatusFailed, combined[0].Status)
+	assert.Equal(t, "download failed: connection reset", combined[0].Detail)
+
+	assert.Equal(t, "web", combined[1].Name)
+	assert.Equal(t, SummaryStatusFailed, combined[1].Status)
+	assert.Contains(t, combined[1].Detail, "not installed")
+}
+
+func TestAppendUpdateAllSummaryRows_EmptyInput(t *testing.T) {
+	combined := AppendUpdateAllSummaryRows(nil, "foo", "1.0.0", nil)
+	assert.Empty(t, combined)
+
+	combined = AppendUpdateAllSummaryRows(combined, "foo", "1.0.0", []SummaryRow{})
+	assert.Empty(t, combined)
+}
+
+func TestAppendUpdateAllSummaryRows_AppendsToExistingDest(t *testing.T) {
+	existing := []UpdateAllSummaryRow{
+		{Agent: "cursor", Name: "alpha", Scope: "project", Path: "/a/alpha", Status: SummaryStatusOK, Version: "1.0.0"},
+	}
+	rows := []SummaryRow{
+		{Agent: "claude", Scope: "global", Path: "/g/beta", Status: SummaryStatusSkipped, Detail: "already at version"},
+	}
+	combined := AppendUpdateAllSummaryRows(existing, "beta", "2.0.0", rows)
+	require.Len(t, combined, 2)
+	assert.Equal(t, "alpha", combined[0].Name)
+	assert.Equal(t, "beta", combined[1].Name)
+	assert.Equal(t, "2.0.0", combined[1].Version)
+	assert.Equal(t, SummaryStatusSkipped, combined[1].Status)
+}
+
+func TestAppendUpdateAllSummaryRows_MultipleSlugs(t *testing.T) {
+	var combined []UpdateAllSummaryRow
+	combined = AppendUpdateAllSummaryRows(combined, "foo", "1.0.0", []SummaryRow{
+		{Agent: "cursor", Scope: "project", Path: "/a/foo", Status: SummaryStatusOK, Detail: SummaryDetailOKInstall},
+	})
+	combined = AppendUpdateAllSummaryRows(combined, "bar", "3.0.0", []SummaryRow{
+		{Agent: "cursor", Scope: "project", Path: "/a/bar", Status: SummaryStatusFailed, Detail: "could not move current plugin aside"},
+	})
+	require.Len(t, combined, 2)
+	assert.Equal(t, "foo", combined[0].Name)
+	assert.Equal(t, "1.0.0", combined[0].Version)
+	assert.Equal(t, SummaryStatusOK, combined[0].Status)
+	assert.Equal(t, "bar", combined[1].Name)
+	assert.Equal(t, "3.0.0", combined[1].Version)
+	assert.Equal(t, SummaryStatusFailed, combined[1].Status)
+}
+
 func TestPrintUpdateAllSummary_Empty(t *testing.T) {
 	require.NoError(t, PrintUpdateAllSummary("Plugin", nil, "table"))
+}
+
+func TestPrintUpdateAllSummary_MixedStatuses_NoError(t *testing.T) {
+	results := AppendUpdateAllSummaryRows(nil, "web", "2.0.0", []SummaryRow{
+		{Agent: "cursor", Scope: "project", Path: "/p/web", Status: SummaryStatusOK, Detail: SummaryDetailOKInstall},
+		{Agent: "claude", Scope: "global", Path: "/g/web", Status: SummaryStatusFailed, Detail: "download failed"},
+	})
+	require.NoError(t, PrintUpdateAllSummary("Plugin", results, "table"))
+	require.NoError(t, PrintUpdateAllSummary("Plugin", results, "json"))
+}
+
+func TestPrintUpdateAllSummary_JSONRoundTrip_MixedStatuses(t *testing.T) {
+	results := AppendUpdateAllSummaryRows(nil, "slug-a", "1.2.3", []SummaryRow{
+		{Agent: "a1", Scope: "project", Path: "/p/a", Status: SummaryStatusOK, Detail: SummaryDetailOKInstall},
+		{Agent: "a2", Scope: "project", Path: "/p/b", Status: SummaryStatusSkipped, Detail: "version already 1.2.3"},
+		{Agent: "a3", Scope: "project", Path: "/p/c", Status: SummaryStatusFailed, Detail: "evidence verification failed"},
+	})
+	data, err := json.MarshalIndent(updateAllSummaryJSON{Results: results}, "", "  ")
+	require.NoError(t, err)
+
+	var payload updateAllSummaryJSON
+	require.NoError(t, json.Unmarshal(data, &payload))
+	require.Len(t, payload.Results, 3)
+	assert.Equal(t, "slug-a", payload.Results[0].Name)
+	assert.Equal(t, SummaryStatusFailed, payload.Results[2].Status)
+	assert.Contains(t, payload.Results[2].Detail, "evidence")
 }

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -34,7 +34,8 @@ func GetSubCommands() []components.Command {
 			Flags: flagkit.GetCommandFlags(flagkit.AgentPluginsUpdate),
 			Description: "Update an installed plugin to the latest (or a specific) version. " +
 				"Use --harness (comma-separated) with --project-dir or --global; or --path <dir>. " +
-				"With --all (requires --harness), updates every installed plugin under those harnesses to latest in one summary table. " +
+				"With --all (requires --harness), updates every installed plugin under those harnesses to latest in one summary table; " +
+				"discovery includes installs with plugin-info.json or plugin.json (same as single-slug update). " +
 				"Resolves versions directly from Artifactory (no marketplace lookup). " +
 				"Skips targets not installed or already at the target version (use --force to re-download).",
 			Arguments: getUpdateArguments(),

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/publish"
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/update"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 )
@@ -28,6 +29,17 @@ func GetSubCommands() []components.Command {
 			Arguments: getInstallArguments(),
 			Action:    install.RunInstall,
 		},
+		{
+			Name:  "update",
+			Flags: flagkit.GetCommandFlags(flagkit.AgentPluginsUpdate),
+			Description: "Update an installed plugin to the latest (or a specific) version. " +
+				"Use --harness (comma-separated) with --project-dir or --global; or --path <dir>. " +
+				"With --all (requires --harness), updates every installed plugin under those harnesses to latest in one summary table. " +
+				"Resolves versions directly from Artifactory (no marketplace lookup). " +
+				"Skips targets not installed or already at the target version (use --force to re-download).",
+			Arguments: getUpdateArguments(),
+			Action:    update.RunUpdate,
+		},
 	}
 }
 
@@ -45,6 +57,15 @@ func getInstallArguments() []components.Argument {
 		{
 			Name:        "slug",
 			Description: "Slug (name) of the plugin to install.",
+		},
+	}
+}
+
+func getUpdateArguments() []components.Argument {
+	return []components.Argument{
+		{
+			Name:        "slug",
+			Description: "Slug (name) of the plugin to update. Omit when using --all.",
 		},
 	}
 }

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -33,13 +33,12 @@ func GetSubCommands() []components.Command {
 			Name:  "update",
 			Flags: flagkit.GetCommandFlags(flagkit.AgentPluginsUpdate),
 			Description: "Update an installed plugin to the latest (or a specific) version. " +
-				"Use --harness (comma-separated) with --project-dir or --global; or --path <dir>. " +
-				"With --all (requires --harness), updates every installed plugin under those harnesses to latest in one summary table; " +
-				"discovery includes installs with plugin-info.json or plugin.json (same as single-slug update). " +
+				"Use --slug with --harness (comma-separated) and --project-dir or --global; or --slug with --path <dir>. " +
+				"With --all (requires --harness), updates every discovered plugin under those harnesses to latest in one summary table " +
+				"(interactive confirmation before proceeding; folder name is the slug, same as --slug). " +
 				"Resolves versions directly from Artifactory (no marketplace lookup). " +
 				"Skips targets not installed or already at the target version (use --force to re-download).",
-			Arguments: getUpdateArguments(),
-			Action:    update.RunUpdate,
+			Action: update.RunUpdate,
 		},
 	}
 }
@@ -58,15 +57,6 @@ func getInstallArguments() []components.Argument {
 		{
 			Name:        "slug",
 			Description: "Slug (name) of the plugin to install.",
-		},
-	}
-}
-
-func getUpdateArguments() []components.Argument {
-	return []components.Argument{
-		{
-			Name:        "slug",
-			Description: "Slug (name) of the plugin to update. Omit when using --all.",
 		},
 	}
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -30,8 +30,8 @@ func TestGetSubCommands_HasPublishInstallAndUpdate(t *testing.T) {
 	updateCmd := commands[2]
 	assert.Equal(t, "update", updateCmd.Name)
 	assert.NotNil(t, updateCmd.Action)
-	require.Len(t, updateCmd.Arguments, 1)
-	assert.Equal(t, "slug", updateCmd.Arguments[0].Name)
+	assert.Empty(t, updateCmd.Arguments)
 	assert.Contains(t, updateCmd.Description, "Update an installed plugin")
+	assert.Contains(t, updateCmd.Description, "--slug")
 	assert.Contains(t, updateCmd.Description, "--all")
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetSubCommands_HasPublishAndInstall(t *testing.T) {
+func TestGetSubCommands_HasPublishInstallAndUpdate(t *testing.T) {
 	commands := GetSubCommands()
-	require.Len(t, commands, 2)
+	require.Len(t, commands, 3)
 
 	publish := commands[0]
 	assert.Equal(t, "publish", publish.Name)
@@ -26,4 +26,12 @@ func TestGetSubCommands_HasPublishAndInstall(t *testing.T) {
 	assert.Equal(t, "slug", installCmd.Arguments[0].Name)
 	assert.Contains(t, installCmd.Description, "Install an agent plugin from Artifactory")
 	assert.Contains(t, installCmd.Description, "marketplace")
+
+	updateCmd := commands[2]
+	assert.Equal(t, "update", updateCmd.Name)
+	assert.NotNil(t, updateCmd.Action)
+	require.Len(t, updateCmd.Arguments, 1)
+	assert.Equal(t, "slug", updateCmd.Arguments[0].Name)
+	assert.Contains(t, updateCmd.Description, "Update an installed plugin")
+	assert.Contains(t, updateCmd.Description, "--all")
 }

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -139,12 +139,12 @@ func (ic *InstallCommand) Run() error {
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	unzipDir, err := ic.fetchAndExtractTo(tmpDir)
+	unzipDir, err := ic.FetchAndExtractTo(tmpDir)
 	if err != nil {
 		return err
 	}
 
-	results := ic.copyExtractedToTargets(unzipDir, installTargets)
+	results := ic.CopyExtractedToTargets(unzipDir, installTargets)
 
 	if err := agentcommon.PrintInstallSummary("Plugin", ic.slug, ic.version, results, ic.format); err != nil {
 		return err
@@ -203,7 +203,9 @@ func (ic *InstallCommand) resolveVersionFromMarketplaces() (string, error) {
 	return resolved, nil
 }
 
-func (ic *InstallCommand) fetchAndExtractTo(tmpDir string) (string, error) {
+// FetchAndExtractTo downloads the plugin zip into tmpDir, extracts it, and runs evidence checks.
+// The returned unzipDir is under tmpDir; callers must keep tmpDir until copies finish.
+func (ic *InstallCommand) FetchAndExtractTo(tmpDir string) (string, error) {
 	zipPath, err := ic.downloadZip(tmpDir)
 	if err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
@@ -218,7 +220,9 @@ func (ic *InstallCommand) fetchAndExtractTo(tmpDir string) (string, error) {
 	return unzipDir, nil
 }
 
-func (ic *InstallCommand) copyExtractedToTargets(unzipDir string, installTargets []plugincommon.AgentTarget) []agentcommon.SummaryRow {
+// CopyExtractedToTargets copies an unpacked plugin tree to the given resolved targets and
+// writes a plugin-info manifest per target.
+func (ic *InstallCommand) CopyExtractedToTargets(unzipDir string, installTargets []plugincommon.AgentTarget) []agentcommon.SummaryRow {
 	results := make([]agentcommon.SummaryRow, 0, len(installTargets))
 	for _, target := range installTargets {
 		if err := agentcommon.EnsureDestinationDir(target.DestinationDir); err != nil {

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -97,7 +97,7 @@ func TestCopyExtractedToTargets_WritesPluginInfoManifest(t *testing.T) {
 		DestinationDir: dest,
 		Scope:          plugincommon.ScopeProject,
 	}
-	rows := ic.copyExtractedToTargets(src, []plugincommon.AgentTarget{target})
+	rows := ic.CopyExtractedToTargets(src, []plugincommon.AgentTarget{target})
 	require.Len(t, rows, 1)
 	assert.Equal(t, agentcommon.SummaryStatusOK, rows[0].Status)
 

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -420,12 +420,7 @@ func restorePluginFromBackup(agentTarget plugincommon.AgentTarget, backupPath st
 }
 
 // applyPluginUpdateCopy copies the extracted tree onto the target and restores the backup on failure.
-func applyPluginUpdateCopy(
-	unzipDir string,
-	installCommand *install.InstallCommand,
-	agentTarget plugincommon.AgentTarget,
-	backupPath string,
-) agentcommon.SummaryRow {
+func applyPluginUpdateCopy(unzipDir string, installCommand *install.InstallCommand, agentTarget plugincommon.AgentTarget, backupPath string) agentcommon.SummaryRow {
 	rows := installCommand.CopyExtractedToTargets(unzipDir, []plugincommon.AgentTarget{agentTarget})
 	if len(rows) != 1 {
 		if restoreErr := restorePluginFromBackup(agentTarget, backupPath); restoreErr != nil {

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -130,24 +130,48 @@ func runUpdateOne(opts updateOptions, slug, requestedVersion string) error {
 	return finalError(results)
 }
 
+// updateAllOutcome tracks aggregate success/failure for a --all run.
+type updateAllOutcome struct {
+	anyOK            bool
+	anyFailed        bool
+	firstResolveErr  error
+	updatedSlugCount int
+}
+
 // runUpdateAll enumerates every installed plugin under each --harness and updates each to its latest version.
 func runUpdateAll(opts updateOptions) error {
-	// slugToTargets groups all install targets by slug so we update each plugin once
-	// with one summary block, regardless of how many harnesses it is installed under.
-	slugToTargets := map[string][]plugincommon.AgentTarget{}
+	slugOrder, slugToTargets, err := discoverInstalledPluginTargets(opts.flags)
+	if err != nil {
+		return err
+	}
+	if len(slugOrder) == 0 {
+		log.Info("No installed plugins found for the given --harness list; nothing to update.")
+		return nil
+	}
+
+	combined, outcome, err := applyUpdateAllForSlugs(opts, slugOrder, slugToTargets)
+	if err != nil {
+		return err
+	}
+	return finalizeUpdateAll(combined, outcome, opts.format)
+}
+
+// discoverInstalledPluginTargets maps each installed slug to its harness install targets.
+func discoverInstalledPluginTargets(flags agentcommon.InstallFlagsResult) ([]string, map[string][]plugincommon.AgentTarget, error) {
+	slugToTargets := make(map[string][]plugincommon.AgentTarget)
 	slugOrder := make([]string, 0)
-	for _, spec := range opts.flags.Specs {
-		installDir, err := agentcommon.ResolveAgentInstallDir(spec, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
+	scope := plugincommon.ScopeProject
+	if flags.IsGlobal {
+		scope = plugincommon.ScopeGlobal
+	}
+	for _, spec := range flags.Specs {
+		installDir, err := agentcommon.ResolveAgentInstallDir(spec, flags.ProjectDirAbs, flags.IsGlobal)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		slugs, err := agentcommon.DiscoverInstalledSlugs(installDir, plugincommon.PluginInfoManifestFile)
 		if err != nil {
-			return err
-		}
-		scope := plugincommon.ScopeProject
-		if opts.flags.IsGlobal {
-			scope = plugincommon.ScopeGlobal
+			return nil, nil, err
 		}
 		for _, slug := range slugs {
 			if _, seen := slugToTargets[slug]; !seen {
@@ -160,50 +184,60 @@ func runUpdateAll(opts updateOptions) error {
 			})
 		}
 	}
+	return slugOrder, slugToTargets, nil
+}
 
-	if len(slugOrder) == 0 {
-		log.Info("No installed plugins found for the given --harness list; nothing to update.")
-		return nil
-	}
-
+// applyUpdateAllForSlugs resolves latest version per slug, updates targets, and builds combined summary rows.
+func applyUpdateAllForSlugs(
+	opts updateOptions,
+	slugOrder []string,
+	slugToTargets map[string][]plugincommon.AgentTarget,
+) ([]agentcommon.UpdateAllSummaryRow, updateAllOutcome, error) {
 	combined := make([]agentcommon.UpdateAllSummaryRow, 0)
-	var anyOK, anyFailed bool
-	var firstResolveErr error
-	var updatedSlugCount int
-
+	var outcome updateAllOutcome
 	for _, slug := range slugOrder {
 		targetVersion, err := resolveLatestPluginVersion(opts.serverDetails, opts.repoKey, slug)
 		if err != nil {
-			if firstResolveErr == nil {
-				firstResolveErr = err
+			if outcome.firstResolveErr == nil {
+				outcome.firstResolveErr = err
 			}
 			log.Warn(fmt.Sprintf("Skipping plugin '%s': could not resolve latest version: %s", slug, err.Error()))
 			continue
 		}
 		results, err := updateSlugAcrossTargets(opts, slug, targetVersion, slugToTargets[slug])
 		if err != nil {
-			return err
+			return nil, updateAllOutcome{}, err
 		}
 		combined = agentcommon.AppendUpdateAllSummaryRows(combined, slug, targetVersion, results)
-		updatedSlugCount++
-		for _, row := range results {
-			switch row.Status {
-			case agentcommon.SummaryStatusOK:
-				anyOK = true
-			case agentcommon.SummaryStatusFailed:
-				anyFailed = true
-			}
+		outcome.updatedSlugCount++
+		ok, failed := tallySummaryRows(results)
+		outcome.anyOK = outcome.anyOK || ok
+		outcome.anyFailed = outcome.anyFailed || failed
+	}
+	return combined, outcome, nil
+}
+
+func tallySummaryRows(results []agentcommon.SummaryRow) (anyOK, anyFailed bool) {
+	for _, row := range results {
+		switch row.Status {
+		case agentcommon.SummaryStatusOK:
+			anyOK = true
+		case agentcommon.SummaryStatusFailed:
+			anyFailed = true
 		}
 	}
+	return anyOK, anyFailed
+}
 
-	if err := agentcommon.PrintUpdateAllSummary("Plugin", combined, opts.format); err != nil {
+func finalizeUpdateAll(combined []agentcommon.UpdateAllSummaryRow, outcome updateAllOutcome, format string) error {
+	if err := agentcommon.PrintUpdateAllSummary("Plugin", combined, format); err != nil {
 		return err
 	}
-	if !anyOK && anyFailed {
+	if !outcome.anyOK && outcome.anyFailed {
 		return fmt.Errorf("update failed for all targets (see summary above)")
 	}
-	if !anyOK && updatedSlugCount == 0 && firstResolveErr != nil {
-		return firstResolveErr
+	if !outcome.anyOK && outcome.updatedSlugCount == 0 && outcome.firstResolveErr != nil {
+		return outcome.firstResolveErr
 	}
 	return nil
 }
@@ -332,46 +366,73 @@ func logDryRun(slug, targetVersion string, checks []preUpdate) {
 	}
 }
 
-// updateOnePlugin updates a single install target using the already-fetched tree in unzipDir:
-// it renames the live install aside, copies from unzipDir, restores the backup on failure, then removes the backup on success.
+// updateOnePlugin updates a single install target using the already-fetched tree in unzipDir.
 func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, check preUpdate) agentcommon.SummaryRow {
 	agentTarget := check.agentTarget
+	backupPath, errRow, ok := movePluginAsideForUpdate(agentTarget)
+	if !ok {
+		return errRow
+	}
+	row := applyPluginUpdateCopy(unzipDir, installCommand, agentTarget, backupPath)
+	if row.Status != agentcommon.SummaryStatusOK {
+		return row
+	}
+	removePluginUpdateBackup(backupPath, filepath.Dir(agentTarget.DestinationDir))
+	return summaryRowFor(agentTarget, agentcommon.SummaryStatusOK, agentcommon.SummaryDetailOKInstall)
+}
+
+// movePluginAsideForUpdate reserves a backup path and renames the live install directory aside.
+func movePluginAsideForUpdate(agentTarget plugincommon.AgentTarget) (backupPath string, errRow agentcommon.SummaryRow, ok bool) {
 	slugBase := filepath.Base(agentTarget.DestinationDir)
 	parent := filepath.Dir(agentTarget.DestinationDir)
-
 	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
 	if err != nil {
-		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error())
+		return "", summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error()), false
 	}
 	if err := os.Rename(agentTarget.DestinationDir, backupPath); err != nil {
-		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("could not move current plugin aside for update: %s", err.Error()))
+		return "", summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("could not move current plugin aside for update: %s", err.Error())), false
 	}
+	return backupPath, agentcommon.SummaryRow{}, true
+}
 
+// restorePluginFromBackup removes a failed new install and renames the backup back into place.
+func restorePluginFromBackup(agentTarget plugincommon.AgentTarget, backupPath string) error {
+	_ = os.RemoveAll(agentTarget.DestinationDir)
+	return os.Rename(backupPath, agentTarget.DestinationDir)
+}
+
+// applyPluginUpdateCopy copies the extracted tree onto the target and restores the backup on failure.
+func applyPluginUpdateCopy(
+	unzipDir string,
+	installCommand *install.InstallCommand,
+	agentTarget plugincommon.AgentTarget,
+	backupPath string,
+) agentcommon.SummaryRow {
 	rows := installCommand.CopyExtractedToTargets(unzipDir, []plugincommon.AgentTarget{agentTarget})
 	if len(rows) != 1 {
-		_ = os.RemoveAll(agentTarget.DestinationDir)
-		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
+		if restoreErr := restorePluginFromBackup(agentTarget, backupPath); restoreErr != nil {
 			return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("internal error: unexpected copy result count; restore failed: %s", restoreErr.Error()))
 		}
 		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, "internal error: unexpected copy result count")
 	}
 	row := rows[0]
 	if row.Status != agentcommon.SummaryStatusOK {
-		_ = os.RemoveAll(agentTarget.DestinationDir)
-		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
+		if restoreErr := restorePluginFromBackup(agentTarget, backupPath); restoreErr != nil {
 			row.Detail = fmt.Sprintf("%s; could not restore previous install: %s", row.Detail, restoreErr.Error())
 		}
 		return row
 	}
+	return row
+}
 
+// removePluginUpdateBackup deletes the backup tree after a successful update.
+func removePluginUpdateBackup(backupPath, parent string) {
 	if err := os.RemoveAll(backupPath); err != nil {
 		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
-	} else {
-		backupRoot := filepath.Join(parent, pluginBackupDirName)
-		_ = os.Remove(backupRoot)
+		return
 	}
-
-	return summaryRowFor(agentTarget, agentcommon.SummaryStatusOK, agentcommon.SummaryDetailOKInstall)
+	backupRoot := filepath.Join(parent, pluginBackupDirName)
+	_ = os.Remove(backupRoot)
 }
 
 func finalError(results []agentcommon.SummaryRow) error {

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -189,10 +189,7 @@ func discoverInstalledPluginTargets(flags agentcommon.InstallFlagsResult) ([]str
 
 // applyUpdateAllForSlugs resolves latest version per slug, updates targets, and builds combined summary rows.
 // Download failures for one slug are logged and recorded as failed rows; remaining slugs still run.
-func applyUpdateAllForSlugs(
-	opts updateOptions,
-	slugOrder []string,
-	slugToTargets map[string][]plugincommon.AgentTarget,
+func applyUpdateAllForSlugs(opts updateOptions, slugOrder []string, slugToTargets map[string][]plugincommon.AgentTarget,
 ) ([]agentcommon.UpdateAllSummaryRow, updateAllOutcome) {
 	combined := make([]agentcommon.UpdateAllSummaryRow, 0)
 	var outcome updateAllOutcome

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -1,0 +1,404 @@
+package update
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
+	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// pluginBackupDirName is the directory under the plugins parent where update backups are stored.
+const pluginBackupDirName = ".plugin-backup"
+
+// resolveLatestPluginVersion is swappable in tests.
+var resolveLatestPluginVersion = plugincommon.ResolveLatestPluginVersion
+
+type preUpdate struct {
+	agentTarget            plugincommon.AgentTarget
+	installedVersion       string
+	alreadyAtTargetVersion bool
+	failureReason          string
+}
+
+// RunUpdate is the CLI action for `jf agent plugins update`.
+func RunUpdate(c *components.Context) error {
+	all := c.GetBoolFlagValue("all")
+	hasSlugArg := c.GetNumberOfArgs() >= 1
+	if !all && !hasSlugArg {
+		return fmt.Errorf("usage: jf agent plugins update <slug> (--harness <name[,name...]> [--global] [--project-dir <dir>] | --path <dir>) [--repo <repo>] [--version <ver>] [--dry-run] [--force] [--format <table|json>]\n       jf agent plugins update --all --harness <name[,name...]> [--global] [--project-dir <dir>] [--repo <repo>] [--dry-run] [--force] [--format <table|json>]")
+	}
+	if all {
+		if hasSlugArg {
+			return fmt.Errorf("--all cannot be combined with a slug argument; it updates every installed plugin for the given --harness list")
+		}
+		if strings.TrimSpace(c.GetStringFlagValue("version")) != "" {
+			return fmt.Errorf("--all cannot be combined with --version; it always updates to the latest version")
+		}
+		if strings.TrimSpace(c.GetStringFlagValue("path")) != "" {
+			return fmt.Errorf("--all cannot be combined with --path; --path targets a single install directory")
+		}
+	}
+
+	flags, err := plugincommon.ValidateInstallFlags(c)
+	if err != nil {
+		return err
+	}
+	if all && flags.AbsoluteInstallBaseDir != "" {
+		return fmt.Errorf("--all requires --harness; --path is not supported")
+	}
+	if all && len(flags.Specs) == 0 {
+		return fmt.Errorf("--all requires --harness <name[,name...]>")
+	}
+
+	serverDetails, err := agentcommon.GetServerDetails(c)
+	if err != nil {
+		return err
+	}
+	quiet := agentcommon.IsQuiet(c)
+	repoKey, err := agentcommon.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet, plugincommon.RepoOptions())
+	if err != nil {
+		return err
+	}
+
+	dryRun := c.GetBoolFlagValue("dry-run")
+	force := c.GetBoolFlagValue("force")
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+
+	opts := updateOptions{
+		serverDetails: serverDetails,
+		repoKey:       repoKey,
+		flags:         flags,
+		dryRun:        dryRun,
+		force:         force,
+		format:        format,
+		quiet:         quiet,
+	}
+
+	if all {
+		return runUpdateAll(opts)
+	}
+
+	slug := c.GetArgumentAt(0)
+	if err := plugincommon.ValidateSlug(slug); err != nil {
+		return err
+	}
+	requestedVersion := strings.TrimSpace(c.GetStringFlagValue("version"))
+	return runUpdateOne(opts, slug, requestedVersion)
+}
+
+type updateOptions struct {
+	serverDetails *config.ServerDetails
+	repoKey       string
+	flags         agentcommon.InstallFlagsResult
+	dryRun        bool
+	force         bool
+	format        string
+	quiet         bool
+}
+
+// runUpdateOne updates a single slug across all resolved targets.
+func runUpdateOne(opts updateOptions, slug, requestedVersion string) error {
+	targets, err := plugincommon.ResolveAgentTargets(slug, opts.flags.AbsoluteInstallBaseDir, opts.flags.Specs, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
+	if err != nil {
+		return err
+	}
+
+	targetVersion, err := resolveTargetVersion(opts.serverDetails, opts.repoKey, slug, requestedVersion)
+	if err != nil {
+		return err
+	}
+
+	results, err := updateSlugAcrossTargets(opts, slug, targetVersion, targets)
+	if err != nil {
+		return err
+	}
+	if err := agentcommon.PrintInstallSummary("Plugin", slug, targetVersion, results, opts.format); err != nil {
+		return err
+	}
+	return finalError(results)
+}
+
+// runUpdateAll enumerates every installed plugin under each --harness and updates each to its latest version.
+func runUpdateAll(opts updateOptions) error {
+	// slugToTargets groups all install targets by slug so we update each plugin once
+	// with one summary block, regardless of how many harnesses it is installed under.
+	slugToTargets := map[string][]plugincommon.AgentTarget{}
+	slugOrder := make([]string, 0)
+	for _, spec := range opts.flags.Specs {
+		installDir, err := agentcommon.ResolveAgentInstallDir(spec, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
+		if err != nil {
+			return err
+		}
+		slugs, err := agentcommon.DiscoverInstalledSlugs(installDir, plugincommon.PluginInfoManifestFile)
+		if err != nil {
+			return err
+		}
+		scope := plugincommon.ScopeProject
+		if opts.flags.IsGlobal {
+			scope = plugincommon.ScopeGlobal
+		}
+		for _, slug := range slugs {
+			if _, seen := slugToTargets[slug]; !seen {
+				slugOrder = append(slugOrder, slug)
+			}
+			slugToTargets[slug] = append(slugToTargets[slug], plugincommon.AgentTarget{
+				Agent:          spec,
+				Scope:          scope,
+				DestinationDir: filepath.Join(installDir, slug),
+			})
+		}
+	}
+
+	if len(slugOrder) == 0 {
+		log.Info("No installed plugins found for the given --harness list; nothing to update.")
+		return nil
+	}
+
+	combined := make([]agentcommon.UpdateAllSummaryRow, 0)
+	var anyOK, anyFailed bool
+	var firstResolveErr error
+	var updatedSlugCount int
+
+	for _, slug := range slugOrder {
+		targetVersion, err := resolveLatestPluginVersion(opts.serverDetails, opts.repoKey, slug)
+		if err != nil {
+			if firstResolveErr == nil {
+				firstResolveErr = err
+			}
+			log.Warn(fmt.Sprintf("Skipping plugin '%s': could not resolve latest version: %s", slug, err.Error()))
+			continue
+		}
+		results, err := updateSlugAcrossTargets(opts, slug, targetVersion, slugToTargets[slug])
+		if err != nil {
+			return err
+		}
+		combined = agentcommon.AppendUpdateAllSummaryRows(combined, slug, targetVersion, results)
+		updatedSlugCount++
+		for _, row := range results {
+			switch row.Status {
+			case agentcommon.SummaryStatusOK:
+				anyOK = true
+			case agentcommon.SummaryStatusFailed:
+				anyFailed = true
+			}
+		}
+	}
+
+	if err := agentcommon.PrintUpdateAllSummary("Plugin", combined, opts.format); err != nil {
+		return err
+	}
+	if !anyOK && anyFailed {
+		return fmt.Errorf("update failed for all targets (see summary above)")
+	}
+	if !anyOK && updatedSlugCount == 0 && firstResolveErr != nil {
+		return firstResolveErr
+	}
+	return nil
+}
+
+func resolveTargetVersion(serverDetails *config.ServerDetails, repoKey, slug, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested != "" && requested != "latest" {
+		if err := plugincommon.ValidateVersion(requested); err != nil {
+			return "", err
+		}
+		return requested, nil
+	}
+	return resolveLatestPluginVersion(serverDetails, repoKey, slug)
+}
+
+// updateSlugAcrossTargets fetches the slug once and runs the backup+copy loop per target.
+// Returns the per-target summary rows. Targets that are not installed or already at the
+// target version are reported without performing a download.
+func updateSlugAcrossTargets(opts updateOptions, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
+	checks := preUpdateTargets(targets, targetVersion, opts.force, opts.quiet)
+	results, updatable := initialResultsAndUpdatable(checks, targetVersion)
+
+	if opts.dryRun {
+		logDryRun(slug, targetVersion, checks)
+		return results, nil
+	}
+	if len(updatable) == 0 {
+		return results, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "plugin-update-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	cmd := install.NewInstallCommand().
+		SetServerDetails(opts.serverDetails).
+		SetRepoKey(opts.repoKey).
+		SetSlug(slug).
+		SetVersion(targetVersion).
+		SetQuiet(opts.quiet).
+		SetProjectDir(opts.flags.ProjectDirAbs).
+		SetGlobal(opts.flags.IsGlobal)
+
+	unzipDir, err := cmd.FetchAndExtractTo(tmpDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, preUpdateCheck := range updatable {
+		results = append(results, updateOnePlugin(unzipDir, cmd, preUpdateCheck))
+	}
+	return results, nil
+}
+
+func preUpdateTargets(targets []plugincommon.AgentTarget, targetVersion string, force, quiet bool) []preUpdate {
+	out := make([]preUpdate, 0, len(targets))
+	for _, agentTarget := range targets {
+		record := preUpdate{agentTarget: agentTarget}
+		installedVersion, err := plugincommon.ReadInstalledPluginVersion(agentTarget.DestinationDir)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				record.failureReason = fmt.Sprintf("plugin not installed at %s; run 'jf agent plugins install' first", agentTarget.DestinationDir)
+			} else {
+				record.failureReason = err.Error()
+			}
+			if !quiet {
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", agentTarget.Agent.Name, agentTarget.DestinationDir, record.failureReason))
+			}
+			out = append(out, record)
+			continue
+		}
+		record.installedVersion = installedVersion
+		if installedVersion == targetVersion && !force {
+			record.alreadyAtTargetVersion = true
+			if !quiet {
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: already at version %s (use --force to re-download)", agentTarget.Agent.Name, agentTarget.DestinationDir, targetVersion))
+			}
+		}
+		out = append(out, record)
+	}
+	return out
+}
+
+func initialResultsAndUpdatable(checks []preUpdate, targetVersion string) ([]agentcommon.SummaryRow, []preUpdate) {
+	results := make([]agentcommon.SummaryRow, 0, len(checks))
+	updatable := make([]preUpdate, 0, len(checks))
+	for _, preUpdateCheck := range checks {
+		switch {
+		case preUpdateCheck.failureReason != "":
+			results = append(results, summaryRowFor(preUpdateCheck.agentTarget, agentcommon.SummaryStatusFailed, preUpdateCheck.failureReason))
+		case preUpdateCheck.alreadyAtTargetVersion:
+			results = append(results, summaryRowFor(preUpdateCheck.agentTarget, agentcommon.SummaryStatusSkipped, fmt.Sprintf("version already %s; use --force to reinstall", targetVersion)))
+		default:
+			updatable = append(updatable, preUpdateCheck)
+		}
+	}
+	return results, updatable
+}
+
+func summaryRowFor(agentTarget plugincommon.AgentTarget, status, detail string) agentcommon.SummaryRow {
+	return agentcommon.SummaryRow{
+		Agent:  agentTarget.Agent.Name,
+		Scope:  string(agentTarget.Scope),
+		Path:   agentTarget.DestinationDir,
+		Status: status,
+		Detail: detail,
+	}
+}
+
+func logDryRun(slug, targetVersion string, checks []preUpdate) {
+	for _, preUpdateCheck := range checks {
+		switch {
+		case preUpdateCheck.failureReason != "":
+			log.Info(fmt.Sprintf("[dry-run] Would skip %s at %s: %s", slug, preUpdateCheck.agentTarget.DestinationDir, preUpdateCheck.failureReason))
+		case preUpdateCheck.alreadyAtTargetVersion:
+			log.Info(fmt.Sprintf("[dry-run] Plugin '%s' already at v%s at %s", slug, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
+		case preUpdateCheck.installedVersion == "":
+			log.Info(fmt.Sprintf("[dry-run] Would install plugin '%s' v%s to %s", slug, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
+		default:
+			log.Info(fmt.Sprintf("[dry-run] Would update plugin '%s' from v%s -> v%s at %s", slug, preUpdateCheck.installedVersion, targetVersion, preUpdateCheck.agentTarget.DestinationDir))
+		}
+	}
+}
+
+// updateOnePlugin updates a single install target using the already-fetched tree in unzipDir:
+// it renames the live install aside, copies from unzipDir, restores the backup on failure, then removes the backup on success.
+func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, check preUpdate) agentcommon.SummaryRow {
+	agentTarget := check.agentTarget
+	slugBase := filepath.Base(agentTarget.DestinationDir)
+	parent := filepath.Dir(agentTarget.DestinationDir)
+
+	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
+	if err != nil {
+		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error())
+	}
+	if err := os.Rename(agentTarget.DestinationDir, backupPath); err != nil {
+		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("could not move current plugin aside for update: %s", err.Error()))
+	}
+
+	rows := installCommand.CopyExtractedToTargets(unzipDir, []plugincommon.AgentTarget{agentTarget})
+	if len(rows) != 1 {
+		_ = os.RemoveAll(agentTarget.DestinationDir)
+		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
+			return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("internal error: unexpected copy result count; restore failed: %s", restoreErr.Error()))
+		}
+		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, "internal error: unexpected copy result count")
+	}
+	row := rows[0]
+	if row.Status != agentcommon.SummaryStatusOK {
+		_ = os.RemoveAll(agentTarget.DestinationDir)
+		if restoreErr := os.Rename(backupPath, agentTarget.DestinationDir); restoreErr != nil {
+			row.Detail = fmt.Sprintf("%s; could not restore previous install: %s", row.Detail, restoreErr.Error())
+		}
+		return row
+	}
+
+	if err := os.RemoveAll(backupPath); err != nil {
+		log.Warn(fmt.Sprintf("Update succeeded but previous copy at %s could not be deleted: %s", backupPath, err.Error()))
+	} else {
+		backupRoot := filepath.Join(parent, pluginBackupDirName)
+		_ = os.Remove(backupRoot)
+	}
+
+	return summaryRowFor(agentTarget, agentcommon.SummaryStatusOK, agentcommon.SummaryDetailOKInstall)
+}
+
+func finalError(results []agentcommon.SummaryRow) error {
+	if len(results) == 0 {
+		return nil
+	}
+	for _, result := range results {
+		if result.Status != agentcommon.SummaryStatusFailed {
+			return nil
+		}
+	}
+	return fmt.Errorf("update failed for all targets (see summary above)")
+}
+
+func reserveUpdateBackupPath(installBase, slug string) (string, error) {
+	backupRoot := filepath.Join(installBase, pluginBackupDirName)
+	// #nosec G301 -- update backup dir under user plugin tree; permissive mode matches install copy behavior for tooling access.
+	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
+		return "", fmt.Errorf("could not create %s directory: %w", pluginBackupDirName, err)
+	}
+	pattern := slug + "-backup-*"
+	d, err := os.MkdirTemp(backupRoot, pattern)
+	if err != nil {
+		return "", fmt.Errorf("could not reserve update backup path: %w", err)
+	}
+	if err := os.Remove(d); err != nil {
+		return "", fmt.Errorf("could not prepare update backup path: %w", err)
+	}
+	return d, nil
+}

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -22,6 +22,9 @@ const pluginBackupDirName = ".plugin-backup"
 // resolveLatestPluginVersion is swappable in tests.
 var resolveLatestPluginVersion = plugincommon.ResolveLatestPluginVersion
 
+// updateSlugAcrossTargetsFn is swappable in tests.
+var updateSlugAcrossTargetsFn = updateSlugAcrossTargets
+
 type preUpdate struct {
 	agentTarget            plugincommon.AgentTarget
 	installedVersion       string
@@ -120,7 +123,7 @@ func runUpdateOne(opts updateOptions, slug, requestedVersion string) error {
 		return err
 	}
 
-	results, err := updateSlugAcrossTargets(opts, slug, targetVersion, targets)
+	results, err := updateSlugAcrossTargetsFn(opts, slug, targetVersion, targets)
 	if err != nil {
 		return err
 	}
@@ -149,10 +152,7 @@ func runUpdateAll(opts updateOptions) error {
 		return nil
 	}
 
-	combined, outcome, err := applyUpdateAllForSlugs(opts, slugOrder, slugToTargets)
-	if err != nil {
-		return err
-	}
+	combined, outcome := applyUpdateAllForSlugs(opts, slugOrder, slugToTargets)
 	return finalizeUpdateAll(combined, outcome, opts.format)
 }
 
@@ -169,7 +169,7 @@ func discoverInstalledPluginTargets(flags agentcommon.InstallFlagsResult) ([]str
 		if err != nil {
 			return nil, nil, err
 		}
-		slugs, err := agentcommon.DiscoverInstalledSlugs(installDir, plugincommon.PluginInfoManifestFile)
+		slugs, err := plugincommon.DiscoverInstalledPluginSlugs(installDir)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -188,11 +188,12 @@ func discoverInstalledPluginTargets(flags agentcommon.InstallFlagsResult) ([]str
 }
 
 // applyUpdateAllForSlugs resolves latest version per slug, updates targets, and builds combined summary rows.
+// Download failures for one slug are logged and recorded as failed rows; remaining slugs still run.
 func applyUpdateAllForSlugs(
 	opts updateOptions,
 	slugOrder []string,
 	slugToTargets map[string][]plugincommon.AgentTarget,
-) ([]agentcommon.UpdateAllSummaryRow, updateAllOutcome, error) {
+) ([]agentcommon.UpdateAllSummaryRow, updateAllOutcome) {
 	combined := make([]agentcommon.UpdateAllSummaryRow, 0)
 	var outcome updateAllOutcome
 	for _, slug := range slugOrder {
@@ -204,9 +205,10 @@ func applyUpdateAllForSlugs(
 			log.Warn(fmt.Sprintf("Skipping plugin '%s': could not resolve latest version: %s", slug, err.Error()))
 			continue
 		}
-		results, err := updateSlugAcrossTargets(opts, slug, targetVersion, slugToTargets[slug])
+		results, err := updateSlugAcrossTargetsFn(opts, slug, targetVersion, slugToTargets[slug])
 		if err != nil {
-			return nil, updateAllOutcome{}, err
+			log.Warn(fmt.Sprintf("Skipping plugin '%s': download failed: %s", slug, err.Error()))
+			results = failedRowsForTargets(slugToTargets[slug], err.Error())
 		}
 		combined = agentcommon.AppendUpdateAllSummaryRows(combined, slug, targetVersion, results)
 		outcome.updatedSlugCount++
@@ -214,7 +216,15 @@ func applyUpdateAllForSlugs(
 		outcome.anyOK = outcome.anyOK || ok
 		outcome.anyFailed = outcome.anyFailed || failed
 	}
-	return combined, outcome, nil
+	return combined, outcome
+}
+
+func failedRowsForTargets(targets []plugincommon.AgentTarget, detail string) []agentcommon.SummaryRow {
+	rows := make([]agentcommon.SummaryRow, 0, len(targets))
+	for _, target := range targets {
+		rows = append(rows, summaryRowFor(target, agentcommon.SummaryStatusFailed, detail))
+	}
+	return rows
 }
 
 func tallySummaryRows(results []agentcommon.SummaryRow) (anyOK, anyFailed bool) {
@@ -273,7 +283,10 @@ func updateSlugAcrossTargets(opts updateOptions, slug, targetVersion string, tar
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	defer func() {
-		_ = os.RemoveAll(tmpDir)
+		// Best-effort teardown of per-slug temp dir after copies finish or fail.
+		if removeErr := os.RemoveAll(tmpDir); removeErr != nil {
+			log.Warn(fmt.Sprintf("Could not remove plugin update temp dir %s: %s", tmpDir, removeErr.Error()))
+		}
 	}()
 
 	cmd := install.NewInstallCommand().
@@ -369,9 +382,9 @@ func logDryRun(slug, targetVersion string, checks []preUpdate) {
 // updateOnePlugin updates a single install target using the already-fetched tree in unzipDir.
 func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, check preUpdate) agentcommon.SummaryRow {
 	agentTarget := check.agentTarget
-	backupPath, errRow, ok := movePluginAsideForUpdate(agentTarget)
-	if !ok {
-		return errRow
+	backupPath, err := movePluginAsideForUpdate(agentTarget)
+	if err != nil {
+		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error())
 	}
 	row := applyPluginUpdateCopy(unzipDir, installCommand, agentTarget, backupPath)
 	if row.Status != agentcommon.SummaryStatusOK {
@@ -382,23 +395,28 @@ func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, ch
 }
 
 // movePluginAsideForUpdate reserves a backup path and renames the live install directory aside.
-func movePluginAsideForUpdate(agentTarget plugincommon.AgentTarget) (backupPath string, errRow agentcommon.SummaryRow, ok bool) {
+func movePluginAsideForUpdate(agentTarget plugincommon.AgentTarget) (string, error) {
 	slugBase := filepath.Base(agentTarget.DestinationDir)
 	parent := filepath.Dir(agentTarget.DestinationDir)
 	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
 	if err != nil {
-		return "", summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error()), false
+		return "", err
 	}
 	if err := os.Rename(agentTarget.DestinationDir, backupPath); err != nil {
-		return "", summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, fmt.Sprintf("could not move current plugin aside for update: %s", err.Error())), false
+		return "", fmt.Errorf("could not move current plugin aside for update: %w", err)
 	}
-	return backupPath, agentcommon.SummaryRow{}, true
+	return backupPath, nil
 }
 
 // restorePluginFromBackup removes a failed new install and renames the backup back into place.
 func restorePluginFromBackup(agentTarget plugincommon.AgentTarget, backupPath string) error {
-	_ = os.RemoveAll(agentTarget.DestinationDir)
-	return os.Rename(backupPath, agentTarget.DestinationDir)
+	if err := os.RemoveAll(agentTarget.DestinationDir); err != nil {
+		log.Warn(fmt.Sprintf("Could not remove failed plugin install at %s before restore: %s", agentTarget.DestinationDir, err.Error()))
+	}
+	if err := os.Rename(backupPath, agentTarget.DestinationDir); err != nil {
+		return fmt.Errorf("could not restore previous plugin install from %s: %w", backupPath, err)
+	}
+	return nil
 }
 
 // applyPluginUpdateCopy copies the extracted tree onto the target and restores the backup on failure.
@@ -432,7 +450,9 @@ func removePluginUpdateBackup(backupPath, parent string) {
 		return
 	}
 	backupRoot := filepath.Join(parent, pluginBackupDirName)
-	_ = os.Remove(backupRoot)
+	if err := os.Remove(backupRoot); err != nil && !os.IsNotExist(err) {
+		log.Warn(fmt.Sprintf("Could not remove empty %s directory at %s: %s", pluginBackupDirName, backupRoot, err.Error()))
+	}
 }
 
 func finalError(results []agentcommon.SummaryRow) error {

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -13,8 +13,19 @@ import (
 	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
+
+// askYesNo is swappable in tests.
+var askYesNo = coreutils.AskYesNo
+
+// isNonInteractive is swappable in tests (GitHub Actions sets CI=true).
+var isNonInteractive = agentcommon.IsNonInteractive
+
+const updateAllConfirmPrompt = "Update all discovered plugins under the given harness(es) to their latest version in the repository? " +
+	"Each install folder name is used as the repository slug (same as update --slug). " +
+	"Matching packages will be updated, including installs that were not made with JFrog CLI."
 
 // pluginBackupDirName is the directory under the plugins parent where update backups are stored.
 const pluginBackupDirName = ".plugin-backup"
@@ -35,13 +46,19 @@ type preUpdate struct {
 // RunUpdate is the CLI action for `jf agent plugins update`.
 func RunUpdate(c *components.Context) error {
 	all := c.GetBoolFlagValue("all")
-	hasSlugArg := c.GetNumberOfArgs() >= 1
-	if !all && !hasSlugArg {
-		return fmt.Errorf("usage: jf agent plugins update <slug> (--harness <name[,name...]> [--global] [--project-dir <dir>] | --path <dir>) [--repo <repo>] [--version <ver>] [--dry-run] [--force] [--format <table|json>]\n       jf agent plugins update --all --harness <name[,name...]> [--global] [--project-dir <dir>] [--repo <repo>] [--dry-run] [--force] [--format <table|json>]")
+	slugFlag := strings.TrimSpace(c.GetStringFlagValue("slug"))
+	if !all && slugFlag == "" {
+		if c.GetNumberOfArgs() > 0 {
+			return fmt.Errorf("unexpected positional argument(s); use --slug to specify the plugin")
+		}
+		return fmt.Errorf("usage: jf agent plugins update --slug <slug> (--harness <name[,name...]> [--global] [--project-dir <dir>] | --path <dir>) [--repo <repo>] [--version <ver>] [--dry-run] [--force] [--format <table|json>]\n       jf agent plugins update --all --harness <name[,name...]> [--global] [--project-dir <dir>] [--repo <repo>] [--dry-run] [--force] [--format <table|json>]")
 	}
 	if all {
-		if hasSlugArg {
-			return fmt.Errorf("--all cannot be combined with a slug argument; it updates every installed plugin for the given --harness list")
+		if slugFlag != "" {
+			return fmt.Errorf("--all cannot be combined with --slug; it updates every installed plugin for the given --harness list")
+		}
+		if c.GetNumberOfArgs() > 0 {
+			return fmt.Errorf("unexpected positional argument(s); use --slug or --all")
 		}
 		if strings.TrimSpace(c.GetStringFlagValue("version")) != "" {
 			return fmt.Errorf("--all cannot be combined with --version; it always updates to the latest version")
@@ -51,57 +68,35 @@ func RunUpdate(c *components.Context) error {
 		}
 	}
 
-	flags, err := plugincommon.ValidateInstallFlags(c)
+	opts, err := newUpdate(c)
 	if err != nil {
 		return err
 	}
-	if all && flags.AbsoluteInstallBaseDir != "" {
+	if all && opts.flags.AbsoluteInstallBaseDir != "" {
 		return fmt.Errorf("--all requires --harness; --path is not supported")
 	}
-	if all && len(flags.Specs) == 0 {
+	if all && len(opts.flags.Specs) == 0 {
 		return fmt.Errorf("--all requires --harness <name[,name...]>")
 	}
 
-	serverDetails, err := agentcommon.GetServerDetails(c)
-	if err != nil {
-		return err
-	}
-	quiet := agentcommon.IsQuiet(c)
-	repoKey, err := agentcommon.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet, plugincommon.RepoOptions())
-	if err != nil {
-		return err
-	}
-
-	dryRun := c.GetBoolFlagValue("dry-run")
-	force := c.GetBoolFlagValue("force")
-	format := "table"
-	if c.GetStringFlagValue("format") != "" {
-		format = c.GetStringFlagValue("format")
-	}
-
-	opts := updateOptions{
-		serverDetails: serverDetails,
-		repoKey:       repoKey,
-		flags:         flags,
-		dryRun:        dryRun,
-		force:         force,
-		format:        format,
-		quiet:         quiet,
-	}
-
 	if all {
+		if err := confirmUpdateAll(opts); err != nil {
+			return err
+		}
 		return runUpdateAll(opts)
 	}
 
-	slug := c.GetArgumentAt(0)
-	if err := plugincommon.ValidateSlug(slug); err != nil {
+	if c.GetNumberOfArgs() > 0 {
+		return fmt.Errorf("unexpected positional argument(s); use --slug to specify the plugin")
+	}
+	if err := plugincommon.ValidateSlug(slugFlag); err != nil {
 		return err
 	}
 	requestedVersion := strings.TrimSpace(c.GetStringFlagValue("version"))
-	return runUpdateOne(opts, slug, requestedVersion)
+	return runUpdateOnSlug(opts, slugFlag, requestedVersion)
 }
 
-type updateOptions struct {
+type update struct {
 	serverDetails *config.ServerDetails
 	repoKey       string
 	flags         agentcommon.InstallFlagsResult
@@ -111,8 +106,37 @@ type updateOptions struct {
 	quiet         bool
 }
 
-// runUpdateOne updates a single slug across all resolved targets.
-func runUpdateOne(opts updateOptions, slug, requestedVersion string) error {
+func newUpdate(c *components.Context) (update, error) {
+	flags, err := plugincommon.ValidateInstallFlags(c)
+	if err != nil {
+		return update{}, err
+	}
+	serverDetails, err := agentcommon.GetServerDetails(c)
+	if err != nil {
+		return update{}, err
+	}
+	quiet := agentcommon.IsQuiet(c)
+	repoKey, err := agentcommon.ResolveRepo(serverDetails, c.GetStringFlagValue("repo"), quiet, plugincommon.RepoOptions())
+	if err != nil {
+		return update{}, err
+	}
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+	return update{
+		serverDetails: serverDetails,
+		repoKey:       repoKey,
+		flags:         flags,
+		dryRun:        c.GetBoolFlagValue("dry-run"),
+		force:         c.GetBoolFlagValue("force"),
+		format:        format,
+		quiet:         quiet,
+	}, nil
+}
+
+// runUpdateOnSlug updates a single slug across all resolved targets.
+func runUpdateOnSlug(opts update, slug, requestedVersion string) error {
 	targets, err := plugincommon.ResolveAgentTargets(slug, opts.flags.AbsoluteInstallBaseDir, opts.flags.Specs, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
 	if err != nil {
 		return err
@@ -141,8 +165,19 @@ type updateAllOutcome struct {
 	updatedSlugCount int
 }
 
+// confirmUpdateAll asks for interactive confirmation before update --all (skipped for --dry-run, --quiet, and CI).
+func confirmUpdateAll(opts update) error {
+	if opts.dryRun || opts.quiet || isNonInteractive() {
+		return nil
+	}
+	if !askYesNo(updateAllConfirmPrompt, false) {
+		return fmt.Errorf("update --all aborted by user")
+	}
+	return nil
+}
+
 // runUpdateAll enumerates every installed plugin under each --harness and updates each to its latest version.
-func runUpdateAll(opts updateOptions) error {
+func runUpdateAll(opts update) error {
 	slugOrder, slugToTargets, err := discoverInstalledPluginTargets(opts.flags)
 	if err != nil {
 		return err
@@ -188,8 +223,8 @@ func discoverInstalledPluginTargets(flags agentcommon.InstallFlagsResult) ([]str
 }
 
 // applyUpdateAllForSlugs resolves latest version per slug, updates targets, and builds combined summary rows.
-// Download failures for one slug are logged and recorded as failed rows; remaining slugs still run.
-func applyUpdateAllForSlugs(opts updateOptions, slugOrder []string, slugToTargets map[string][]plugincommon.AgentTarget,
+// Resolve and download failures for one slug are logged and recorded as failed rows; remaining slugs still run.
+func applyUpdateAllForSlugs(opts update, slugOrder []string, slugToTargets map[string][]plugincommon.AgentTarget,
 ) ([]agentcommon.UpdateAllSummaryRow, updateAllOutcome) {
 	combined := make([]agentcommon.UpdateAllSummaryRow, 0)
 	var outcome updateAllOutcome
@@ -200,6 +235,11 @@ func applyUpdateAllForSlugs(opts updateOptions, slugOrder []string, slugToTarget
 				outcome.firstResolveErr = err
 			}
 			log.Warn(fmt.Sprintf("Skipping plugin '%s': could not resolve latest version: %s", slug, err.Error()))
+			results := failedRowsForTargets(slugToTargets[slug], err.Error())
+			combined = agentcommon.AppendUpdateAllSummaryRows(combined, slug, "", results)
+			outcome.updatedSlugCount++
+			_, slugFailed := tallySummaryRows(results)
+			outcome.anyFailed = outcome.anyFailed || slugFailed
 			continue
 		}
 		results, err := updateSlugAcrossTargetsFn(opts, slug, targetVersion, slugToTargets[slug])
@@ -209,9 +249,9 @@ func applyUpdateAllForSlugs(opts updateOptions, slugOrder []string, slugToTarget
 		}
 		combined = agentcommon.AppendUpdateAllSummaryRows(combined, slug, targetVersion, results)
 		outcome.updatedSlugCount++
-		ok, failed := tallySummaryRows(results)
-		outcome.anyOK = outcome.anyOK || ok
-		outcome.anyFailed = outcome.anyFailed || failed
+		slugOK, slugFailed := tallySummaryRows(results)
+		outcome.anyOK = outcome.anyOK || slugOK
+		outcome.anyFailed = outcome.anyFailed || slugFailed
 	}
 	return combined, outcome
 }
@@ -224,6 +264,8 @@ func failedRowsForTargets(targets []plugincommon.AgentTarget, detail string) []a
 	return rows
 }
 
+// tallySummaryRows reports whether any per-target row succeeded (ok) or failed.
+// Skipped rows are ignored. Used during update --all to aggregate exit conditions across slugs.
 func tallySummaryRows(results []agentcommon.SummaryRow) (anyOK, anyFailed bool) {
 	for _, row := range results {
 		switch row.Status {
@@ -263,7 +305,7 @@ func resolveTargetVersion(serverDetails *config.ServerDetails, repoKey, slug, re
 // updateSlugAcrossTargets fetches the slug once and runs the backup+copy loop per target.
 // Returns the per-target summary rows. Targets that are not installed or already at the
 // target version are reported without performing a download.
-func updateSlugAcrossTargets(opts updateOptions, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
+func updateSlugAcrossTargets(opts update, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
 	checks := preUpdateTargets(targets, targetVersion, opts.force, opts.quiet)
 	results, updatable := initialResultsAndUpdatable(checks, targetVersion)
 
@@ -286,7 +328,7 @@ func updateSlugAcrossTargets(opts updateOptions, slug, targetVersion string, tar
 		}
 	}()
 
-	cmd := install.NewInstallCommand().
+	installCmd := install.NewInstallCommand().
 		SetServerDetails(opts.serverDetails).
 		SetRepoKey(opts.repoKey).
 		SetSlug(slug).
@@ -295,44 +337,44 @@ func updateSlugAcrossTargets(opts updateOptions, slug, targetVersion string, tar
 		SetProjectDir(opts.flags.ProjectDirAbs).
 		SetGlobal(opts.flags.IsGlobal)
 
-	unzipDir, err := cmd.FetchAndExtractTo(tmpDir)
+	unzipDir, err := installCmd.FetchAndExtractTo(tmpDir)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, preUpdateCheck := range updatable {
-		results = append(results, updateOnePlugin(unzipDir, cmd, preUpdateCheck))
+		results = append(results, updatePlugin(unzipDir, installCmd, preUpdateCheck))
 	}
 	return results, nil
 }
 
 func preUpdateTargets(targets []plugincommon.AgentTarget, targetVersion string, force, quiet bool) []preUpdate {
-	out := make([]preUpdate, 0, len(targets))
+	checks := make([]preUpdate, 0, len(targets))
 	for _, agentTarget := range targets {
-		record := preUpdate{agentTarget: agentTarget}
+		preUpdateCheck := preUpdate{agentTarget: agentTarget}
 		installedVersion, err := plugincommon.ReadInstalledPluginVersion(agentTarget.DestinationDir)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				record.failureReason = fmt.Sprintf("plugin not installed at %s; run 'jf agent plugins install' first", agentTarget.DestinationDir)
+				preUpdateCheck.failureReason = fmt.Sprintf("plugin not installed at %s; run 'jf agent plugins install' first", agentTarget.DestinationDir)
 			} else {
-				record.failureReason = err.Error()
+				preUpdateCheck.failureReason = err.Error()
 			}
 			if !quiet {
-				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", agentTarget.Agent.Name, agentTarget.DestinationDir, record.failureReason))
+				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", agentTarget.Agent.Name, agentTarget.DestinationDir, preUpdateCheck.failureReason))
 			}
-			out = append(out, record)
+			checks = append(checks, preUpdateCheck)
 			continue
 		}
-		record.installedVersion = installedVersion
+		preUpdateCheck.installedVersion = installedVersion
 		if installedVersion == targetVersion && !force {
-			record.alreadyAtTargetVersion = true
+			preUpdateCheck.alreadyAtTargetVersion = true
 			if !quiet {
 				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: already at version %s (use --force to re-download)", agentTarget.Agent.Name, agentTarget.DestinationDir, targetVersion))
 			}
 		}
-		out = append(out, record)
+		checks = append(checks, preUpdateCheck)
 	}
-	return out
+	return checks
 }
 
 func initialResultsAndUpdatable(checks []preUpdate, targetVersion string) ([]agentcommon.SummaryRow, []preUpdate) {
@@ -376,10 +418,11 @@ func logDryRun(slug, targetVersion string, checks []preUpdate) {
 	}
 }
 
-// updateOnePlugin updates a single install target using the already-fetched tree in unzipDir.
-func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, check preUpdate) agentcommon.SummaryRow {
+// updatePlugin updates a single install target using the already-fetched tree in unzipDir.
+// On success the backup is deleted; on copy failure applyPluginUpdateCopy restores the backup first.
+func updatePlugin(unzipDir string, installCommand *install.InstallCommand, check preUpdate) agentcommon.SummaryRow {
 	agentTarget := check.agentTarget
-	backupPath, err := movePluginAsideForUpdate(agentTarget)
+	backupPath, err := createPluginBackupForUpdate(agentTarget)
 	if err != nil {
 		return summaryRowFor(agentTarget, agentcommon.SummaryStatusFailed, err.Error())
 	}
@@ -391,8 +434,8 @@ func updateOnePlugin(unzipDir string, installCommand *install.InstallCommand, ch
 	return summaryRowFor(agentTarget, agentcommon.SummaryStatusOK, agentcommon.SummaryDetailOKInstall)
 }
 
-// movePluginAsideForUpdate reserves a backup path and renames the live install directory aside.
-func movePluginAsideForUpdate(agentTarget plugincommon.AgentTarget) (string, error) {
+// createPluginBackupForUpdate reserves a backup path and renames the live install directory aside.
+func createPluginBackupForUpdate(agentTarget plugincommon.AgentTarget) (string, error) {
 	slugBase := filepath.Base(agentTarget.DestinationDir)
 	parent := filepath.Dir(agentTarget.DestinationDir)
 	backupPath, err := reserveUpdateBackupPath(parent, slugBase)
@@ -416,7 +459,10 @@ func restorePluginFromBackup(agentTarget plugincommon.AgentTarget, backupPath st
 	return nil
 }
 
-// applyPluginUpdateCopy copies the extracted tree onto the target and restores the backup on failure.
+// applyPluginUpdateCopy installs the extracted plugin tree at agentTarget.
+// The live install must already have been moved aside to backupPath (createPluginBackupForUpdate).
+// If the copy fails or returns a non-ok summary row, restorePluginFromBackup removes any partial
+// new install and renames the backup back to DestinationDir so the previous version remains in place.
 func applyPluginUpdateCopy(unzipDir string, installCommand *install.InstallCommand, agentTarget plugincommon.AgentTarget, backupPath string) agentcommon.SummaryRow {
 	rows := installCommand.CopyExtractedToTargets(unzipDir, []plugincommon.AgentTarget{agentTarget})
 	if len(rows) != 1 {
@@ -461,17 +507,16 @@ func finalError(results []agentcommon.SummaryRow) error {
 
 func reserveUpdateBackupPath(installBase, slug string) (string, error) {
 	backupRoot := filepath.Join(installBase, pluginBackupDirName)
-	// #nosec G301 -- update backup dir under user plugin tree; permissive mode matches install copy behavior for tooling access.
-	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
+	if err := os.MkdirAll(backupRoot, agentcommon.InstallDirMode); err != nil {
 		return "", fmt.Errorf("could not create %s directory: %w", pluginBackupDirName, err)
 	}
 	pattern := slug + "-backup-*"
-	d, err := os.MkdirTemp(backupRoot, pattern)
+	reservedBackupPath, err := os.MkdirTemp(backupRoot, pattern)
 	if err != nil {
 		return "", fmt.Errorf("could not reserve update backup path: %w", err)
 	}
-	if err := os.Remove(d); err != nil {
+	if err := os.Remove(reservedBackupPath); err != nil {
 		return "", fmt.Errorf("could not prepare update backup path: %w", err)
 	}
-	return d, nil
+	return reservedBackupPath, nil
 }

--- a/agent/plugins/commands/update/update_test.go
+++ b/agent/plugins/commands/update/update_test.go
@@ -18,11 +18,11 @@ import (
 
 func TestReserveUpdateBackupPath(t *testing.T) {
 	base := t.TempDir()
-	p, err := reserveUpdateBackupPath(base, "plugin-a")
+	reservedBackupPath, err := reserveUpdateBackupPath(base, "plugin-a")
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(base, pluginBackupDirName), filepath.Dir(p))
-	assert.Contains(t, filepath.Base(p), "plugin-a-backup-")
-	_, err = os.Stat(p)
+	require.Equal(t, filepath.Join(base, pluginBackupDirName), filepath.Dir(reservedBackupPath))
+	assert.Contains(t, filepath.Base(reservedBackupPath), "plugin-a-backup-")
+	_, err = os.Stat(reservedBackupPath)
 	require.True(t, errors.Is(err, fs.ErrNotExist), "reserved path must not exist until rename")
 }
 
@@ -135,10 +135,10 @@ func TestUpdateOnePlugin_SuccessRemovesBackup(t *testing.T) {
 	}
 
 	src := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(src, "plugin.json"), []byte(`{"name":"web","version":"2.0.0"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "plugin.json"), []byte(`{"name":"web","version":"2.0.0"}`), agentcommon.DefaultFileMode))
 
 	installCommand := install.NewInstallCommand().SetSlug("web").SetVersion("2.0.0").SetRepoKey("r")
-	row := updateOnePlugin(src, installCommand, check)
+	row := updatePlugin(src, installCommand, check)
 	assert.Equal(t, agentcommon.SummaryStatusOK, row.Status)
 	assert.Equal(t, agentcommon.SummaryDetailOKInstall, row.Detail)
 
@@ -170,11 +170,18 @@ func TestResolveTargetVersion_RejectsInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRunUpdate_AllRejectsSlugArg(t *testing.T) {
+func TestRunUpdate_AllRejectsSlugFlag(t *testing.T) {
+	ctx := newUpdateContext(t, nil, map[string]string{"harness": "claude", "slug": "web"}, map[string]bool{"all": true})
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with --slug")
+}
+
+func TestRunUpdate_AllRejectsPositionalArg(t *testing.T) {
 	ctx := newUpdateContext(t, []string{"web"}, map[string]string{"harness": "claude"}, map[string]bool{"all": true})
 	err := RunUpdate(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--all cannot be combined with a slug argument")
+	assert.Contains(t, err.Error(), "unexpected positional argument")
 }
 
 func TestRunUpdate_AllRejectsVersion(t *testing.T) {
@@ -196,8 +203,8 @@ func TestDiscoverInstalledPluginTargets_MergesHarnesses(t *testing.T) {
 	pluginsDir := "plugins"
 	installRoot := filepath.Join(projectRoot, pluginsDir)
 
-	require.NoError(t, os.MkdirAll(filepath.Join(installRoot, "shared"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(installRoot, "shared", "plugin.json"), []byte(`{"name":"shared","version":"1.0.0"}`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(installRoot, "shared"), agentcommon.InstallDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(installRoot, "shared", "plugin.json"), []byte(`{"name":"shared","version":"1.0.0"}`), agentcommon.DefaultFileMode))
 
 	flags := agentcommon.InstallFlagsResult{
 		Specs: []plugincommon.AgentSpec{
@@ -218,8 +225,8 @@ func TestDiscoverInstalledPluginTargets_PluginJSONOnly(t *testing.T) {
 	pluginsDir := "plugins"
 	installRoot := filepath.Join(projectRoot, pluginsDir)
 	pluginDir := filepath.Join(installRoot, "legacy")
-	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"legacy","version":"0.9.0"}`), 0o644))
+	require.NoError(t, os.MkdirAll(pluginDir, agentcommon.InstallDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"legacy","version":"0.9.0"}`), agentcommon.DefaultFileMode))
 
 	flags := agentcommon.InstallFlagsResult{
 		Specs:         []plugincommon.AgentSpec{{Name: "cursor", Config: agentcommon.AgentConfig{ProjectDir: pluginsDir}}},
@@ -249,6 +256,39 @@ func TestFinalizeUpdateAll_ReturnsFirstResolveErrWhenNothingUpdated(t *testing.T
 	assert.ErrorIs(t, err, resolveErr)
 }
 
+func TestApplyUpdateAllForSlugs_ContinuesOnResolveError(t *testing.T) {
+	oldResolve := resolveLatestPluginVersion
+	defer func() {
+		resolveLatestPluginVersion = oldResolve
+	}()
+
+	resolveLatestPluginVersion = func(_ *config.ServerDetails, _, slug string) (string, error) {
+		if slug == "missing" {
+			return "", errors.New("plugin 'missing' has no versions in repository 'repo'")
+		}
+		return "2.0.0", nil
+	}
+
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "cursor"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: "/tmp/missing",
+	}
+	opts := update{serverDetails: &config.ServerDetails{}, repoKey: "repo"}
+	combined, outcome := applyUpdateAllForSlugs(opts, []string{"missing"}, map[string][]plugincommon.AgentTarget{
+		"missing": {target},
+	})
+
+	require.Len(t, combined, 1)
+	assert.Equal(t, "missing", combined[0].Name)
+	assert.Equal(t, agentcommon.SummaryStatusFailed, combined[0].Status)
+	assert.Contains(t, combined[0].Detail, "no versions in repository")
+	assert.Empty(t, combined[0].Version)
+	assert.True(t, outcome.anyFailed)
+	assert.False(t, outcome.anyOK)
+	assert.Equal(t, 1, outcome.updatedSlugCount)
+}
+
 func TestApplyUpdateAllForSlugs_ContinuesOnDownloadError(t *testing.T) {
 	oldResolve := resolveLatestPluginVersion
 	oldUpdate := updateSlugAcrossTargetsFn
@@ -260,7 +300,7 @@ func TestApplyUpdateAllForSlugs_ContinuesOnDownloadError(t *testing.T) {
 	resolveLatestPluginVersion = func(*config.ServerDetails, string, string) (string, error) {
 		return "2.0.0", nil
 	}
-	updateSlugAcrossTargetsFn = func(opts updateOptions, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
+	updateSlugAcrossTargetsFn = func(opts update, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
 		if slug == "bad" {
 			return nil, errors.New("download failed")
 		}
@@ -274,7 +314,7 @@ func TestApplyUpdateAllForSlugs_ContinuesOnDownloadError(t *testing.T) {
 		Scope:          plugincommon.ScopeProject,
 		DestinationDir: "/tmp/bad",
 	}
-	opts := updateOptions{serverDetails: &config.ServerDetails{}, repoKey: "repo"}
+	opts := update{serverDetails: &config.ServerDetails{}, repoKey: "repo"}
 	combined, outcome := applyUpdateAllForSlugs(opts, []string{"bad", "good"}, map[string][]plugincommon.AgentTarget{
 		"bad":  {target},
 		"good": {{Agent: plugincommon.AgentSpec{Name: "cursor"}, Scope: plugincommon.ScopeProject, DestinationDir: "/tmp/good"}},
@@ -288,13 +328,13 @@ func TestApplyUpdateAllForSlugs_ContinuesOnDownloadError(t *testing.T) {
 	assert.Equal(t, 2, outcome.updatedSlugCount)
 }
 
-func TestMovePluginAsideForUpdate_MissingInstallDir(t *testing.T) {
+func TestCreatePluginBackupForUpdate_MissingInstallDir(t *testing.T) {
 	target := plugincommon.AgentTarget{
 		Agent:          plugincommon.AgentSpec{Name: "cursor"},
 		Scope:          plugincommon.ScopeProject,
 		DestinationDir: filepath.Join(t.TempDir(), "missing"),
 	}
-	_, err := movePluginAsideForUpdate(target)
+	_, err := createPluginBackupForUpdate(target)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "move current plugin aside")
 }
@@ -304,12 +344,12 @@ func TestRestorePluginFromBackup_RestoresPreviousInstall(t *testing.T) {
 	live := filepath.Join(parent, "web")
 	backup := filepath.Join(parent, ".plugin-backup", "web-backup-test")
 
-	require.NoError(t, os.MkdirAll(live, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(live, "plugin.json"), []byte(`{"name":"web","version":"1.0.0"}`), 0o644))
-	require.NoError(t, os.MkdirAll(backup, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(backup, "plugin.json"), []byte(`{"name":"web","version":"0.9.0"}`), 0o644))
+	require.NoError(t, os.MkdirAll(live, agentcommon.InstallDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(live, "plugin.json"), []byte(`{"name":"web","version":"1.0.0"}`), agentcommon.DefaultFileMode))
+	require.NoError(t, os.MkdirAll(backup, agentcommon.InstallDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(backup, "plugin.json"), []byte(`{"name":"web","version":"0.9.0"}`), agentcommon.DefaultFileMode))
 
-	require.NoError(t, os.MkdirAll(filepath.Join(live, "failed-copy"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(live, "failed-copy"), agentcommon.InstallDirMode))
 
 	target := plugincommon.AgentTarget{DestinationDir: live}
 	require.NoError(t, restorePluginFromBackup(target, backup))
@@ -321,11 +361,62 @@ func TestRestorePluginFromBackup_RestoresPreviousInstall(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-func TestRunUpdate_RequiresArgWithoutAll(t *testing.T) {
+func TestConfirmUpdateAll_SkipsWhenDryRun(t *testing.T) {
+	require.NoError(t, confirmUpdateAll(update{dryRun: true}))
+}
+
+func TestConfirmUpdateAll_SkipsWhenQuiet(t *testing.T) {
+	require.NoError(t, confirmUpdateAll(update{quiet: true}))
+}
+
+func TestConfirmUpdateAll_SkipsWhenNonInteractive(t *testing.T) {
+	oldCheck := isNonInteractive
+	defer func() { isNonInteractive = oldCheck }()
+	isNonInteractive = func() bool { return true }
+
+	require.NoError(t, confirmUpdateAll(update{}))
+}
+
+func TestConfirmUpdateAll_AbortsWhenUserDeclines(t *testing.T) {
+	oldAsk := askYesNo
+	oldCheck := isNonInteractive
+	defer func() {
+		askYesNo = oldAsk
+		isNonInteractive = oldCheck
+	}()
+	isNonInteractive = func() bool { return false }
+	askYesNo = func(_ string, _ bool) bool { return false }
+
+	err := confirmUpdateAll(update{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aborted by user")
+}
+
+func TestConfirmUpdateAll_ContinuesWhenUserAccepts(t *testing.T) {
+	oldAsk := askYesNo
+	oldCheck := isNonInteractive
+	defer func() {
+		askYesNo = oldAsk
+		isNonInteractive = oldCheck
+	}()
+	isNonInteractive = func() bool { return false }
+	askYesNo = func(_ string, _ bool) bool { return true }
+
+	require.NoError(t, confirmUpdateAll(update{}))
+}
+
+func TestRunUpdate_RequiresSlugWithoutAll(t *testing.T) {
 	ctx := newUpdateContext(t, nil, map[string]string{"harness": "claude"}, nil)
 	err := RunUpdate(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "usage:")
+}
+
+func TestRunUpdate_RejectsPositionalSlug(t *testing.T) {
+	ctx := newUpdateContext(t, []string{"web"}, map[string]string{"harness": "claude"}, nil)
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use --slug")
 }
 
 func newUpdateContext(t *testing.T, args []string, stringFlags map[string]string, boolFlags map[string]bool) *components.Context {
@@ -345,7 +436,7 @@ func pluginDir(t *testing.T, manifest string) string {
 	t.Helper()
 	base := t.TempDir()
 	dir := filepath.Join(base, "web")
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644))
+	require.NoError(t, os.MkdirAll(dir, agentcommon.InstallDirMode))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), agentcommon.DefaultFileMode))
 	return dir
 }

--- a/agent/plugins/commands/update/update_test.go
+++ b/agent/plugins/commands/update/update_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
 	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -188,6 +189,136 @@ func TestRunUpdate_AllRejectsPath(t *testing.T) {
 	err := RunUpdate(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--all cannot be combined with --path")
+}
+
+func TestDiscoverInstalledPluginTargets_MergesHarnesses(t *testing.T) {
+	projectRoot := t.TempDir()
+	pluginsDir := "plugins"
+	installRoot := filepath.Join(projectRoot, pluginsDir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(installRoot, "shared"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(installRoot, "shared", "plugin.json"), []byte(`{"name":"shared","version":"1.0.0"}`), 0o644))
+
+	flags := agentcommon.InstallFlagsResult{
+		Specs: []plugincommon.AgentSpec{
+			{Name: "cursor", Config: agentcommon.AgentConfig{ProjectDir: pluginsDir}},
+			{Name: "claude", Config: agentcommon.AgentConfig{ProjectDir: pluginsDir}},
+		},
+		ProjectDirAbs: projectRoot,
+	}
+
+	slugOrder, slugToTargets, err := discoverInstalledPluginTargets(flags)
+	require.NoError(t, err)
+	require.Equal(t, []string{"shared"}, slugOrder)
+	require.Len(t, slugToTargets["shared"], 2)
+}
+
+func TestDiscoverInstalledPluginTargets_PluginJSONOnly(t *testing.T) {
+	projectRoot := t.TempDir()
+	pluginsDir := "plugins"
+	installRoot := filepath.Join(projectRoot, pluginsDir)
+	pluginDir := filepath.Join(installRoot, "legacy")
+	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"legacy","version":"0.9.0"}`), 0o644))
+
+	flags := agentcommon.InstallFlagsResult{
+		Specs:         []plugincommon.AgentSpec{{Name: "cursor", Config: agentcommon.AgentConfig{ProjectDir: pluginsDir}}},
+		ProjectDirAbs: projectRoot,
+	}
+
+	slugOrder, _, err := discoverInstalledPluginTargets(flags)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"legacy"}, slugOrder)
+}
+
+func TestFinalizeUpdateAll_AllFailed(t *testing.T) {
+	combined := []agentcommon.UpdateAllSummaryRow{
+		{Agent: "cursor", Name: "a", Status: agentcommon.SummaryStatusFailed},
+	}
+	outcome := updateAllOutcome{anyFailed: true}
+	err := finalizeUpdateAll(combined, outcome, "table")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed for all targets")
+}
+
+func TestFinalizeUpdateAll_ReturnsFirstResolveErrWhenNothingUpdated(t *testing.T) {
+	resolveErr := errors.New("no versions in repo")
+	outcome := updateAllOutcome{firstResolveErr: resolveErr}
+	err := finalizeUpdateAll(nil, outcome, "table")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, resolveErr)
+}
+
+func TestApplyUpdateAllForSlugs_ContinuesOnDownloadError(t *testing.T) {
+	oldResolve := resolveLatestPluginVersion
+	oldUpdate := updateSlugAcrossTargetsFn
+	defer func() {
+		resolveLatestPluginVersion = oldResolve
+		updateSlugAcrossTargetsFn = oldUpdate
+	}()
+
+	resolveLatestPluginVersion = func(*config.ServerDetails, string, string) (string, error) {
+		return "2.0.0", nil
+	}
+	updateSlugAcrossTargetsFn = func(opts updateOptions, slug, targetVersion string, targets []plugincommon.AgentTarget) ([]agentcommon.SummaryRow, error) {
+		if slug == "bad" {
+			return nil, errors.New("download failed")
+		}
+		return []agentcommon.SummaryRow{
+			{Agent: targets[0].Agent.Name, Scope: string(targets[0].Scope), Path: targets[0].DestinationDir, Status: agentcommon.SummaryStatusOK},
+		}, nil
+	}
+
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "cursor"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: "/tmp/bad",
+	}
+	opts := updateOptions{serverDetails: &config.ServerDetails{}, repoKey: "repo"}
+	combined, outcome := applyUpdateAllForSlugs(opts, []string{"bad", "good"}, map[string][]plugincommon.AgentTarget{
+		"bad":  {target},
+		"good": {{Agent: plugincommon.AgentSpec{Name: "cursor"}, Scope: plugincommon.ScopeProject, DestinationDir: "/tmp/good"}},
+	})
+
+	require.Equal(t, 2, len(combined))
+	assert.Equal(t, agentcommon.SummaryStatusFailed, combined[0].Status)
+	assert.Equal(t, agentcommon.SummaryStatusOK, combined[1].Status)
+	assert.True(t, outcome.anyOK)
+	assert.True(t, outcome.anyFailed)
+	assert.Equal(t, 2, outcome.updatedSlugCount)
+}
+
+func TestMovePluginAsideForUpdate_MissingInstallDir(t *testing.T) {
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "cursor"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: filepath.Join(t.TempDir(), "missing"),
+	}
+	_, err := movePluginAsideForUpdate(target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "move current plugin aside")
+}
+
+func TestRestorePluginFromBackup_RestoresPreviousInstall(t *testing.T) {
+	parent := t.TempDir()
+	live := filepath.Join(parent, "web")
+	backup := filepath.Join(parent, ".plugin-backup", "web-backup-test")
+
+	require.NoError(t, os.MkdirAll(live, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(live, "plugin.json"), []byte(`{"name":"web","version":"1.0.0"}`), 0o644))
+	require.NoError(t, os.MkdirAll(backup, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(backup, "plugin.json"), []byte(`{"name":"web","version":"0.9.0"}`), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(live, "failed-copy"), 0o755))
+
+	target := plugincommon.AgentTarget{DestinationDir: live}
+	require.NoError(t, restorePluginFromBackup(target, backup))
+
+	data, err := os.ReadFile(filepath.Join(live, "plugin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "0.9.0")
+	_, err = os.Stat(backup)
+	require.True(t, os.IsNotExist(err))
 }
 
 func TestRunUpdate_RequiresArgWithoutAll(t *testing.T) {

--- a/agent/plugins/commands/update/update_test.go
+++ b/agent/plugins/commands/update/update_test.go
@@ -1,0 +1,220 @@
+package update
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
+	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReserveUpdateBackupPath(t *testing.T) {
+	base := t.TempDir()
+	p, err := reserveUpdateBackupPath(base, "plugin-a")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, pluginBackupDirName), filepath.Dir(p))
+	assert.Contains(t, filepath.Base(p), "plugin-a-backup-")
+	_, err = os.Stat(p)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "reserved path must not exist until rename")
+}
+
+func TestPreUpdateTargets_NotInstalled(t *testing.T) {
+	base := t.TempDir()
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "claude"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: filepath.Join(base, "missing"),
+	}
+	checks := preUpdateTargets([]plugincommon.AgentTarget{target}, "1.0.0", false, true)
+	require.Len(t, checks, 1)
+	assert.Contains(t, checks[0].failureReason, "not installed")
+}
+
+func TestPreUpdateTargets_UpToDate(t *testing.T) {
+	dir := pluginDir(t, `{"name":"web","version":"2.0.0"}`)
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "claude"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preUpdateTargets([]plugincommon.AgentTarget{target}, "2.0.0", false, true)
+	require.Len(t, checks, 1)
+	assert.True(t, checks[0].alreadyAtTargetVersion)
+	assert.Equal(t, "2.0.0", checks[0].installedVersion)
+}
+
+func TestPreUpdateTargets_UpToDate_UsesManifestVersion(t *testing.T) {
+	dir := pluginDir(t, `{"name":"web","version":"1.0.0"}`)
+	require.NoError(t, agentcommon.WriteInstallInfoManifest(dir, plugincommon.PluginInfoManifestFile, plugincommon.PluginInfoManifest{
+		Repo:             "r",
+		Slug:             "web",
+		InstalledVersion: "2.0.0",
+		Scope:            "project",
+		Agent:            "claude",
+	}))
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "claude"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preUpdateTargets([]plugincommon.AgentTarget{target}, "2.0.0", false, true)
+	require.Len(t, checks, 1)
+	assert.True(t, checks[0].alreadyAtTargetVersion)
+	assert.Equal(t, "2.0.0", checks[0].installedVersion)
+}
+
+func TestPreUpdateTargets_ForceOverridesUpToDate(t *testing.T) {
+	dir := pluginDir(t, `{"name":"web","version":"2.0.0"}`)
+	target := plugincommon.AgentTarget{
+		Agent:          plugincommon.AgentSpec{Name: "claude"},
+		Scope:          plugincommon.ScopeProject,
+		DestinationDir: dir,
+	}
+	checks := preUpdateTargets([]plugincommon.AgentTarget{target}, "2.0.0", true, true)
+	require.Len(t, checks, 1)
+	assert.False(t, checks[0].alreadyAtTargetVersion)
+}
+
+func TestInitialResultsAndUpdatable_Mixed(t *testing.T) {
+	checks := []preUpdate{
+		{agentTarget: plugincommon.AgentTarget{Agent: plugincommon.AgentSpec{Name: "a1"}, Scope: plugincommon.ScopeProject, DestinationDir: "/x/a1"}, failureReason: "not installed"},
+		{agentTarget: plugincommon.AgentTarget{Agent: plugincommon.AgentSpec{Name: "a2"}, Scope: plugincommon.ScopeProject, DestinationDir: "/x/a2"}, alreadyAtTargetVersion: true, installedVersion: "1.0.0"},
+		{agentTarget: plugincommon.AgentTarget{Agent: plugincommon.AgentSpec{Name: "a3"}, Scope: plugincommon.ScopeProject, DestinationDir: "/x/a3"}, installedVersion: "1.0.0"},
+	}
+	results, updatable := initialResultsAndUpdatable(checks, "2.0.0")
+	require.Len(t, results, 2)
+	require.Len(t, updatable, 1)
+	assert.Equal(t, agentcommon.SummaryStatusFailed, results[0].Status)
+	assert.Equal(t, agentcommon.SummaryStatusSkipped, results[1].Status)
+	assert.Equal(t, "a3", updatable[0].agentTarget.Agent.Name)
+}
+
+func TestFinalError_AllOK(t *testing.T) {
+	results := []agentcommon.SummaryRow{
+		{Status: agentcommon.SummaryStatusOK},
+		{Status: agentcommon.SummaryStatusSkipped},
+	}
+	require.NoError(t, finalError(results))
+}
+
+func TestFinalError_PartialSuccess(t *testing.T) {
+	results := []agentcommon.SummaryRow{
+		{Status: agentcommon.SummaryStatusFailed},
+		{Status: agentcommon.SummaryStatusOK},
+	}
+	require.NoError(t, finalError(results))
+}
+
+func TestFinalError_AllFailed(t *testing.T) {
+	results := []agentcommon.SummaryRow{
+		{Status: agentcommon.SummaryStatusFailed},
+		{Status: agentcommon.SummaryStatusFailed},
+	}
+	err := finalError(results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed for all targets")
+}
+
+func TestUpdateOnePlugin_SuccessRemovesBackup(t *testing.T) {
+	dir := pluginDir(t, `{"name":"web","version":"1.0.0"}`)
+	check := preUpdate{
+		agentTarget: plugincommon.AgentTarget{
+			Agent:          plugincommon.AgentSpec{Name: "claude"},
+			Scope:          plugincommon.ScopeProject,
+			DestinationDir: dir,
+		},
+		installedVersion: "1.0.0",
+	}
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "plugin.json"), []byte(`{"name":"web","version":"2.0.0"}`), 0o644))
+
+	installCommand := install.NewInstallCommand().SetSlug("web").SetVersion("2.0.0").SetRepoKey("r")
+	row := updateOnePlugin(src, installCommand, check)
+	assert.Equal(t, agentcommon.SummaryStatusOK, row.Status)
+	assert.Equal(t, agentcommon.SummaryDetailOKInstall, row.Detail)
+
+	entries, err := os.ReadDir(filepath.Dir(dir))
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.ElementsMatch(t, []string{"web"}, names)
+
+	backupRoot := filepath.Join(filepath.Dir(dir), pluginBackupDirName)
+	_, statErr := os.Stat(backupRoot)
+	require.Error(t, statErr)
+	assert.True(t, os.IsNotExist(statErr), pluginBackupDirName+" should be removed when empty after successful update")
+	data, err := os.ReadFile(filepath.Join(dir, "plugin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "2.0.0")
+}
+
+func TestResolveTargetVersion_ExplicitUsedDirectly(t *testing.T) {
+	got, err := resolveTargetVersion(nil, "repo", "slug", "1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3", got)
+}
+
+func TestResolveTargetVersion_RejectsInvalid(t *testing.T) {
+	_, err := resolveTargetVersion(nil, "repo", "slug", "not-a-version")
+	require.Error(t, err)
+}
+
+func TestRunUpdate_AllRejectsSlugArg(t *testing.T) {
+	ctx := newUpdateContext(t, []string{"web"}, map[string]string{"harness": "claude"}, map[string]bool{"all": true})
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with a slug argument")
+}
+
+func TestRunUpdate_AllRejectsVersion(t *testing.T) {
+	ctx := newUpdateContext(t, nil, map[string]string{"harness": "claude", "version": "1.2.3"}, map[string]bool{"all": true})
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with --version")
+}
+
+func TestRunUpdate_AllRejectsPath(t *testing.T) {
+	ctx := newUpdateContext(t, nil, map[string]string{"path": t.TempDir()}, map[string]bool{"all": true})
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with --path")
+}
+
+func TestRunUpdate_RequiresArgWithoutAll(t *testing.T) {
+	ctx := newUpdateContext(t, nil, map[string]string{"harness": "claude"}, nil)
+	err := RunUpdate(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "usage:")
+}
+
+func newUpdateContext(t *testing.T, args []string, stringFlags map[string]string, boolFlags map[string]bool) *components.Context {
+	t.Helper()
+	ctx := &components.Context{Arguments: args}
+	ctx.PrintCommandHelp = func(string) error { return nil }
+	for name, value := range stringFlags {
+		ctx.AddStringFlag(name, value)
+	}
+	for name, value := range boolFlags {
+		ctx.AddBoolFlag(name, value)
+	}
+	return ctx
+}
+
+func pluginDir(t *testing.T, manifest string) string {
+	t.Helper()
+	base := t.TempDir()
+	dir := filepath.Join(base, "web")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644))
+	return dir
+}

--- a/agent/plugins/common/metadata.go
+++ b/agent/plugins/common/metadata.go
@@ -24,6 +24,10 @@ const manifestJSONIndent = "    "
 // not pass --version.
 const defaultPluginVersion = "1.0.0"
 
+// ErrPluginManifestNotFound is returned when no plugin.json could be located in any of
+// the searched paths under a plugin directory.
+var ErrPluginManifestNotFound = errors.New("no plugin.json")
+
 // knownManifestRelPaths lists the built-in relative locations checked for plugin.json.
 // agent-config.json "plugin-manifest-paths" entries are prepended (higher priority);
 // defaults fill in any path not already listed. The first existing file wins.
@@ -123,7 +127,7 @@ func findPrimaryPluginManifest(pluginRoot string) (relativePath string, meta Plu
 func pluginManifestNotFoundError(pluginRoot string, relPaths []string) error {
 	configPath := agentcommon.AgentConfigPathForDisplay()
 	return fmt.Errorf(
-		"no %s found under %s (checked: %s).\n\n"+
+		"%w found under %s (checked: %s).\n\n"+
 			"To search additional locations, edit %s and add relative paths under %q "+
 			"(paths are relative to the plugin directory). Custom paths are checked first, "+
 			"then built-in defaults.\n\n"+
@@ -133,7 +137,7 @@ func pluginManifestNotFoundError(pluginRoot string, relPaths []string) error {
 			"      \"my-layout/%s\"\n"+
 			"    ]\n"+
 			"  }",
-		manifestFileName,
+		ErrPluginManifestNotFound,
 		pluginRoot,
 		strings.Join(relPaths, ", "),
 		configPath,

--- a/agent/plugins/common/plugin_info_meta.go
+++ b/agent/plugins/common/plugin_info_meta.go
@@ -40,16 +40,21 @@ func ReadInstalledPluginVersion(pluginDir string) (string, error) {
 }
 
 // DiscoverInstalledPluginSlugs returns sorted plugin directory names under installDir that
-// ReadInstalledPluginVersion recognizes (plugin-info.json and/or plugin.json), matching
-// single-slug update rather than manifest-only discovery.
+// ReadInstalledPluginVersion recognizes (plugin-info.json and/or plugin.json).
+// The directory name is the slug used for Artifactory, matching update --slug behavior.
 func DiscoverInstalledPluginSlugs(installDir string) ([]string, error) {
-	entries, err := os.ReadDir(installDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read install dir %s: %w", installDir, err)
+	entries, readErr := os.ReadDir(installDir)
+	if readErr != nil && errors.Is(readErr, os.ErrNotExist) {
+		return nil, nil
 	}
+	slugs := pluginSlugsFromInstallDirEntries(installDir, entries)
+	if readErr != nil {
+		return slugs, fmt.Errorf("read install dir %s: %w", installDir, readErr)
+	}
+	return slugs, nil
+}
+
+func pluginSlugsFromInstallDirEntries(installDir string, entries []os.DirEntry) []string {
 	slugs := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -66,5 +71,5 @@ func DiscoverInstalledPluginSlugs(installDir string) ([]string, error) {
 		slugs = append(slugs, name)
 	}
 	sort.Strings(slugs)
-	return slugs, nil
+	return slugs
 }

--- a/agent/plugins/common/plugin_info_meta.go
+++ b/agent/plugins/common/plugin_info_meta.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// ReadInstalledPluginVersion returns the version string for an installed plugin directory.
+// It prefers .jfrog/plugin-info.json (installedVersion) when present and non-empty,
+// otherwise falls back to the version from plugin.json.
+// Returns an error wrapping os.ErrNotExist when the install directory or plugin.json
+// is missing, so callers can use errors.Is(err, fs.ErrNotExist) to detect "not installed".
+func ReadInstalledPluginVersion(pluginDir string) (string, error) {
+	manifest, err := agentcommon.ReadInstallInfoManifest(pluginDir, PluginInfoManifestFile)
+	if err != nil {
+		log.Warn(fmt.Sprintf("Invalid plugin-info manifest under %s (%v); using plugin.json for installed version.", pluginDir, err))
+	} else if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
+		return strings.TrimSpace(manifest.InstalledVersion), nil
+	}
+
+	if _, statErr := os.Stat(pluginDir); statErr != nil {
+		return "", statErr
+	}
+
+	_, meta, err := findPrimaryPluginManifest(pluginDir)
+	if err != nil {
+		if errors.Is(err, ErrPluginManifestNotFound) {
+			return "", fmt.Errorf("%w: %s", os.ErrNotExist, err.Error())
+		}
+		return "", err
+	}
+	return strings.TrimSpace(meta.Version), nil
+}

--- a/agent/plugins/common/plugin_info_meta.go
+++ b/agent/plugins/common/plugin_info_meta.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
@@ -35,4 +37,34 @@ func ReadInstalledPluginVersion(pluginDir string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(meta.Version), nil
+}
+
+// DiscoverInstalledPluginSlugs returns sorted plugin directory names under installDir that
+// ReadInstalledPluginVersion recognizes (plugin-info.json and/or plugin.json), matching
+// single-slug update rather than manifest-only discovery.
+func DiscoverInstalledPluginSlugs(installDir string) ([]string, error) {
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read install dir %s: %w", installDir, err)
+	}
+	slugs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		pluginDir := filepath.Join(installDir, name)
+		if _, err := ReadInstalledPluginVersion(pluginDir); err != nil {
+			continue
+		}
+		slugs = append(slugs, name)
+	}
+	sort.Strings(slugs)
+	return slugs, nil
 }

--- a/agent/plugins/common/plugin_info_meta_test.go
+++ b/agent/plugins/common/plugin_info_meta_test.go
@@ -82,7 +82,7 @@ func TestReadInstalledPluginVersion_CorruptManifestFallsBackToPluginJSON(t *test
 
 func TestDiscoverInstalledPluginSlugs_MatchesReadInstalledPluginVersion(t *testing.T) {
 	base := t.TempDir()
-	_ = makePluginDirInRoot(t, base, "alpha", `{"name":"alpha","version":"1.0.0"}`)
+	makePluginDirInRoot(t, base, "alpha", `{"name":"alpha","version":"1.0.0"}`)
 
 	betaDir := filepath.Join(base, "beta")
 	manifestDir := filepath.Join(betaDir, ".jfrog")
@@ -100,19 +100,18 @@ func TestDiscoverInstalledPluginSlugs_MatchesReadInstalledPluginVersion(t *testi
 func TestDiscoverInstalledPluginSlugs_SortsOutput(t *testing.T) {
 	base := t.TempDir()
 	for _, slug := range []string{"zeta", "alpha"} {
-		_ = makePluginDirInRoot(t, base, slug, fmt.Sprintf(`{"name":%q,"version":"1.0.0"}`, slug))
+		makePluginDirInRoot(t, base, slug, fmt.Sprintf(`{"name":%q,"version":"1.0.0"}`, slug))
 	}
 	got, err := DiscoverInstalledPluginSlugs(base)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alpha", "zeta"}, got)
 }
 
-func makePluginDirInRoot(t *testing.T, root, slug, manifest string) string {
+func makePluginDirInRoot(t *testing.T, root, slug, manifest string) {
 	t.Helper()
 	dir := filepath.Join(root, slug)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644))
-	return dir
 }
 
 func makePluginDir(t *testing.T, manifest string) string {

--- a/agent/plugins/common/plugin_info_meta_test.go
+++ b/agent/plugins/common/plugin_info_meta_test.go
@@ -1,0 +1,88 @@
+package common
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInstalledPluginVersion_PrefersManifest(t *testing.T) {
+	dir := makePluginDir(t, `{"name":"web","version":"1.0.0"}`)
+	require.NoError(t, agentcommon.WriteInstallInfoManifest(dir, PluginInfoManifestFile, PluginInfoManifest{
+		Repo:             "r",
+		Slug:             "web",
+		InstalledVersion: "2.0.0",
+		Scope:            "project",
+		Agent:            "claude",
+	}))
+	v, err := ReadInstalledPluginVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", v)
+}
+
+func TestReadInstalledPluginVersion_FallsBackToPluginJSON(t *testing.T) {
+	dir := makePluginDir(t, `{"name":"web","version":"1.2.3"}`)
+	v, err := ReadInstalledPluginVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3", v)
+}
+
+func TestReadInstalledPluginVersion_ManifestEmptyUsesPluginJSON(t *testing.T) {
+	dir := makePluginDir(t, `{"name":"web","version":"1.0.0"}`)
+	require.NoError(t, agentcommon.WriteInstallInfoManifest(dir, PluginInfoManifestFile, PluginInfoManifest{
+		Repo:             "r",
+		Slug:             "web",
+		InstalledVersion: "",
+		Scope:            "project",
+		Agent:            "claude",
+	}))
+	v, err := ReadInstalledPluginVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", v)
+}
+
+func TestReadInstalledPluginVersion_NoVersionField(t *testing.T) {
+	dir := makePluginDir(t, `{"name":"web"}`)
+	v, err := ReadInstalledPluginVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "", v)
+}
+
+func TestReadInstalledPluginVersion_NotInstalled(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-plugin")
+	_, err := ReadInstalledPluginVersion(missing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "expected fs.ErrNotExist, got %v", err)
+}
+
+func TestReadInstalledPluginVersion_DirWithoutManifest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "empty")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	_, err := ReadInstalledPluginVersion(dir)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "expected fs.ErrNotExist, got %v", err)
+}
+
+func TestReadInstalledPluginVersion_CorruptManifestFallsBackToPluginJSON(t *testing.T) {
+	dir := makePluginDir(t, `{"name":"web","version":"3.4.5"}`)
+	manifestDir := filepath.Join(dir, ".jfrog")
+	require.NoError(t, os.MkdirAll(manifestDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, PluginInfoManifestFile), []byte("not json"), 0o644))
+	v, err := ReadInstalledPluginVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "3.4.5", v)
+}
+
+func makePluginDir(t *testing.T, manifest string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "web")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644))
+	return dir
+}

--- a/agent/plugins/common/plugin_info_meta_test.go
+++ b/agent/plugins/common/plugin_info_meta_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -77,6 +78,41 @@ func TestReadInstalledPluginVersion_CorruptManifestFallsBackToPluginJSON(t *test
 	v, err := ReadInstalledPluginVersion(dir)
 	require.NoError(t, err)
 	assert.Equal(t, "3.4.5", v)
+}
+
+func TestDiscoverInstalledPluginSlugs_MatchesReadInstalledPluginVersion(t *testing.T) {
+	base := t.TempDir()
+	_ = makePluginDirInRoot(t, base, "alpha", `{"name":"alpha","version":"1.0.0"}`)
+
+	betaDir := filepath.Join(base, "beta")
+	manifestDir := filepath.Join(betaDir, ".jfrog")
+	require.NoError(t, os.MkdirAll(manifestDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, PluginInfoManifestFile), []byte(`{"installedVersion":"1.0.0"}`), 0o644))
+
+	empty := filepath.Join(base, "gamma")
+	require.NoError(t, os.MkdirAll(empty, 0o755))
+
+	got, err := DiscoverInstalledPluginSlugs(base)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "beta"}, got)
+}
+
+func TestDiscoverInstalledPluginSlugs_SortsOutput(t *testing.T) {
+	base := t.TempDir()
+	for _, slug := range []string{"zeta", "alpha"} {
+		_ = makePluginDirInRoot(t, base, slug, fmt.Sprintf(`{"name":%q,"version":"1.0.0"}`, slug))
+	}
+	got, err := DiscoverInstalledPluginSlugs(base)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "zeta"}, got)
+}
+
+func makePluginDirInRoot(t *testing.T, root, slug, manifest string) string {
+	t.Helper()
+	dir := filepath.Join(root, slug)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(manifest), 0o644))
+	return dir
 }
 
 func makePluginDir(t *testing.T, manifest string) string {

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -514,6 +514,7 @@ const (
 	// Agent plugin commands keys
 	AgentPluginsPublish = "agent-plugins-publish"
 	AgentPluginsInstall = "agent-plugins-install"
+	AgentPluginsUpdate  = "agent-plugins-update"
 
 	// Agent namespace-specific flags (shared by skills and agent-plugins commands)
 	version    = "version"
@@ -522,6 +523,7 @@ const (
 	// Skills-specific flags
 	installPath         = "path"
 	agentForce          = "force"
+	agentAll            = "all"
 	signingKey          = "signing-key"
 	keyAlias            = "key-alias"
 	propSearch          = "prop"
@@ -887,6 +889,9 @@ var commandFlags = map[string][]string{
 	AgentPluginsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
 	},
+	AgentPluginsUpdate: {
+		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet, dryRun, agentForce, agentAll,
+	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
 	},
@@ -1211,6 +1216,7 @@ var flagsMap = map[string]components.Flag{
 	// Skills-specific flags
 	installPath:         components.NewStringFlag(installPath, "Base directory for a direct install or update: files go under <path>/<slug>. Mutually exclusive with --harness, --project-dir, and --global.", components.SetMandatoryFalse()),
 	agentForce:          components.NewBoolFlag(agentForce, "Re-download and reinstall even if the skill is already at the target version.", components.WithBoolDefaultValueFalse()),
+	agentAll:            components.NewBoolFlag(agentAll, "Update every installed plugin for the given --harness list to its latest version. Mutually exclusive with a slug argument, --version, and --path.", components.WithBoolDefaultValueFalse()),
 	signingKey:          components.NewStringFlag(signingKey, "Path to PGP private key for signing evidence. Overrides EVD_SIGNING_KEY_PATH env var.", components.SetMandatoryFalse()),
 	keyAlias:            components.NewStringFlag(keyAlias, "Alias for the signing key. Overrides EVD_KEY_ALIAS env var.", components.SetMandatoryFalse()),
 	agentFormat:         components.NewStringFlag(Format, "Output format: \"table\" (default) or \"json\".", components.SetMandatoryFalse()),

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -524,6 +524,7 @@ const (
 	installPath         = "path"
 	agentForce          = "force"
 	agentAll            = "all"
+	agentSlug           = "slug"
 	signingKey          = "signing-key"
 	keyAlias            = "key-alias"
 	propSearch          = "prop"
@@ -890,7 +891,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
 	},
 	AgentPluginsUpdate: {
-		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet, dryRun, agentForce, agentAll,
+		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet, dryRun, agentForce, agentAll, agentSlug,
 	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,
@@ -1216,7 +1217,8 @@ var flagsMap = map[string]components.Flag{
 	// Skills-specific flags
 	installPath:         components.NewStringFlag(installPath, "Base directory for a direct install or update: files go under <path>/<slug>. Mutually exclusive with --harness, --project-dir, and --global.", components.SetMandatoryFalse()),
 	agentForce:          components.NewBoolFlag(agentForce, "Re-download and reinstall even if the skill is already at the target version.", components.WithBoolDefaultValueFalse()),
-	agentAll:            components.NewBoolFlag(agentAll, "Update every installed plugin for the given --harness list to its latest version. Mutually exclusive with a slug argument, --version, and --path.", components.WithBoolDefaultValueFalse()),
+	agentAll:            components.NewBoolFlag(agentAll, "Update every installed plugin for the given --harness list to its latest version. Mutually exclusive with --slug, --version, and --path.", components.WithBoolDefaultValueFalse()),
+	agentSlug:           components.NewStringFlag(agentSlug, "Slug (name) of the plugin to update. Required unless --all is set.", components.SetMandatoryFalse()),
 	signingKey:          components.NewStringFlag(signingKey, "Path to PGP private key for signing evidence. Overrides EVD_SIGNING_KEY_PATH env var.", components.SetMandatoryFalse()),
 	keyAlias:            components.NewStringFlag(keyAlias, "Alias for the signing key. Overrides EVD_KEY_ALIAS env var.", components.SetMandatoryFalse()),
 	agentFormat:         components.NewStringFlag(Format, "Output format: \"table\" (default) or \"json\".", components.SetMandatoryFalse()),


### PR DESCRIPTION
- New update command with --all, --dry-run, --force, --path
- Latest version from Artifactory per plugin
- Combined --all summary table with plugin name column
- plugin-info.json helpers and DiscoverInstalledSlugs

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
