### PR TITLE
RTECO-1021 - Enhance metrics visibility by including package manager context

### DIFF
--- a/artifactory/cli/cli.go
+++ b/artifactory/cli/cli.go
@@ -557,7 +557,7 @@ func dockerPromoteCmd(c *components.Context) error {
 	dockerPromoteCommand := container.NewDockerPromoteCommand()
 	dockerPromoteCommand.SetParams(params).SetServerDetails(artDetails)
 
-	if err = commands.Exec(dockerPromoteCommand); err != nil {
+	if err = commands.ExecWithPackageManager(dockerPromoteCommand, "docker"); err != nil {
 		return err
 	}
 
@@ -656,7 +656,7 @@ func containerPushCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return
 	}
-	err = commands.Exec(dockerPushCommand)
+	err = commands.ExecWithPackageManager(dockerPushCommand, containerManagerType.String())
 	result := dockerPushCommand.Result()
 
 	// Cleanup.
@@ -736,7 +736,7 @@ func containerPullCmd(c *components.Context, containerManagerType containerutils
 	if err != nil {
 		return err
 	}
-	if err = commands.Exec(dockerPullCommand); err != nil {
+	if err = commands.ExecWithPackageManager(dockerPullCommand, containerManagerType.String()); err != nil {
 		return err
 	}
 	if outputFormat == coreformat.None {
@@ -804,7 +804,7 @@ func BuildDockerCreateCmd(c *components.Context) error {
 		return err
 	}
 	buildDockerCreateCommand.SetRepo(sourceRepo).SetServerDetails(artDetails).SetBuildConfiguration(buildConfiguration)
-	return commands.Exec(buildDockerCreateCommand)
+	return commands.ExecWithPackageManager(buildDockerCreateCommand, "docker")
 }
 
 func ocStartBuildCmd(c *components.Context) error {
@@ -851,7 +851,7 @@ func ocStartBuildCmd(c *components.Context) error {
 	coreutils.RemoveFlagFromCommand(&filteredOcArgs, flagIndex, valueIndex)
 
 	ocCmd := oc.NewOcStartBuildCommand().SetOcArgs(filteredOcArgs).SetRepo(repo).SetServerId(serverId).SetBuildConfiguration(buildConfiguration)
-	return commands.Exec(ocCmd)
+	return commands.ExecWithPackageManager(ocCmd, "docker")
 }
 
 func nugetDepsTreeCmd(c *components.Context) error {

--- a/artifactory/commands/npm/common.go
+++ b/artifactory/commands/npm/common.go
@@ -50,20 +50,17 @@ func (ca *CommonArgs) SetUseNative(useNpmRc bool) *CommonArgs {
 // then falls back to the deprecated --run-native flag for backward compatibility.
 // Returns: useNative flag, filtered args (with --run-native removed if present), error
 func CheckIsNativeAndFetchFilteredArgs(args []string) (useNative bool, filteredArgs []string, err error) {
-	filteredArgs = args
-	// Check JFROG_RUN_NATIVE environment variable first (preferred method)
-	useNative = flexpack.IsFlexPackEnabled()
-	if useNative {
-		log.Info("Running npm in native mode (JFROG_RUN_NATIVE=true)")
-		return
-	}
-
-	// Check deprecated --run-native flag for backward compatibility
+	// Always strip --run-native from args so it never reaches the npm binary,
+	// regardless of whether native mode is triggered by env var or flag.
 	filteredArgs, useNativeFlag, err := coreutils.ExtractUseNativeFromArgs(args)
 	if err != nil {
 		return false, args, err
 	}
-	if useNativeFlag {
+
+	if flexpack.IsFlexPackEnabled() {
+		log.Info("Running npm in native mode (JFROG_RUN_NATIVE=true)")
+		useNative = true
+	} else if useNativeFlag {
 		log.Warn("The --run-native flag is deprecated. Please use JFROG_RUN_NATIVE=true environment variable instead.")
 		log.Info("Running npm in native mode")
 		useNative = true

--- a/artifactory/commands/npm/npmcommand.go
+++ b/artifactory/commands/npm/npmcommand.go
@@ -129,17 +129,32 @@ func (nc *NpmCommand) SetDisableCVSCheck(disable bool) *NpmCommand {
 }
 
 func (nc *NpmCommand) Init() error {
-	// Read config file.
-	log.Debug("Preparing to read the config file", nc.configFilePath)
-	vConfig, err := project.ReadConfigFile(nc.configFilePath, project.YAML)
-	if err != nil {
-		return err
+	if nc.configFilePath != "" {
+		log.Debug("Preparing to read the config file", nc.configFilePath)
+		vConfig, err := project.ReadConfigFile(nc.configFilePath, project.YAML)
+		if err != nil {
+			return err
+		}
+		
+		repoConfig, err := nc.getRepoConfig(vConfig)
+		if err != nil {
+			return err
+		}
+		nc.SetRepoConfig(repoConfig)
+	} else if nc.UseNative() {
+		// No config file + native mode — CLI layer set useNative and stripped --run-native already.
+		// Only strip --server-id (not a valid npm flag) and resolve server details.
+		filteredArgs, serverID, err := coreutils.ExtractServerIdFromCommand(nc.npmArgs)
+		if err != nil {
+			return err
+		}
+		nc.npmArgs = filteredArgs
+		nc.serverDetails, err = config.GetSpecificConfig(serverID, true, false)
+		if err != nil {
+			return err
+		}
 	}
 
-	repoConfig, err := nc.getRepoConfig(vConfig)
-	if err != nil {
-		return err
-	}
 	_, _, _, filteredNpmArgs, buildConfiguration, err := commandUtils.ExtractNpmOptionsFromArgs(nc.npmArgs)
 	if err != nil {
 		return err
@@ -149,7 +164,7 @@ func (nc *NpmCommand) Init() error {
 	if err != nil {
 		return err
 	}
-	nc.SetRepoConfig(repoConfig).SetArgs(filteredNpmArgs).SetBuildConfiguration(buildConfiguration)
+	nc.SetArgs(filteredNpmArgs).SetBuildConfiguration(buildConfiguration)
 	nc.SetDisableCVSCheck(disableCVSCheck)
 	return nil
 }
@@ -199,13 +214,6 @@ func (nc *NpmCommand) PreparePrerequisites(repo string) error {
 		return err
 	}
 	log.Debug("Working directory set to:", nc.workingDirectory)
-
-	// Check for native mode (env var or deprecated flag)
-	useNative, _, err := CheckIsNativeAndFetchFilteredArgs(nc.npmArgs)
-	if err != nil {
-		return err
-	}
-	nc.SetUseNative(useNative)
 	nc.installHandler = NewNpmInstallStrategy(nc.UseNative(), nc)
 
 	return nc.installHandler.PrepareInstallPrerequisites(repo)

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -129,11 +129,6 @@ func (npc *NpmPublishCommand) Init() error {
 	if err != nil {
 		return err
 	}
-	// Check for native mode (env var or deprecated flag)
-	useNative, filteredNpmArgs, err := CheckIsNativeAndFetchFilteredArgs(filteredNpmArgs)
-	if err != nil {
-		return err
-	}
 	filteredNpmArgs, tag, err := coreutils.ExtractTagFromArgs(filteredNpmArgs)
 	if err != nil {
 		return err
@@ -154,8 +149,20 @@ func (npc *NpmPublishCommand) Init() error {
 			return errorutils.CheckError(err)
 		}
 		npc.SetBuildConfiguration(buildConfiguration).SetRepo(deployerParams.TargetRepo()).SetNpmArgs(filteredNpmArgs).SetServerDetails(rtDetails)
+	} else if npc.UseNative() {
+		// No config file + native mode: CLI layer already set useNative and stripped --run-native.
+		// Extract --server-id for metrics reporting and strip it from args.
+		filteredNpmArgs, serverID, err := coreutils.ExtractServerIdFromCommand(filteredNpmArgs)
+		if err != nil {
+			return err
+		}
+		rtDetails, err := config.GetSpecificConfig(serverID, true, false)
+		if err != nil {
+			return err
+		}
+		npc.SetBuildConfiguration(buildConfiguration).SetNpmArgs(filteredNpmArgs).SetServerDetails(rtDetails)
 	}
-	npc.SetDetailedSummary(detailedSummary).SetXrayScan(xrayScan).SetScanOutputFormat(scanOutputFormat).SetDistTag(tag).SetUseNative(useNative)
+	npc.SetDetailedSummary(detailedSummary).SetXrayScan(xrayScan).SetScanOutputFormat(scanOutputFormat).SetDistTag(tag)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jfrog/build-info-go v1.13.1-0.20260528065004-80409c046540
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260508101905-a17af78a38d7
 	github.com/pkg/errors v0.9.1
@@ -200,7 +200,7 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260520105053-3d9532efc2f6
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260520104800-3fa62a50e049
+// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260604085947-7c110b77b4b4
 
 // replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab
 

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18 h1:tPv7XscDFAZaijVwMQNb+HmuucUMYQdjuA5frdGzhF0=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06 h1:A8hWKHyvqzGXfWmh+8lXv3waAkim4xiucBfGhl7ZOeQ=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260508101905-a17af78a38d7 h1:o8fk4yWLqNMldarXyh/4NbmdbYbuM+lKYobdJK7shqM=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----

### Summary

  Records the package manager behind each CLI command in the `jfcli_commands_count` visibility metric.
  Adds `package_manager` and `package_alias` labels to the wire payload so usage analytics can break down
  CLI adoption by ecosystem (npm, go, maven, docker, etc.) and distinguish ghost-frog alias invocations
  from direct `jf <pm>` calls.
  
  Depends on:
  1. https://github.com/jfrog/jfrog-cli/pull/3534
  2. https://github.com/jfrog/jfrog-cli-core/pull/1569 