### PR TITLE
RTECO-1270 - Add backward compatability for skills

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	agentCLI "github.com/jfrog/jfrog-cli-artifactory/agent/cli"
+	skillsCLI "github.com/jfrog/jfrog-cli-artifactory/agent/skills/cli"
 	artifactoryCLI "github.com/jfrog/jfrog-cli-artifactory/artifactory/cli"
 	distributionCLI "github.com/jfrog/jfrog-cli-artifactory/distribution/cli"
 	ideCLI "github.com/jfrog/jfrog-cli-artifactory/ide/cli"
@@ -37,6 +38,13 @@ func GetJfrogCliArtifactoryApp() components.App {
 		Name:        "agent",
 		Description: "Agent commands.",
 		Commands:    agentCLI.GetCommands(),
+		Category:    "Command Namespaces",
+	})
+	app.Subcommands = append(app.Subcommands, components.Namespace{
+		Name:        "skills",
+		Aliases:     []string{"skill"},
+		Description: "Agent skill commands (same as jf agent skills).",
+		Commands:    skillsCLI.GetSubCommands(),
 		Category:    "Command Namespaces",
 	})
 	app.Commands = append(app.Commands, lifecycle.GetCommands()...)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetJfrogCliArtifactoryApp(t *testing.T) {
@@ -21,14 +22,35 @@ func TestGetJfrogCliArtifactoryApp(t *testing.T) {
 	}
 }
 
-func TestGetJfrogCliArtifactoryApp_NoTopLevelSkillsNamespace(t *testing.T) {
+func TestGetJfrogCliArtifactoryApp_TopLevelSkillsNamespace(t *testing.T) {
 	app := GetJfrogCliArtifactoryApp()
-	for _, ns := range app.Subcommands {
-		assert.NotEqual(t, "skills", ns.Name, "top-level 'skills' namespace must be removed; use 'jf agent skills' instead")
-		for _, alias := range ns.Aliases {
-			assert.NotEqual(t, "skill", alias, "'skill' alias must be removed")
-		}
+
+	skillsNS := findNamespaceByName(app.Subcommands, "skills")
+	require.NotNil(t, skillsNS, "top-level 'skills' namespace should exist for backward compatibility")
+	require.Equal(t, []string{"skill"}, skillsNS.Aliases)
+
+	agentNS := findNamespaceByName(app.Subcommands, "agent")
+	require.NotNil(t, agentNS)
+	agentSkills := findCommandByName(agentNS.Commands, "skills")
+	require.NotNil(t, agentSkills)
+
+	want := []string{"list", "publish", "install", "update", "search", "delete"}
+	topLevel := commandNames(skillsNS.Commands)
+	agentLevel := commandNames(agentSkills.Subcommands)
+	require.Equal(t, want, topLevel)
+	require.Equal(t, want, agentLevel)
+	for i := range want {
+		require.NotNil(t, skillsNS.Commands[i].Action)
+		require.NotNil(t, agentSkills.Subcommands[i].Action)
 	}
+}
+
+func commandNames(commands []components.Command) []string {
+	names := make([]string, 0, len(commands))
+	for _, cmd := range commands {
+		names = append(names, cmd.Name)
+	}
+	return names
 }
 
 // Helper function to find a command by name


### PR DESCRIPTION
Adding backward compatability for skills
- Now both jf agent skills and jf skills work


- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
