### PR TITLE
RTECO-1079 - Remove updating plugins during publish

### DIFF
--- a/agent/plugins/commands/publish/publish.go
+++ b/agent/plugins/commands/publish/publish.go
@@ -101,19 +101,6 @@ func (pc *PublishCommand) Run() error {
 		return err
 	}
 
-	// Update plugin.json on disk before zipping, matching jf agent skills publish (SKILL.md is updated
-	// before zip there too). If a later step fails, the manifest stays at the new version; skills
-	// publish behaves the same way and does not roll back.
-	if meta.ManifestVersion != "" && meta.ManifestVersion != version {
-		log.Info(fmt.Sprintf(
-			"Updating plugin.json on disk from '%s' to '%s' before publish",
-			meta.ManifestVersion, version,
-		))
-		if err := plugincommon.UpdatePluginManifestVersions(pc.pluginDir, version); err != nil {
-			return fmt.Errorf("failed to update plugin.json version: %w", err)
-		}
-	}
-
 	log.Info(fmt.Sprintf("Publishing plugin '%s' version '%s'", slug, version))
 
 	zipPath, sha256Hex, zipTmpDir, _, err := pc.resolveZip(slug, version)

--- a/agent/plugins/common/metadata_test.go
+++ b/agent/plugins/common/metadata_test.go
@@ -232,7 +232,7 @@ func TestValidateSlug(t *testing.T) {
 	}
 }
 
-func TestUpdatePluginManifestVersions_BeforePublishOrder(t *testing.T) {
+func TestUpdatePluginManifestVersions_UpdatesPrimaryManifest(t *testing.T) {
 	dir := t.TempDir()
 	writePluginJSON(t, dir, "plugin.json", map[string]string{"name": "demo", "version": "1.0.0"})
 
@@ -259,7 +259,7 @@ func TestUpdatePluginManifestVersions_BeforePublishOrder(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 	if doc["version"] != "1.0.2" {
-		t.Fatalf("version on disk = %q, want 1.0.2 before zip/publish", doc["version"])
+		t.Fatalf("version on disk = %q, want 1.0.2", doc["version"])
 	}
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----

### Summary:
Earlier we used to update plugin.json with version that we are publishing.
We should not do it, as there can be many plugin.json files, which cause inconsistent values in different files