### PR TITLE
RTECO-1079 - Consistent plugin identification

### DIFF
--- a/agent/plugins/commands/list/list.go
+++ b/agent/plugins/commands/list/list.go
@@ -257,10 +257,11 @@ func (lc *ListCommand) buildPluginRowsForHarness(registry map[string]agentcommon
 	return rows, nil
 }
 
-// buildRowForPlugin reads plugin.json and install manifest for a single plugin directory.
-// Returns (row, true) on success, (zero, false) if the plugin should be skipped.
+// buildRowForPlugin builds one local list row. Inclusion and installed version match update:
+// ReadInstalledPluginVersion (plugin-info.json, then plugin.json). Description comes from
+// plugin.json when present.
 func (lc *ListCommand) buildRowForPlugin(pluginDir, name, projectDir string) (localListRow, bool) {
-	meta, err := pluginscommon.ReadPluginMeta(pluginDir)
+	installedVer, err := pluginscommon.ReadInstalledPluginVersion(pluginDir)
 	if err != nil {
 		log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", name, err.Error()))
 		return localListRow{}, false
@@ -276,15 +277,18 @@ func (lc *ListCommand) buildRowForPlugin(pluginDir, name, projectDir string) (lo
 	if manifest != nil && strings.TrimSpace(manifest.Repo) != "" {
 		repo = manifest.Repo
 	}
-	installedVer := strings.TrimSpace(meta.Version)
-	if manifest != nil && strings.TrimSpace(manifest.InstalledVersion) != "" {
-		installedVer = strings.TrimSpace(manifest.InstalledVersion)
+
+	description := ""
+	if meta, metaErr := pluginscommon.ReadPluginMeta(pluginDir); metaErr != nil {
+		log.Warn(fmt.Sprintf("Plugin '%s': could not read plugin.json (%s)", name, metaErr.Error()))
+	} else {
+		description = meta.Description
 	}
 
 	row := localListRow{
 		Name:        name,
 		Version:     installedVer,
-		Description: meta.Description,
+		Description: description,
 		Repo:        repo,
 		Path:        pluginDisplayPath(pluginDir, projectDir, lc.global),
 	}

--- a/agent/plugins/commands/list/list_test.go
+++ b/agent/plugins/commands/list/list_test.go
@@ -1,9 +1,14 @@
 package list
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListCommand_NoMode(t *testing.T) {
@@ -25,6 +30,32 @@ func TestListCommand_GlobalAndProjectDir(t *testing.T) {
 	err := cmd.Run()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestBuildRowForPlugin_ManifestOnlyMatchesUpdate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "web")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".jfrog"), 0o755))
+	require.NoError(t, agentcommon.WriteInstallInfoManifest(dir, plugincommon.PluginInfoManifestFile, plugincommon.PluginInfoManifest{
+		Repo:             "plugins-local",
+		Slug:             "web",
+		InstalledVersion: "2.0.0",
+		Scope:            "global",
+		Agent:            "claude",
+	}))
+
+	row, ok := (&ListCommand{}).buildRowForPlugin(dir, "web", "")
+	require.True(t, ok)
+	assert.Equal(t, "2.0.0", row.Version)
+	assert.Equal(t, "plugins-local", row.Repo)
+	assert.Empty(t, row.Description)
+}
+
+func TestBuildRowForPlugin_SkipsWhenNotInstalled(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cache")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	_, ok := (&ListCommand{}).buildRowForPlugin(dir, "cache", "")
+	assert.False(t, ok)
 }
 
 func TestListCommand_CheckUpdatesWithRepo(t *testing.T) {

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -354,13 +354,12 @@ func preUpdateTargets(targets []plugincommon.AgentTarget, targetVersion string, 
 		preUpdateCheck := preUpdate{agentTarget: agentTarget}
 		installedVersion, err := plugincommon.ReadInstalledPluginVersion(agentTarget.DestinationDir)
 		if err != nil {
+			slug := filepath.Base(agentTarget.DestinationDir)
+			log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", slug, err.Error()))
 			if errors.Is(err, fs.ErrNotExist) {
 				preUpdateCheck.failureReason = fmt.Sprintf("plugin not installed at %s; run 'jf agent plugins install' first", agentTarget.DestinationDir)
 			} else {
 				preUpdateCheck.failureReason = err.Error()
-			}
-			if !quiet {
-				log.Info(fmt.Sprintf("Skipping update for agent %s at %s: %s", agentTarget.Agent.Name, agentTarget.DestinationDir, preUpdateCheck.failureReason))
 			}
 			checks = append(checks, preUpdateCheck)
 			continue

--- a/agent/plugins/common/plugin_info_meta.go
+++ b/agent/plugins/common/plugin_info_meta.go
@@ -66,6 +66,7 @@ func pluginSlugsFromInstallDirEntries(installDir string, entries []os.DirEntry) 
 		}
 		pluginDir := filepath.Join(installDir, name)
 		if _, err := ReadInstalledPluginVersion(pluginDir); err != nil {
+			log.Warn(fmt.Sprintf("Skipping plugin '%s': %s", name, err.Error()))
 			continue
 		}
 		slugs = append(slugs, name)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary:

In plugins update
 - for --all, if we don't find plugins.json, plugin-info.json, we will skip that folder & inform the use that we couldn't find plugin.json, so we are not considering that folder as plugin
 - for --slug <slug_name> , same as above

- for both list & update, we are maintaining consistent behaviour, first we check .jfrog/plugin-info.json, fall back to plugin.json