### PR TITLE
RTECO-1079 - Change the semver error response

### DIFF
--- a/agent/common/semver.go
+++ b/agent/common/semver.go
@@ -52,11 +52,11 @@ func LatestVersion(versions []string) (string, error) {
 func CompareSemver(firstVersion, secondVersion string) (int, error) {
 	firstVersionParts, err := parseSemver(strings.TrimSpace(firstVersion))
 	if err != nil {
-		return 0, fmt.Errorf("compare semver: invalid first version %q: %w", firstVersion, err)
+		return 0, err
 	}
 	secondVersionParts, err := parseSemver(strings.TrimSpace(secondVersion))
 	if err != nil {
-		return 0, fmt.Errorf("compare semver: invalid second version %q: %w", secondVersion, err)
+		return 0, err
 	}
 	if firstVersionParts.Major != secondVersionParts.Major {
 		return firstVersionParts.Major - secondVersionParts.Major, nil
@@ -92,26 +92,24 @@ func ValidateSemver(version string) error {
 	if strings.ContainsAny(version, "/\\") {
 		return fmt.Errorf("invalid version %q: must not contain path separators", version)
 	}
-	if _, err := parseSemver(version); err != nil {
-		return fmt.Errorf("invalid semver version %q: %w", version, err)
-	}
-	return nil
+	_, err := parseSemver(version)
+	return err
 }
 
 func parseSemver(version string) (semverParts, error) {
 	versionWithoutPrefix := strings.TrimPrefix(version, "v")
 	versionSegments := strings.SplitN(versionWithoutPrefix, ".", 3)
 	if len(versionSegments) != 3 {
-		return semverParts{}, fmt.Errorf("invalid semver: %s", version)
+		return semverParts{}, fmt.Errorf("invalid version %q: expected format major.minor.patch", version)
 	}
 
 	major, err := strconv.Atoi(versionSegments[0])
 	if err != nil {
-		return semverParts{}, fmt.Errorf("invalid major version in %s: %w", version, err)
+		return semverParts{}, fmt.Errorf("invalid version %q: major must be a number (got %q)", version, versionSegments[0])
 	}
 	minor, err := strconv.Atoi(versionSegments[1])
 	if err != nil {
-		return semverParts{}, fmt.Errorf("invalid minor version in %s: %w", version, err)
+		return semverParts{}, fmt.Errorf("invalid version %q: minor must be a number (got %q)", version, versionSegments[1])
 	}
 
 	// Patch may contain pre-release or build metadata; take numeric part only for comparison
@@ -119,7 +117,7 @@ func parseSemver(version string) (semverParts, error) {
 	patchSegment = strings.SplitN(patchSegment, "+", 2)[0]
 	patch, err := strconv.Atoi(patchSegment)
 	if err != nil {
-		return semverParts{}, fmt.Errorf("invalid patch version in %s: %w", version, err)
+		return semverParts{}, fmt.Errorf("invalid version %q: patch must be a number (got %q)", version, patchSegment)
 	}
 
 	return semverParts{Major: major, Minor: minor, Patch: patch, Raw: version}, nil

--- a/agent/common/semver_test.go
+++ b/agent/common/semver_test.go
@@ -96,6 +96,17 @@ func TestValidateSemver(t *testing.T) {
 	}
 }
 
+func TestValidateSemver_ErrorMessageIsDirect(t *testing.T) {
+	t.Parallel()
+	err := ValidateSemver("1.9.e")
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Equal(t, `invalid version "1.9.e": patch must be a number (got "e")`, msg)
+	assert.NotContains(t, msg, "strconv")
+	assert.NotContains(t, msg, "invalid semver version")
+	assert.NotContains(t, msg, "invalid patch version in")
+}
+
 func TestNextMinorVersion(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary

Remove verbose error, print error exactly, short, simple and meaninful