### PR TITLE
RTECO-1079 - Implement search for plugins

### DIFF
--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -19,7 +19,7 @@ func TestGetCommands_HasPluginsAndSkillsNamespaces(t *testing.T) {
 		assert.NotNil(t, sub.Action, "plugins subcommand %q must have an Action", sub.Name)
 		pluginsNames = append(pluginsNames, sub.Name)
 	}
-	assert.ElementsMatch(t, []string{"publish", "install", "update", "delete", "list"}, pluginsNames)
+	assert.ElementsMatch(t, []string{"publish", "install", "update", "delete", "list", "search"}, pluginsNames)
 
 	skills := commands[1]
 	assert.Equal(t, "skills", skills.Name)

--- a/agent/common/property_search.go
+++ b/agent/common/property_search.go
@@ -10,10 +10,19 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
+
+// artifactoryPropertySearchAPI is the Artifactory REST path for GET property search.
+// See https://jfrog.com/help/r/jfrog-rest-apis/property-search
+const artifactoryPropertySearchAPI = "api/search/prop"
+
+// artifactoryStorageURIInfix is the "/api/storage/" segment in item URIs returned by property search.
+// Built from jfrog-client-go StorageRestApi (Artifactory Storage REST API path).
+const artifactoryStorageURIInfix = "/" + services.StorageRestApi
 
 // PropertySearchResult is one artifact hit from Artifactory GET api/search/prop.
 type PropertySearchResult struct {
@@ -38,19 +47,35 @@ type propSearchResultItem struct {
 	URI string `json:"uri"`
 }
 
+// HTTP client settings for property search: same defaults as jfrog-client-go config.NewConfigBuilder
+// (3 retries, 0 ms retry wait) and standard CLI lightweight API calls via utils.CreateServiceManager.
+const (
+	propertySearchHTTPRetries            = 3
+	propertySearchHTTPRetryWaitMilliSecs = 0
+)
+
+func createPropertySearchServiceManager(serverDetails *config.ServerDetails) (artifactory.ArtifactoryServicesManager, error) {
+	return utils.CreateServiceManager(
+		serverDetails,
+		propertySearchHTTPRetries,
+		propertySearchHTTPRetryWaitMilliSecs,
+		false,
+	)
+}
+
 // SearchByProperty calls GET api/search/prop?{namePropertyKey}={query}[&repos={repoKey}].
 func SearchByProperty(serverDetails *config.ServerDetails, opts PropertySearchOptions) ([]PropertySearchResult, error) {
 	query, err := validatePropertySearchOpts(opts)
 	if err != nil {
 		return nil, err
 	}
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := createPropertySearchServiceManager(serverDetails)
 	if err != nil {
 		return nil, err
 	}
-	artURL := clientutils.AddTrailingSlashIfNeeded(sm.GetConfig().GetServiceDetails().GetUrl())
+	artURL := clientutils.AddTrailingSlashIfNeeded(serviceManager.GetConfig().GetServiceDetails().GetUrl())
 	searchURL := propertySearchRequestURL(artURL, opts, query)
-	uris, err := fetchPropertySearchURIs(sm, searchURL)
+	uris, err := fetchPropertySearchURIs(serviceManager, searchURL)
 	if err != nil {
 		return nil, err
 	}
@@ -69,18 +94,18 @@ func validatePropertySearchOpts(opts PropertySearchOptions) (string, error) {
 }
 
 func propertySearchRequestURL(artURL string, opts PropertySearchOptions, query string) string {
-	searchURL := fmt.Sprintf("%sapi/search/prop?%s=%s", artURL, opts.NamePropertyKey, url.QueryEscape(query))
+	searchURL := fmt.Sprintf("%s%s?%s=%s", artURL, artifactoryPropertySearchAPI, opts.NamePropertyKey, url.QueryEscape(query))
 	if strings.TrimSpace(opts.RepoKey) != "" {
 		searchURL += "&repos=" + url.QueryEscape(opts.RepoKey)
 	}
 	return searchURL
 }
 
-func fetchPropertySearchURIs(sm artifactory.ArtifactoryServicesManager, searchURL string) ([]string, error) {
+func fetchPropertySearchURIs(serviceManager artifactory.ArtifactoryServicesManager, searchURL string) ([]string, error) {
 	log.Debug("Property search request:", searchURL)
 
-	httpDetails := sm.GetConfig().GetServiceDetails().CreateHttpClientDetails()
-	resp, body, _, err := sm.Client().SendGet(searchURL, true, &httpDetails)
+	httpDetails := serviceManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	resp, body, _, err := serviceManager.Client().SendGet(searchURL, true, &httpDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +126,7 @@ func fetchPropertySearchURIs(sm artifactory.ArtifactoryServicesManager, searchUR
 func propertySearchResultsFromURIs(uris []string) []PropertySearchResult {
 	results := make([]PropertySearchResult, 0, len(uris))
 	for _, uri := range uris {
-		parsed, ok := ParsePropertySearchURI(uri)
+		parsed, ok := parsePropertySearchURI(uri)
 		if !ok {
 			log.Warn(fmt.Sprintf("Skipping property search result with unparseable URI: %s", uri))
 			continue
@@ -111,14 +136,14 @@ func propertySearchResultsFromURIs(uris []string) []PropertySearchResult {
 	return results
 }
 
-// ParsePropertySearchURI extracts repo, slug, and version from a storage URI like:
+// parsePropertySearchURI extracts repo, slug, and version from a storage URI like:
 // https://host/artifactory/api/storage/{repo}/{slug}/{version}/{slug}-{version}.zip
-func ParsePropertySearchURI(uri string) (PropertySearchResult, bool) {
-	idx := strings.Index(uri, "/api/storage/")
+func parsePropertySearchURI(uri string) (PropertySearchResult, bool) {
+	idx := strings.Index(uri, artifactoryStorageURIInfix)
 	if idx == -1 {
 		return PropertySearchResult{}, false
 	}
-	path := uri[idx+len("/api/storage/"):]
+	path := uri[idx+len(artifactoryStorageURIInfix):]
 	parts := strings.SplitN(path, "/", 4)
 	if len(parts) < 3 {
 		return PropertySearchResult{}, false
@@ -137,11 +162,11 @@ func GetItemPropertyDescription(
 	repoPath string,
 	descriptionPropertyKeys []string,
 ) (string, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := createPropertySearchServiceManager(serverDetails)
 	if err != nil {
 		return "", err
 	}
-	props, err := sm.GetItemProps(repoPath)
+	props, err := serviceManager.GetItemProps(repoPath)
 	if err != nil {
 		return "", err
 	}

--- a/agent/common/property_search.go
+++ b/agent/common/property_search.go
@@ -1,0 +1,184 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// PropertySearchResult is one artifact hit from Artifactory GET api/search/prop.
+type PropertySearchResult struct {
+	Repo    string
+	Name    string
+	Version string
+	URI     string
+}
+
+// PropertySearchOptions configures a property search by package name key.
+type PropertySearchOptions struct {
+	NamePropertyKey string
+	Query           string
+	RepoKey         string
+}
+
+type propSearchResponse struct {
+	Results []propSearchResultItem `json:"results"`
+}
+
+type propSearchResultItem struct {
+	URI string `json:"uri"`
+}
+
+// SearchByProperty calls GET api/search/prop?{namePropertyKey}={query}[&repos={repoKey}].
+func SearchByProperty(serverDetails *config.ServerDetails, opts PropertySearchOptions) ([]PropertySearchResult, error) {
+	query, err := validatePropertySearchOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	if err != nil {
+		return nil, err
+	}
+	artURL := clientutils.AddTrailingSlashIfNeeded(sm.GetConfig().GetServiceDetails().GetUrl())
+	searchURL := propertySearchRequestURL(artURL, opts, query)
+	uris, err := fetchPropertySearchURIs(sm, searchURL)
+	if err != nil {
+		return nil, err
+	}
+	return propertySearchResultsFromURIs(uris), nil
+}
+
+func validatePropertySearchOpts(opts PropertySearchOptions) (string, error) {
+	if strings.TrimSpace(opts.NamePropertyKey) == "" {
+		return "", fmt.Errorf("name property key is required for property search")
+	}
+	query := strings.TrimSpace(opts.Query)
+	if query == "" {
+		return "", fmt.Errorf("search query is required for property search")
+	}
+	return query, nil
+}
+
+func propertySearchRequestURL(artURL string, opts PropertySearchOptions, query string) string {
+	searchURL := fmt.Sprintf("%sapi/search/prop?%s=%s", artURL, opts.NamePropertyKey, url.QueryEscape(query))
+	if strings.TrimSpace(opts.RepoKey) != "" {
+		searchURL += "&repos=" + url.QueryEscape(opts.RepoKey)
+	}
+	return searchURL
+}
+
+func fetchPropertySearchURIs(sm artifactory.ArtifactoryServicesManager, searchURL string) ([]string, error) {
+	log.Debug("Property search request:", searchURL)
+
+	httpDetails := sm.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	resp, body, _, err := sm.Client().SendGet(searchURL, true, &httpDetails)
+	if err != nil {
+		return nil, err
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return nil, err
+	}
+	var wrapper propSearchResponse
+	if err = json.Unmarshal(body, &wrapper); err != nil {
+		return nil, errorutils.CheckErrorf("failed to parse property search response: %s", err.Error())
+	}
+	uris := make([]string, len(wrapper.Results))
+	for i, item := range wrapper.Results {
+		uris[i] = item.URI
+	}
+	return uris, nil
+}
+
+func propertySearchResultsFromURIs(uris []string) []PropertySearchResult {
+	results := make([]PropertySearchResult, 0, len(uris))
+	for _, uri := range uris {
+		parsed, ok := ParsePropertySearchURI(uri)
+		if !ok {
+			log.Warn(fmt.Sprintf("Skipping property search result with unparseable URI: %s", uri))
+			continue
+		}
+		results = append(results, parsed)
+	}
+	return results
+}
+
+// ParsePropertySearchURI extracts repo, slug, and version from a storage URI like:
+// https://host/artifactory/api/storage/{repo}/{slug}/{version}/{slug}-{version}.zip
+func ParsePropertySearchURI(uri string) (PropertySearchResult, bool) {
+	idx := strings.Index(uri, "/api/storage/")
+	if idx == -1 {
+		return PropertySearchResult{}, false
+	}
+	path := uri[idx+len("/api/storage/"):]
+	parts := strings.SplitN(path, "/", 4)
+	if len(parts) < 3 {
+		return PropertySearchResult{}, false
+	}
+	return PropertySearchResult{
+		Repo:    parts[0],
+		Name:    parts[1],
+		Version: parts[2],
+		URI:     uri,
+	}, true
+}
+
+// GetItemPropertyDescription returns the first non-empty value among descriptionPropertyKeys on repoPath.
+func GetItemPropertyDescription(
+	serverDetails *config.ServerDetails,
+	repoPath string,
+	descriptionPropertyKeys []string,
+) (string, error) {
+	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	if err != nil {
+		return "", err
+	}
+	props, err := sm.GetItemProps(repoPath)
+	if err != nil {
+		return "", err
+	}
+	for _, key := range descriptionPropertyKeys {
+		if descs, ok := props.Properties[key]; ok && len(descs) > 0 {
+			return descs[0], nil
+		}
+	}
+	return "", nil
+}
+
+// SearchRowsByProperty runs property search and resolves optional description properties per hit.
+func SearchRowsByProperty(
+	serverDetails *config.ServerDetails,
+	opts PropertySearchOptions,
+	descriptionPropertyKeys []string,
+) ([]SearchResultRow, error) {
+	hits, err := SearchByProperty(serverDetails, opts)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]SearchResultRow, 0, len(hits))
+	for _, hit := range hits {
+		desc := ""
+		repoPath := fmt.Sprintf("%s/%s/%s/%s-%s.zip", hit.Repo, hit.Name, hit.Version, hit.Name, hit.Version)
+		d, err := GetItemPropertyDescription(serverDetails, repoPath, descriptionPropertyKeys)
+		if err != nil {
+			log.Debug(fmt.Sprintf("Could not fetch description for %s: %s", repoPath, err.Error()))
+		} else {
+			desc = d
+		}
+		rows = append(rows, SearchResultRow{
+			Name:        hit.Name,
+			Version:     hit.Version,
+			Repository:  hit.Repo,
+			Description: desc,
+		})
+	}
+	return rows, nil
+}

--- a/agent/common/property_search_test.go
+++ b/agent/common/property_search_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePropertySearchURI_Valid(t *testing.T) {
+	uri := "https://example.com/artifactory/api/storage/plugins-local/my-plugin/1.0.0/my-plugin-1.0.0.zip"
+	got, ok := ParsePropertySearchURI(uri)
+	require.True(t, ok)
+	assert.Equal(t, "plugins-local", got.Repo)
+	assert.Equal(t, "my-plugin", got.Name)
+	assert.Equal(t, "1.0.0", got.Version)
+	assert.Equal(t, uri, got.URI)
+}
+
+func TestParsePropertySearchURI_Invalid(t *testing.T) {
+	_, ok := ParsePropertySearchURI("https://example.com/artifactory/plugins-local/foo")
+	assert.False(t, ok)
+}
+
+func TestValidatePropertySearchOpts(t *testing.T) {
+	_, err := validatePropertySearchOpts(PropertySearchOptions{})
+	require.Error(t, err)
+
+	got, err := validatePropertySearchOpts(PropertySearchOptions{
+		NamePropertyKey: "agentplugins.name",
+		Query:           " my-plugin ",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-plugin", got)
+}
+
+func TestPropertySearchRequestURL(t *testing.T) {
+	opts := PropertySearchOptions{
+		NamePropertyKey: "agentplugins.name",
+		Query:           "demo",
+		RepoKey:         "plugins-local",
+	}
+	got := propertySearchRequestURL("https://example.com/artifactory/", opts, "demo")
+	assert.Contains(t, got, "https://example.com/artifactory/api/search/prop?agentplugins.name=demo")
+	assert.Contains(t, got, "repos=plugins-local")
+}

--- a/agent/common/property_search_test.go
+++ b/agent/common/property_search_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParsePropertySearchURI_Valid(t *testing.T) {
 	uri := "https://example.com/artifactory/api/storage/plugins-local/my-plugin/1.0.0/my-plugin-1.0.0.zip"
-	got, ok := ParsePropertySearchURI(uri)
+	got, ok := parsePropertySearchURI(uri)
 	require.True(t, ok)
 	assert.Equal(t, "plugins-local", got.Repo)
 	assert.Equal(t, "my-plugin", got.Name)
@@ -18,7 +18,7 @@ func TestParsePropertySearchURI_Valid(t *testing.T) {
 }
 
 func TestParsePropertySearchURI_Invalid(t *testing.T) {
-	_, ok := ParsePropertySearchURI("https://example.com/artifactory/plugins-local/foo")
+	_, ok := parsePropertySearchURI("https://example.com/artifactory/plugins-local/foo")
 	assert.False(t, ok)
 }
 
@@ -41,6 +41,6 @@ func TestPropertySearchRequestURL(t *testing.T) {
 		RepoKey:         "plugins-local",
 	}
 	got := propertySearchRequestURL("https://example.com/artifactory/", opts, "demo")
-	assert.Contains(t, got, "https://example.com/artifactory/api/search/prop?agentplugins.name=demo")
+	assert.Contains(t, got, "https://example.com/artifactory/"+artifactoryPropertySearchAPI+"?agentplugins.name=demo")
 	assert.Contains(t, got, "repos=plugins-local")
 }

--- a/agent/common/search_output.go
+++ b/agent/common/search_output.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// SearchResultRow is one row in agent skills/plugins search output.
+type SearchResultRow struct {
+	Name        string `json:"name" col-name:"Name"`
+	Version     string `json:"version" col-name:"Version"`
+	Repository  string `json:"repository" col-name:"Repository"`
+	Description string `json:"description" col-name:"Description"`
+}
+
+// PrintSearchResultsOptions configures table/json output for search commands.
+type PrintSearchResultsOptions struct {
+	Query           string
+	Format          string
+	TableTitle      string
+	EmptyTableLabel string
+	NotFoundMessage string
+}
+
+// PrintSearchResults prints search rows as a table or JSON.
+func PrintSearchResults(rows []SearchResultRow, opts PrintSearchResultsOptions) error {
+	if len(rows) == 0 {
+		log.Info(fmt.Sprintf(opts.NotFoundMessage, opts.Query))
+		return nil
+	}
+	if strings.EqualFold(opts.Format, "json") {
+		data, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal results: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	return coreutils.PrintTable(rows, opts.TableTitle, opts.EmptyTableLabel, false)
+}

--- a/agent/common/search_output_test.go
+++ b/agent/common/search_output_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintSearchResults_Table(t *testing.T) {
+	rows := []SearchResultRow{
+		{Name: "my-item", Version: "1.0.0", Repository: "repo-a", Description: "desc"},
+	}
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := PrintSearchResults(rows, PrintSearchResultsOptions{
+		Query:           "q",
+		Format:          "table",
+		TableTitle:      "Items",
+		EmptyTableLabel: "No items found",
+		NotFoundMessage: "No items for '%s'.",
+	})
+	require.NoError(t, err)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	assert.Contains(t, buf.String(), "my-item")
+}
+
+func TestPrintSearchResults_JSON(t *testing.T) {
+	rows := []SearchResultRow{{Name: "a", Version: "1.0.0", Repository: "r"}}
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := PrintSearchResults(rows, PrintSearchResultsOptions{Query: "a", Format: "json", NotFoundMessage: "%s"})
+	require.NoError(t, err)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	var parsed []SearchResultRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Len(t, parsed, 1)
+}

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/install"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/list"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/publish"
+	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/search"
 	"github.com/jfrog/jfrog-cli-artifactory/agent/plugins/commands/update"
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
@@ -54,6 +55,22 @@ func GetSubCommands() []components.Command {
 			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsList),
 			Description: "List agent plugins from Artifactory (--repo) or locally installed (--harness).",
 			Action:      list.RunList,
+		},
+		{
+			Name:        "search",
+			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsSearch),
+			Description: "Search for agent plugins by agentplugins.name via Artifactory property search. Use --repo to limit to one repository (otherwise all repos are searched).",
+			Arguments:   getSearchArguments(),
+			Action:      search.RunSearch,
+		},
+	}
+}
+
+func getSearchArguments() []components.Argument {
+	return []components.Argument{
+		{
+			Name:        "query",
+			Description: "Plugin name or search term.",
 		},
 	}
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGetSubCommands_HasPublishInstallUpdateAndDelete(t *testing.T) {
 	commands := GetSubCommands()
-	require.Len(t, commands, 5)
+	require.Len(t, commands, 6)
 
 	byName := make(map[string]components.Command, len(commands))
 	for _, cmd := range commands {
@@ -47,4 +47,11 @@ func TestGetSubCommands_HasPublishInstallUpdateAndDelete(t *testing.T) {
 	lst := byName["list"]
 	assert.NotNil(t, lst.Action)
 	assert.Contains(t, lst.Description, "List agent plugins")
+
+	srch := byName["search"]
+	assert.NotNil(t, srch.Action)
+	require.Len(t, srch.Arguments, 1)
+	assert.Equal(t, "query", srch.Arguments[0].Name)
+	assert.Contains(t, srch.Description, "agentplugins.name")
+	assert.Contains(t, srch.Description, "property search")
 }

--- a/agent/plugins/commands/search/search.go
+++ b/agent/plugins/commands/search/search.go
@@ -1,0 +1,92 @@
+package search
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+)
+
+type SearchCommand struct {
+	serverDetails *config.ServerDetails
+	query         string
+	repoKey       string
+	format        string
+}
+
+func (sc *SearchCommand) SetServerDetails(details *config.ServerDetails) *SearchCommand {
+	sc.serverDetails = details
+	return sc
+}
+
+func (sc *SearchCommand) SetQuery(query string) *SearchCommand {
+	sc.query = query
+	return sc
+}
+
+func (sc *SearchCommand) SetRepoKey(repoKey string) *SearchCommand {
+	sc.repoKey = repoKey
+	return sc
+}
+
+func (sc *SearchCommand) SetFormat(format string) *SearchCommand {
+	sc.format = format
+	return sc
+}
+
+func (sc *SearchCommand) Run() error {
+	rows, err := agentcommon.SearchRowsByProperty(sc.serverDetails, agentcommon.PropertySearchOptions{
+		NamePropertyKey: plugincommon.SearchNamePropertyKey,
+		Query:           sc.query,
+		RepoKey:         sc.repoKey,
+	}, plugincommon.SearchDescriptionPropertyKeys)
+	if err != nil {
+		return fmt.Errorf("plugin search failed: %w", err)
+	}
+	return agentcommon.PrintSearchResults(rows, agentcommon.PrintSearchResultsOptions{
+		Query:           sc.query,
+		Format:          sc.format,
+		TableTitle:      "Plugins",
+		EmptyTableLabel: "No plugins found",
+		NotFoundMessage: "No plugins found matching '%s'.",
+	})
+}
+
+// RunSearch is the CLI action for `jf agent plugins search`.
+func RunSearch(c *components.Context) error {
+	if c.GetNumberOfArgs() < 1 {
+		return fmt.Errorf("usage: jf agent plugins search <query> [--repo <repo>] [--format json]")
+	}
+
+	query := strings.TrimSpace(c.GetArgumentAt(0))
+	if query == "" {
+		return fmt.Errorf("search query cannot be empty. Usage: jf agent plugins search <query>")
+	}
+
+	serverDetails, err := agentcommon.GetServerDetails(c)
+	if err != nil {
+		return err
+	}
+
+	repoKey := strings.TrimSpace(c.GetStringFlagValue("repo"))
+	if repoKey == "" {
+		repoKey = os.Getenv(plugincommon.RepoEnvVar)
+	}
+
+	format := "table"
+	if c.GetStringFlagValue("format") != "" {
+		format = c.GetStringFlagValue("format")
+	}
+
+	cmd := &SearchCommand{}
+	cmd.SetServerDetails(serverDetails).
+		SetQuery(query).
+		SetRepoKey(repoKey).
+		SetFormat(format)
+
+	return cmd.Run()
+}

--- a/agent/plugins/commands/search/search.go
+++ b/agent/plugins/commands/search/search.go
@@ -50,9 +50,9 @@ func (sc *SearchCommand) Run() error {
 	return agentcommon.PrintSearchResults(rows, agentcommon.PrintSearchResultsOptions{
 		Query:           sc.query,
 		Format:          sc.format,
-		TableTitle:      "Plugins",
-		EmptyTableLabel: "No plugins found",
-		NotFoundMessage: "No plugins found matching '%s'.",
+		TableTitle:      plugincommon.SearchTableTitle,
+		EmptyTableLabel: plugincommon.SearchEmptyTableLabel,
+		NotFoundMessage: plugincommon.SearchNotFoundMessage,
 	})
 }
 

--- a/agent/plugins/commands/search/search_test.go
+++ b/agent/plugins/commands/search/search_test.go
@@ -1,0 +1,21 @@
+package search
+
+import (
+	"testing"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchCommand_RunEmptyResults(t *testing.T) {
+	sc := &SearchCommand{query: "missing", format: "table"}
+	// No server details: SearchRowsByProperty fails before print; this test only covers print path.
+	err := agentcommon.PrintSearchResults(nil, agentcommon.PrintSearchResultsOptions{
+		Query:           sc.query,
+		Format:          sc.format,
+		TableTitle:      "Plugins",
+		EmptyTableLabel: "No plugins found",
+		NotFoundMessage: "No plugins found matching '%s'.",
+	})
+	require.NoError(t, err)
+}

--- a/agent/plugins/commands/search/search_test.go
+++ b/agent/plugins/commands/search/search_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	plugincommon "github.com/jfrog/jfrog-cli-artifactory/agent/plugins/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,9 +14,9 @@ func TestSearchCommand_RunEmptyResults(t *testing.T) {
 	err := agentcommon.PrintSearchResults(nil, agentcommon.PrintSearchResultsOptions{
 		Query:           sc.query,
 		Format:          sc.format,
-		TableTitle:      "Plugins",
-		EmptyTableLabel: "No plugins found",
-		NotFoundMessage: "No plugins found matching '%s'.",
+		TableTitle:      plugincommon.SearchTableTitle,
+		EmptyTableLabel: plugincommon.SearchEmptyTableLabel,
+		NotFoundMessage: plugincommon.SearchNotFoundMessage,
 	})
 	require.NoError(t, err)
 }

--- a/agent/plugins/common/search.go
+++ b/agent/plugins/common/search.go
@@ -1,8 +1,12 @@
 package common
 
-// Property keys used for agent plugin search (Artifactory property search API).
+// Property keys and CLI output labels for agent plugin search.
 const (
 	SearchNamePropertyKey = "agentplugins.name"
+
+	SearchTableTitle      = "Plugins"
+	SearchEmptyTableLabel = "No plugins found"
+	SearchNotFoundMessage = "No plugins found matching '%s'."
 )
 
 // SearchDescriptionPropertyKeys lists description property keys tried in order.

--- a/agent/plugins/common/search.go
+++ b/agent/plugins/common/search.go
@@ -1,0 +1,11 @@
+package common
+
+// Property keys used for agent plugin search (Artifactory property search API).
+const (
+	SearchNamePropertyKey = "agentplugins.name"
+)
+
+// SearchDescriptionPropertyKeys lists description property keys tried in order.
+var SearchDescriptionPropertyKeys = []string{
+	"agentplugins.description",
+}

--- a/agent/skills/commands/search/search.go
+++ b/agent/skills/commands/search/search.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,16 +9,8 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/cliutils/flagkit"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
-
-type searchResult struct {
-	Name        string `json:"name" col-name:"Name"`
-	Version     string `json:"version" col-name:"Version"`
-	Repository  string `json:"repository" col-name:"Repository"`
-	Description string `json:"description" col-name:"Description"`
-}
 
 type SearchCommand struct {
 	serverDetails *config.ServerDetails
@@ -77,7 +68,7 @@ func (sc *SearchCommand) runSkillsAPISearch() error {
 		log.Debug(fmt.Sprintf("Discovered %d skills repositories: %v", len(repos), repos))
 	}
 
-	var results []searchResult
+	var results []agentcommon.SearchResultRow
 	var failedRepos []string
 	var firstErr error
 	for _, repo := range repos {
@@ -91,7 +82,7 @@ func (sc *SearchCommand) runSkillsAPISearch() error {
 			continue
 		}
 		for _, item := range items {
-			results = append(results, searchResult{
+			results = append(results, agentcommon.SearchResultRow{
 				Name:        item.Name,
 				Version:     item.Version,
 				Repository:  repo,
@@ -109,57 +100,28 @@ func (sc *SearchCommand) runSkillsAPISearch() error {
 }
 
 func (sc *SearchCommand) runPropSearch() error {
-	propResults, err := common.SearchSkillsByProperty(sc.serverDetails, sc.query)
+	rows, err := agentcommon.SearchRowsByProperty(sc.serverDetails, agentcommon.PropertySearchOptions{
+		NamePropertyKey: common.SearchNamePropertyKey,
+		Query:           sc.query,
+		RepoKey:         sc.repoKey,
+	}, common.SearchDescriptionPropertyKeys)
 	if err != nil {
 		return fmt.Errorf("property search failed: %w", err)
 	}
-
-	var results []searchResult
-	for _, pr := range propResults {
-		desc := ""
-		repoPath := fmt.Sprintf("%s/%s/%s/%s-%s.zip", pr.Repo, pr.Name, pr.Version, pr.Name, pr.Version)
-		d, err := common.GetSkillDescription(sc.serverDetails, repoPath)
-		if err != nil {
-			log.Debug(fmt.Sprintf("Could not fetch description for %s: %s", repoPath, err.Error()))
-		} else {
-			desc = d
-		}
-		results = append(results, searchResult{
-			Name:        pr.Name,
-			Version:     pr.Version,
-			Repository:  pr.Repo,
-			Description: desc,
-		})
-	}
-
-	return sc.printResults(results)
+	return sc.printResults(rows)
 }
 
-func (sc *SearchCommand) printResults(results []searchResult) error {
-	if len(results) == 0 {
-		log.Info(fmt.Sprintf("No skills found matching '%s'.", sc.query))
-		return nil
-	}
-
-	if strings.EqualFold(sc.format, "json") {
-		return printJSON(results)
-	}
-	return printTable(results)
+func (sc *SearchCommand) printResults(results []agentcommon.SearchResultRow) error {
+	return agentcommon.PrintSearchResults(results, agentcommon.PrintSearchResultsOptions{
+		Query:           sc.query,
+		Format:          sc.format,
+		TableTitle:      "Skills",
+		EmptyTableLabel: "No skills found",
+		NotFoundMessage: "No skills found matching '%s'.",
+	})
 }
 
-func printJSON(results []searchResult) error {
-	data, err := json.MarshalIndent(results, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal results: %w", err)
-	}
-	fmt.Println(string(data))
-	return nil
-}
-
-func printTable(results []searchResult) error {
-	return coreutils.PrintTable(results, "Skills", "No skills found", false)
-}
-
+// RunSearch is the CLI action for `jf agent skills search`.
 func RunSearch(c *components.Context) error {
 	if c.GetNumberOfArgs() < 1 {
 		return fmt.Errorf("usage: jf agent skills search <query> [--repo <repo>] [--format json] [--prop]")

--- a/agent/skills/commands/search/search_test.go
+++ b/agent/skills/commands/search/search_test.go
@@ -1,85 +1,20 @@
 package search
 
 import (
-	"bytes"
-	"encoding/json"
-	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrintTable(t *testing.T) {
-	results := []searchResult{
-		{Name: "my-skill", Version: "1.0.0", Repository: "repo-a", Description: "A great skill"},
-		{Name: "another-skill", Version: "2.1.0", Repository: "repo-b", Description: "Another one"},
-	}
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := printTable(results)
+func TestPrintResults_DelegatesToCommon(t *testing.T) {
+	sc := &SearchCommand{query: "q", format: "table"}
+	err := sc.printResults(nil)
 	require.NoError(t, err)
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	assert.Contains(t, output, "NAME")
-	assert.Contains(t, output, "VERSION")
-	assert.Contains(t, output, "REPOSITORY")
-	assert.Contains(t, output, "DESCRIPTION")
-	assert.Contains(t, output, "my-skill")
-	assert.Contains(t, output, "1.0.0")
-	assert.Contains(t, output, "repo-a")
-	assert.Contains(t, output, "another-skill")
 }
 
-func TestPrintJSON(t *testing.T) {
-	results := []searchResult{
-		{Name: "skill-a", Version: "1.0.0", Repository: "repo", Description: "desc"},
+func TestSearchResultRowShape(t *testing.T) {
+	_ = agentcommon.SearchResultRow{
+		Name: "skill-a", Version: "1.0.0", Repository: "skills-local", Description: "desc",
 	}
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := printJSON(results)
-	require.NoError(t, err)
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-
-	var parsed []searchResult
-	err = json.Unmarshal(buf.Bytes(), &parsed)
-	require.NoError(t, err)
-	assert.Len(t, parsed, 1)
-	assert.Equal(t, "skill-a", parsed[0].Name)
-	assert.Equal(t, "1.0.0", parsed[0].Version)
-}
-
-func TestPrintTableEmptyResults(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := printTable([]searchResult{})
-	require.NoError(t, err)
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	assert.Contains(t, output, "No skills found")
 }

--- a/agent/skills/common/repo.go
+++ b/agent/skills/common/repo.go
@@ -6,7 +6,13 @@ const (
 	PackageType = "skills"
 	RepoEnvVar  = "JFROG_SKILLS_REPO"
 	RepoLabel   = "skills"
+
+	// SearchNamePropertyKey is the Artifactory property key for skills name search (--prop).
+	SearchNamePropertyKey = "skill.name"
 )
+
+// SearchDescriptionPropertyKeys lists description property keys tried in order after property search.
+var SearchDescriptionPropertyKeys = []string{"skill.description"}
 
 func RepoOptions() agentcommon.ResolveRepoOptions {
 	return agentcommon.ResolveRepoOptions{

--- a/agent/skills/common/skills_api.go
+++ b/agent/skills/common/skills_api.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ListSkills(serverDetails *config.ServerDetails, repoKey string, limit int, sortBy string) ([]services.SkillListItem, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -16,7 +16,7 @@ func ListSkills(serverDetails *config.ServerDetails, repoKey string, limit int, 
 	cursor := ""
 	pageSize := 100
 	for {
-		items, nextCursor, err := sm.ListSkills(repoKey, pageSize, cursor, sortBy)
+		items, nextCursor, err := serviceManager.ListSkills(repoKey, pageSize, cursor, sortBy)
 		if err != nil {
 			return nil, err
 		}
@@ -33,27 +33,27 @@ func ListSkills(serverDetails *config.ServerDetails, repoKey string, limit int, 
 }
 
 func ListVersions(serverDetails *config.ServerDetails, repoKey, slug string) ([]services.SkillVersion, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
 	if err != nil {
 		return nil, err
 	}
-	return sm.ListSkillVersions(repoKey, slug)
+	return serviceManager.ListSkillVersions(repoKey, slug)
 }
 
 func SearchSkills(serverDetails *config.ServerDetails, repoKey, query string, limit int) ([]services.SkillSearchResult, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
 	if err != nil {
 		return nil, err
 	}
-	return sm.SearchSkills(repoKey, query, limit)
+	return serviceManager.SearchSkills(repoKey, query, limit)
 }
 
 func VersionExists(serverDetails *config.ServerDetails, repoKey, slug, version string) (bool, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+	serviceManager, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
 	if err != nil {
 		return false, err
 	}
-	return sm.SkillVersionExists(repoKey, slug, version)
+	return serviceManager.SkillVersionExists(repoKey, slug, version)
 }
 
 func SearchSkillsByProperty(serverDetails *config.ServerDetails, query, repoKey string) ([]services.SkillPropertySearchResult, error) {

--- a/agent/skills/common/skills_api.go
+++ b/agent/skills/common/skills_api.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
@@ -55,26 +56,28 @@ func VersionExists(serverDetails *config.ServerDetails, repoKey, slug, version s
 	return sm.SkillVersionExists(repoKey, slug, version)
 }
 
-func SearchSkillsByProperty(serverDetails *config.ServerDetails, query string) ([]services.SkillPropertySearchResult, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
+func SearchSkillsByProperty(serverDetails *config.ServerDetails, query, repoKey string) ([]services.SkillPropertySearchResult, error) {
+	results, err := agentcommon.SearchByProperty(serverDetails, agentcommon.PropertySearchOptions{
+		NamePropertyKey: SearchNamePropertyKey,
+		Query:           query,
+		RepoKey:         repoKey,
+	})
 	if err != nil {
 		return nil, err
 	}
-	return sm.SearchSkillsByProperty(query)
+	out := make([]services.SkillPropertySearchResult, len(results))
+	for i, r := range results {
+		out[i] = services.SkillPropertySearchResult{
+			Repo:    r.Repo,
+			Name:    r.Name,
+			Version: r.Version,
+			URI:     r.URI,
+		}
+	}
+	return out, nil
 }
 
 // GetSkillDescription fetches the skill.description property for a given artifact path.
 func GetSkillDescription(serverDetails *config.ServerDetails, repoPath string) (string, error) {
-	sm, err := utils.CreateServiceManager(serverDetails, 3, 0, false)
-	if err != nil {
-		return "", err
-	}
-	props, err := sm.GetItemProps(repoPath)
-	if err != nil {
-		return "", err
-	}
-	if descs, ok := props.Properties["skill.description"]; ok && len(descs) > 0 {
-		return descs[0], nil
-	}
-	return "", nil
+	return agentcommon.GetItemPropertyDescription(serverDetails, repoPath, SearchDescriptionPropertyKeys)
 }

--- a/cliutils/flagkit/flags.go
+++ b/cliutils/flagkit/flags.go
@@ -517,6 +517,7 @@ const (
 	AgentPluginsUpdate  = "agent-plugins-update"
 	AgentPluginsDelete  = "agent-plugins-delete"
 	AgentPluginsList    = "agent-plugins-list"
+	AgentPluginsSearch  = "agent-plugins-search"
 
 	// Agent namespace-specific flags (shared by skills and agent-plugins commands)
 	version    = "version"
@@ -900,6 +901,9 @@ var commandFlags = map[string][]string{
 	},
 	AgentPluginsList: {
 		url, user, password, accessToken, serverId, repo, harness, projectDir, agentGlobal, agentFormat, agentLimit, agentSortBy, agentSortOrder, agentCheckUpdates,
+	},
+	AgentPluginsSearch: {
+		url, user, password, accessToken, serverId, repo, agentFormat,
 	},
 	SkillsInstall: {
 		url, user, password, accessToken, serverId, repo, version, harness, projectDir, agentGlobal, installPath, agentFormat, agentQuiet,


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary:
Implement plugins search:

- Currently we don't have any API supported to search
- So we are using generic search (same as skills search "some-name" --prop)
- here user don't have to give --prop, because this is the only search method we have currently

### Command:
`jf agent plugins search "agent-sdk-dev" --repo plugins-local`