### PR TITLE
RTECO-1299 - Masked the admin tokens

### DIFF
--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -103,6 +103,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run Artifactory tests
         if: matrix.suite == 'artifactory'
         working-directory: jfrog-cli
@@ -230,6 +234,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run NuGet tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.nuget
@@ -284,6 +292,10 @@ jobs:
         with:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
 
       - name: Run npm tests
         working-directory: jfrog-cli
@@ -348,6 +360,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run pnpm tests
         working-directory: jfrog-cli
         env:
@@ -404,6 +420,10 @@ jobs:
         with:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
 
       - name: Run Maven tests
         working-directory: jfrog-cli
@@ -468,6 +488,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run Gradle tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.gradle
@@ -523,6 +547,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run Conan tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan
@@ -577,6 +605,10 @@ jobs:
         with:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
 
       - name: Run Helm tests
         working-directory: jfrog-cli
@@ -767,6 +799,10 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
+
       - name: Run Python tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}
@@ -816,6 +852,10 @@ jobs:
         with:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Mask local Artifactory admin token
+        shell: bash
+        run: echo "::add-mask::$JFROG_TESTS_LOCAL_ACCESS_TOKEN"
 
       - name: Run Lifecycle tests
         working-directory: jfrog-cli


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
What: Masked the admin token in tests.