### PR TITLE
RTECO-1079 - Update agents commands help

### DIFF
--- a/agent/cli/cli_test.go
+++ b/agent/cli/cli_test.go
@@ -38,6 +38,6 @@ func TestGetCommands_HasPluginsAndSkillsNamespaces(t *testing.T) {
 func TestGetCommands_PluginsPublishDescription(t *testing.T) {
 	commands := GetCommands()
 	publish := commands[0].Subcommands[0]
-	assert.Contains(t, publish.Description, "Publish an agent plugin to Artifactory")
-	assert.Contains(t, publish.Description, "Signs and attaches evidence")
+	assert.Equal(t, "publish", publish.Name)
+	assert.Equal(t, "Publish an agent plugin to Artifactory.", publish.Description)
 }

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -44,7 +44,7 @@ func GetSubCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsList),
-			Description: "List agent plugins in Artifactory or locally.",
+			Description: "List agent plugins from Artifactory or on the local machine.",
 			Action:      list.RunList,
 		},
 		{

--- a/agent/plugins/cli/cli.go
+++ b/agent/plugins/cli/cli.go
@@ -17,31 +17,22 @@ func GetSubCommands() []components.Command {
 		{
 			Name:        "publish",
 			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsPublish),
-			Description: "Publish an agent plugin to Artifactory. Signs and attaches evidence if a signing key is provided.",
+			Description: "Publish an agent plugin to Artifactory.",
 			Arguments:   getPublishArguments(),
 			Action:      publish.RunPublish,
 		},
 		{
-			Name:  "install",
-			Flags: flagkit.GetCommandFlags(flagkit.AgentPluginsInstall),
-			Description: "Install an agent plugin from Artifactory. Use --harness <name[,name...]> with " +
-				"--project-dir (default: current directory) or --global; or --path <dir> for a direct install " +
-				"at <dir>/<slug>. If --version is omitted with --harness, the install command downloads each " +
-				"<harness>-marketplace.json and uses the version listed there (all must match); with --path, the latest " +
-				"published version is used. Use --format json for machine-readable install summary.",
-			Arguments: getInstallArguments(),
-			Action:    install.RunInstall,
+			Name:        "install",
+			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsInstall),
+			Description: "Install an agent plugin from Artifactory.",
+			Arguments:   getInstallArguments(),
+			Action:      install.RunInstall,
 		},
 		{
-			Name:  "update",
-			Flags: flagkit.GetCommandFlags(flagkit.AgentPluginsUpdate),
-			Description: "Update an installed plugin to the latest (or a specific) version. " +
-				"Use --slug with --harness (comma-separated) and --project-dir or --global; or --slug with --path <dir>. " +
-				"With --all (requires --harness), updates every discovered plugin under those harnesses to latest in one summary table " +
-				"(interactive confirmation before proceeding; folder name is the slug, same as --slug). " +
-				"Resolves versions directly from Artifactory (no marketplace lookup). " +
-				"Skips targets not installed or already at the target version (use --force to re-download).",
-			Action: update.RunUpdate,
+			Name:        "update",
+			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsUpdate),
+			Description: "Update an installed agent plugin.",
+			Action:      update.RunUpdate,
 		},
 		{
 			Name:        "delete",
@@ -53,13 +44,13 @@ func GetSubCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsList),
-			Description: "List agent plugins from Artifactory (--repo) or locally installed (--harness).",
+			Description: "List agent plugins in Artifactory or locally.",
 			Action:      list.RunList,
 		},
 		{
 			Name:        "search",
 			Flags:       flagkit.GetCommandFlags(flagkit.AgentPluginsSearch),
-			Description: "Search for agent plugins by agentplugins.name via Artifactory property search. Use --repo to limit to one repository (otherwise all repos are searched).",
+			Description: "Search for agent plugins in Artifactory.",
 			Arguments:   getSearchArguments(),
 			Action:      search.RunSearch,
 		},
@@ -70,7 +61,7 @@ func getSearchArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "query",
-			Description: "Plugin name or search term.",
+			Description: "Agent plugin name or search term.",
 		},
 	}
 }
@@ -79,7 +70,7 @@ func getPublishArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "path",
-			Description: "Path to the plugin folder containing plugin.json.",
+			Description: "Path to the agent plugin folder containing plugin.json.",
 		},
 	}
 }
@@ -88,7 +79,7 @@ func getInstallArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "slug",
-			Description: "Slug (name) of the plugin to install.",
+			Description: "Agent plugin slug to install.",
 		},
 	}
 }
@@ -97,7 +88,7 @@ func getDeleteArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "slug",
-			Description: "Plugin name/slug to delete.",
+			Description: "Agent plugin slug to delete.",
 		},
 	}
 }

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -45,7 +45,7 @@ func TestGetSubCommands_HasPublishInstallUpdateAndDelete(t *testing.T) {
 
 	lst := byName["list"]
 	assert.NotNil(t, lst.Action)
-	assert.Equal(t, "List agent plugins in Artifactory or locally.", lst.Description)
+	assert.Equal(t, "List agent plugins from Artifactory or on the local machine.", lst.Description)
 
 	srch := byName["search"]
 	assert.NotNil(t, srch.Action)

--- a/agent/plugins/cli/cli_test.go
+++ b/agent/plugins/cli/cli_test.go
@@ -21,37 +21,36 @@ func TestGetSubCommands_HasPublishInstallUpdateAndDelete(t *testing.T) {
 	assert.NotNil(t, publish.Action)
 	require.Len(t, publish.Arguments, 1)
 	assert.Equal(t, "path", publish.Arguments[0].Name)
-	assert.Contains(t, publish.Description, "Publish an agent plugin to Artifactory")
-	assert.Contains(t, publish.Description, "Signs and attaches evidence")
+	assert.Equal(t, "Publish an agent plugin to Artifactory.", publish.Description)
+	assert.Equal(t, "Path to the agent plugin folder containing plugin.json.", publish.Arguments[0].Description)
 
 	installCmd := byName["install"]
 	assert.NotNil(t, installCmd.Action)
 	require.Len(t, installCmd.Arguments, 1)
 	assert.Equal(t, "slug", installCmd.Arguments[0].Name)
-	assert.Contains(t, installCmd.Description, "Install an agent plugin from Artifactory")
-	assert.Contains(t, installCmd.Description, "marketplace")
+	assert.Equal(t, "Install an agent plugin from Artifactory.", installCmd.Description)
+	assert.Equal(t, "Agent plugin slug to install.", installCmd.Arguments[0].Description)
 
 	updateCmd := byName["update"]
 	assert.NotNil(t, updateCmd.Action)
 	assert.Empty(t, updateCmd.Arguments)
-	assert.Contains(t, updateCmd.Description, "Update an installed plugin")
-	assert.Contains(t, updateCmd.Description, "--slug")
-	assert.Contains(t, updateCmd.Description, "--all")
+	assert.Equal(t, "Update an installed agent plugin.", updateCmd.Description)
 
 	del := byName["delete"]
 	assert.NotNil(t, del.Action)
 	require.Len(t, del.Arguments, 1)
 	assert.Equal(t, "slug", del.Arguments[0].Name)
-	assert.Contains(t, del.Description, "Delete a specific agent plugin version")
+	assert.Equal(t, "Delete a specific agent plugin version from Artifactory.", del.Description)
+	assert.Equal(t, "Agent plugin slug to delete.", del.Arguments[0].Description)
 
 	lst := byName["list"]
 	assert.NotNil(t, lst.Action)
-	assert.Contains(t, lst.Description, "List agent plugins")
+	assert.Equal(t, "List agent plugins in Artifactory or locally.", lst.Description)
 
 	srch := byName["search"]
 	assert.NotNil(t, srch.Action)
 	require.Len(t, srch.Arguments, 1)
 	assert.Equal(t, "query", srch.Arguments[0].Name)
-	assert.Contains(t, srch.Description, "agentplugins.name")
-	assert.Contains(t, srch.Description, "property search")
+	assert.Equal(t, "Search for agent plugins in Artifactory.", srch.Description)
+	assert.Equal(t, "Agent plugin name or search term.", srch.Arguments[0].Description)
 }

--- a/agent/skills/cli/cli.go
+++ b/agent/skills/cli/cli.go
@@ -17,34 +17,34 @@ func GetSubCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsList),
-			Description: "List skills: registry (--repo), project-local (--harness [--project-dir], default .), or global-local (--harness --global). Use --check-updates with --harness to compare installs to the registry. --repo and --harness are mutually exclusive; --global and --project-dir are mutually exclusive.",
+			Description: "List skills in Artifactory or locally.",
 			Action:      skillslist.RunList,
 		},
 		{
 			Name:        "publish",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsPublish),
-			Description: "Publish a skill to Artifactory. Signs and attaches evidence if a signing key is provided. Runs Xray security scan after upload (use --skip-scan or JFROG_CLI_SKIP_SKILLS_SCAN=true to bypass). Scan timeout is configurable via JFROG_CLI_SKILLS_SCAN_TIMEOUT (default: 5m, e.g. 2m, 30s).",
+			Description: "Publish a skill to Artifactory.",
 			Arguments:   getPublishArguments(),
 			Action:      publish.RunPublish,
 		},
 		{
 			Name:        "install",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsInstall),
-			Description: "Install a skill from Artifactory. Use --harness (comma-separated) with --project-dir (default: current directory) or --global, or use --path <dir> for a direct install to <dir>/<slug> (same layout as skills update). Harness paths use ~/.jfrog/agents/agent-config.json with built-in fallbacks. Verifies evidence when signing keys are configured. Use --format json for machine-readable install summary.",
+			Description: "Install a skill from Artifactory.",
 			Arguments:   getInstallArguments(),
 			Action:      install.RunInstall,
 		},
 		{
 			Name:        "update",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsUpdate),
-			Description: "Update an installed skill to the latest (or a specific) version. Same targeting flags as install: use --harness (comma-separated) with --project-dir (default: current directory) or --global, or --path <dir> for a direct update at <dir>/<slug>. Pre-update checks skip targets that are not installed or already at the target version (use --force to re-download). Logs skip and failure reasons when not quiet. Downloads once for all targets. Use --dry-run to preview, --format json for machine-readable summaries.",
+			Description: "Update an installed skill.",
 			Arguments:   getUpdateArguments(),
 			Action:      update.RunUpdate,
 		},
 		{
 			Name:        "search",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsSearch),
-			Description: "Search for skills across Artifactory repositories.",
+			Description: "Search for skills in Artifactory.",
 			Arguments:   getSearchArguments(),
 			Action:      search.RunSearch,
 		},
@@ -80,7 +80,7 @@ func getInstallArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "slug",
-			Description: "Skill name/slug to install.",
+			Description: "Skill slug to install.",
 		},
 	}
 }
@@ -89,7 +89,7 @@ func getUpdateArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "slug",
-			Description: "Skill name/slug to update.",
+			Description: "Skill slug to update.",
 		},
 	}
 }
@@ -98,7 +98,7 @@ func getDeleteArguments() []components.Argument {
 	return []components.Argument{
 		{
 			Name:        "slug",
-			Description: "Skill name/slug to delete.",
+			Description: "Skill slug to delete.",
 		},
 	}
 }

--- a/agent/skills/cli/cli.go
+++ b/agent/skills/cli/cli.go
@@ -17,7 +17,7 @@ func GetSubCommands() []components.Command {
 		{
 			Name:        "list",
 			Flags:       flagkit.GetCommandFlags(flagkit.SkillsList),
-			Description: "List skills in Artifactory or locally.",
+			Description: "List skills from Artifactory or on the local machine.",
 			Action:      skillslist.RunList,
 		},
 		{

--- a/agent/skills/cli/cli_test.go
+++ b/agent/skills/cli/cli_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSubCommands_DescriptionsAndArguments(t *testing.T) {
+	commands := GetSubCommands()
+	require.Len(t, commands, 6)
+
+	byName := make(map[string]components.Command, len(commands))
+	for _, cmd := range commands {
+		byName[cmd.Name] = cmd
+	}
+
+	assert.Equal(t, "List skills in Artifactory or locally.", byName["list"].Description)
+
+	publish := byName["publish"]
+	assert.Equal(t, "Publish a skill to Artifactory.", publish.Description)
+	assert.Equal(t, "Path to the skill folder containing SKILL.md.", publish.Arguments[0].Description)
+
+	installCmd := byName["install"]
+	assert.Equal(t, "Install a skill from Artifactory.", installCmd.Description)
+	assert.Equal(t, "Skill slug to install.", installCmd.Arguments[0].Description)
+
+	updateCmd := byName["update"]
+	assert.Equal(t, "Update an installed skill.", updateCmd.Description)
+	assert.Equal(t, "Skill slug to update.", updateCmd.Arguments[0].Description)
+
+	searchCmd := byName["search"]
+	assert.Equal(t, "Search for skills in Artifactory.", searchCmd.Description)
+	assert.Equal(t, "Skill name or search term.", searchCmd.Arguments[0].Description)
+
+	del := byName["delete"]
+	assert.Equal(t, "Delete a specific skill version from Artifactory.", del.Description)
+	assert.Equal(t, "Skill slug to delete.", del.Arguments[0].Description)
+}

--- a/agent/skills/cli/cli_test.go
+++ b/agent/skills/cli/cli_test.go
@@ -17,7 +17,7 @@ func TestGetSubCommands_DescriptionsAndArguments(t *testing.T) {
 		byName[cmd.Name] = cmd
 	}
 
-	assert.Equal(t, "List skills in Artifactory or locally.", byName["list"].Description)
+	assert.Equal(t, "List skills from Artifactory or on the local machine.", byName["list"].Description)
 
 	publish := byName["publish"]
 	assert.Equal(t, "Publish a skill to Artifactory.", publish.Description)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary
When user does jf agent plugins --help or ``jf agent skills --help`` , the output is more verbose, difficult to read & understand.

So made the output simple. If user wants to know more information, he will go through the documentation