### PR TITLE
JGC-492 - Add --format flag for release-bundle-create, promote, and distribute

### DIFF
--- a/lifecycle/cli.go
+++ b/lifecycle/cli.go
@@ -27,6 +27,7 @@ import (
 	artifactoryUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	speccore "github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	pluginsCommon "github.com/jfrog/jfrog-cli-core/v2/plugins/common"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
@@ -46,14 +47,15 @@ const (
 func GetCommands() []components.Command {
 	return []components.Command{
 		{
-			Name:          cmddefs.ReleaseBundleCreate,
-			Aliases:       []string{"rbc"},
-			Flags:         flagkit.GetCommandFlags(cmddefs.ReleaseBundleCreate),
-			Description:   rbCreate.GetDescription(),
-			AIDescription: rbCreate.GetAIDescription(),
-			Arguments:     rbCreate.GetArguments(),
-			Category:      lcCategory,
-			Action:        create,
+			Name:             cmddefs.ReleaseBundleCreate,
+			Aliases:          []string{"rbc"},
+			Flags:            flagkit.GetCommandFlags(cmddefs.ReleaseBundleCreate),
+			Description:      rbCreate.GetDescription(),
+			AIDescription:    rbCreate.GetAIDescription(),
+			Arguments:        rbCreate.GetArguments(),
+			Category:         lcCategory,
+			Action:           create,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
 			Name:          cmddefs.ReleaseBundleUpdate,
@@ -76,24 +78,26 @@ func GetCommands() []components.Command {
 			Action:        finalize,
 		},
 		{
-			Name:          "release-bundle-promote",
-			Aliases:       []string{"rbp"},
-			Flags:         flagkit.GetCommandFlags(cmddefs.ReleaseBundlePromote),
-			Description:   rbPromote.GetDescription(),
-			AIDescription: rbPromote.GetAIDescription(),
-			Arguments:     rbPromote.GetArguments(),
-			Category:      lcCategory,
-			Action:        promote,
+			Name:             "release-bundle-promote",
+			Aliases:          []string{"rbp"},
+			Flags:            flagkit.GetCommandFlags(cmddefs.ReleaseBundlePromote),
+			Description:      rbPromote.GetDescription(),
+			AIDescription:    rbPromote.GetAIDescription(),
+			Arguments:        rbPromote.GetArguments(),
+			Category:         lcCategory,
+			Action:           promote,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json, coreformat.Table},
 		},
 		{
-			Name:          "release-bundle-distribute",
-			Aliases:       []string{"rbd"},
-			Flags:         flagkit.GetCommandFlags(cmddefs.ReleaseBundleDistribute),
-			Description:   rbDistribute.GetDescription(),
-			AIDescription: rbDistribute.GetAIDescription(),
-			Arguments:     rbDistribute.GetArguments(),
-			Category:      lcCategory,
-			Action:        distribute,
+			Name:             "release-bundle-distribute",
+			Aliases:          []string{"rbd"},
+			Flags:            flagkit.GetCommandFlags(cmddefs.ReleaseBundleDistribute),
+			Description:      rbDistribute.GetDescription(),
+			AIDescription:    rbDistribute.GetAIDescription(),
+			Arguments:        rbDistribute.GetArguments(),
+			Category:         lcCategory,
+			Action:           distribute,
+			SupportedFormats: []coreformat.OutputFormat{coreformat.Json},
 		},
 		{
 			Name:          "release-bundle-export",
@@ -260,11 +264,17 @@ func create(c *components.Context) (err error) {
 	if err != nil {
 		return
 	}
+	outputFormat, err := c.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
 	createCmd := lifecycle.NewReleaseBundleCreateCommand().SetServerDetails(lcDetails).SetReleaseBundleName(c.GetArgumentAt(0)).
 		SetReleaseBundleVersion(c.GetArgumentAt(1)).SetSigningKeyName(c.GetStringFlagValue(flagkit.SigningKey)).
 		SetSync(c.GetBoolFlagValue(flagkit.Sync)).SetDraft(c.GetBoolFlagValue(flagkit.Draft)).
 		SetReleaseBundleProject(pluginsCommon.GetProject(c)).SetSpec(creationSpec).
-		SetBuildsSpecPath(c.GetStringFlagValue(flagkit.Builds)).SetReleaseBundlesSpecPath(c.GetStringFlagValue(flagkit.ReleaseBundles))
+		SetBuildsSpecPath(c.GetStringFlagValue(flagkit.Builds)).SetReleaseBundlesSpecPath(c.GetStringFlagValue(flagkit.ReleaseBundles)).
+		SetOutputFormat(outputFormat)
 
 	err = lifecycle.ValidateFeatureSupportedVersion(lcDetails, minArtifactoryVersionForMultiSourceSupport)
 	// err == nil means new flags are supported and may be added to createCmd
@@ -425,11 +435,17 @@ func promote(c *components.Context) error {
 		return err
 	}
 
+	outputFormat, err := c.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
 	promoteCmd := lifecycle.NewReleaseBundlePromoteCommand().SetServerDetails(lcDetails).SetReleaseBundleName(c.GetArgumentAt(0)).
 		SetReleaseBundleVersion(c.GetArgumentAt(1)).SetEnvironment(c.GetArgumentAt(2)).SetSigningKeyName(c.GetStringFlagValue(flagkit.SigningKey)).
 		SetSync(c.GetBoolFlagValue(flagkit.Sync)).SetReleaseBundleProject(pluginsCommon.GetProject(c)).
 		SetIncludeReposPatterns(splitRepos(c, flagkit.IncludeRepos)).SetExcludeReposPatterns(splitRepos(c, flagkit.ExcludeRepos)).
-		SetPromotionType(c.GetStringFlagValue(flagkit.PromotionType))
+		SetPromotionType(c.GetStringFlagValue(flagkit.PromotionType)).
+		SetOutputFormat(outputFormat)
 	return commands.Exec(promoteCmd)
 }
 
@@ -447,6 +463,11 @@ func distribute(c *components.Context) error {
 		return err
 	}
 
+	outputFormat, err := c.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
 	distributeCmd := lifecycle.NewReleaseBundleDistributeCommand()
 	distributeCmd.SetServerDetails(lcDetails).
 		SetReleaseBundleName(c.GetArgumentAt(0)).
@@ -458,7 +479,8 @@ func distribute(c *components.Context) error {
 		SetPathMappingPattern(c.GetStringFlagValue(flagkit.PathMappingPattern)).
 		SetPathMappingTarget(c.GetStringFlagValue(flagkit.PathMappingTarget)).
 		SetSync(c.GetBoolFlagValue(flagkit.Sync)).
-		SetMaxWaitMinutes(maxWaitMinutes)
+		SetMaxWaitMinutes(maxWaitMinutes).
+		SetOutputFormat(outputFormat)
 	return commands.Exec(distributeCmd)
 }
 

--- a/lifecycle/commands/common.go
+++ b/lifecycle/commands/common.go
@@ -23,6 +23,10 @@ const (
 	minimalLifecycleArtifactoryVersion                    = "7.63.2"
 	minArtifactoryVersionForMultiSourceAndPackagesSupport = "7.114.0"
 	minArtifactoryVersionForDraftBundleSupport            = "7.136.0"
+
+	// Status values emitted by the --format json echo output.
+	statusCreated     = "created"
+	statusDistributed = "distributed"
 )
 
 type releaseBundleCmd struct {

--- a/lifecycle/commands/createcommon.go
+++ b/lifecycle/commands/createcommon.go
@@ -614,17 +614,16 @@ func (rbc *ReleaseBundleCreateCommand) printCreateOutput() error {
 	if rbc.outputFormat != coreformat.Json {
 		return nil
 	}
-	type createOutput struct {
+	return printEchoJson(rbc.releaseBundleName, rbc.releaseBundleVersion, "created")
+}
+
+func printEchoJson(name, version, status string) error {
+	type output struct {
 		Name    string `json:"release_bundle_name"`
 		Version string `json:"release_bundle_version"`
 		Status  string `json:"status"`
 	}
-	out := createOutput{
-		Name:    rbc.releaseBundleName,
-		Version: rbc.releaseBundleVersion,
-		Status:  "created",
-	}
-	content, err := json.Marshal(out)
+	content, err := json.Marshal(output{Name: name, Version: version, Status: status})
 	if err != nil {
 		return err
 	}

--- a/lifecycle/commands/createcommon.go
+++ b/lifecycle/commands/createcommon.go
@@ -1,17 +1,20 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/lifecycle"
 	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -35,6 +38,7 @@ type ReleaseBundleCreateCommand struct {
 	signingKeyName string
 	spec           *spec.SpecFiles
 	draft          bool
+	outputFormat   coreformat.OutputFormat
 	// Backward compatibility:
 	buildsSpecPath         string
 	releaseBundlesSpecPath string
@@ -84,6 +88,11 @@ func (rbc *ReleaseBundleCreateCommand) SetSpec(spec *spec.SpecFiles) *ReleaseBun
 
 func (rbc *ReleaseBundleCreateCommand) SetDraft(draft bool) *ReleaseBundleCreateCommand {
 	rbc.draft = draft
+	return rbc
+}
+
+func (rbc *ReleaseBundleCreateCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundleCreateCommand {
+	rbc.outputFormat = f
 	return rbc
 }
 
@@ -160,34 +169,36 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 		return err
 	}
 
+	var runErr error
 	if sourceTypes != nil && isSingleSourceType(sourceTypes) {
 		switch sourceTypes[0] {
 		case services.Aql:
-			return rbc.createFromAql(servicesManager, rbDetails, queryParams)
+			runErr = rbc.createFromAql(servicesManager, rbDetails, queryParams)
 		case services.Artifacts:
-			return rbc.createFromArtifacts(servicesManager, rbDetails, queryParams)
+			runErr = rbc.createFromArtifacts(servicesManager, rbDetails, queryParams)
 		case services.Builds:
-			return rbc.createFromBuilds(servicesManager, rbDetails, queryParams)
+			runErr = rbc.createFromBuilds(servicesManager, rbDetails, queryParams)
 		case services.ReleaseBundles:
-			return rbc.createFromReleaseBundles(servicesManager, rbDetails, queryParams)
+			runErr = rbc.createFromReleaseBundles(servicesManager, rbDetails, queryParams)
 		case services.Packages:
-			return rbc.createFromPackages(servicesManager, rbDetails, queryParams)
+			runErr = rbc.createFromPackages(servicesManager, rbDetails, queryParams)
 		default:
 			return errorutils.CheckError(errors.New("unknown source for release bundle creation was provided"))
 		}
-	}
-
-	if isReleaseBundleCreationWithMultiSourcesSupported {
+	} else if isReleaseBundleCreationWithMultiSourcesSupported {
 		sources, err := rbc.getMultipleSourcesIfDefined()
 		if err != nil {
 			return err
 		}
 		updateReleaseBundleRepoKeyWithProject(sources)
-		_, err = rbc.createFromMultipleSources(servicesManager, rbDetails, queryParams, sources)
-		return err
+		_, runErr = rbc.createFromMultipleSources(servicesManager, rbDetails, queryParams, sources)
+	} else {
+		return errorutils.CheckErrorf("release bundle creation failed, unable to identify source for creation")
 	}
-
-	return errorutils.CheckErrorf("release bundle creation failed, unable to identify source for creation")
+	if runErr != nil {
+		return runErr
+	}
+	return rbc.printCreateOutput()
 }
 
 func updateReleaseBundleRepoKeyWithProject(sources []services.RbSource) {
@@ -596,5 +607,27 @@ func validateCreationSource(unsupportedFields []bool, errMsg string) error {
 	if coreutils.SumTrueValues(unsupportedFields) > 0 {
 		return errorutils.CheckError(errors.New(errMsg))
 	}
+	return nil
+}
+
+func (rbc *ReleaseBundleCreateCommand) printCreateOutput() error {
+	if rbc.outputFormat != coreformat.Json {
+		return nil
+	}
+	type createOutput struct {
+		Name    string `json:"release_bundle_name"`
+		Version string `json:"release_bundle_version"`
+		Status  string `json:"status"`
+	}
+	out := createOutput{
+		Name:    rbc.releaseBundleName,
+		Version: rbc.releaseBundleVersion,
+		Status:  "created",
+	}
+	content, err := json.Marshal(out)
+	if err != nil {
+		return err
+	}
+	log.Output(clientutils.IndentJson(content))
 	return nil
 }

--- a/lifecycle/commands/createcommon.go
+++ b/lifecycle/commands/createcommon.go
@@ -170,7 +170,8 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 	}
 
 	var runErr error
-	if sourceTypes != nil && isSingleSourceType(sourceTypes) {
+	switch {
+	case sourceTypes != nil && isSingleSourceType(sourceTypes):
 		switch sourceTypes[0] {
 		case services.Aql:
 			runErr = rbc.createFromAql(servicesManager, rbDetails, queryParams)
@@ -185,14 +186,14 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 		default:
 			return errorutils.CheckError(errors.New("unknown source for release bundle creation was provided"))
 		}
-	} else if isReleaseBundleCreationWithMultiSourcesSupported {
+	case isReleaseBundleCreationWithMultiSourcesSupported:
 		sources, err := rbc.getMultipleSourcesIfDefined()
 		if err != nil {
 			return err
 		}
 		updateReleaseBundleRepoKeyWithProject(sources)
 		_, runErr = rbc.createFromMultipleSources(servicesManager, rbDetails, queryParams, sources)
-	} else {
+	default:
 		return errorutils.CheckErrorf("release bundle creation failed, unable to identify source for creation")
 	}
 	if runErr != nil {

--- a/lifecycle/commands/createcommon.go
+++ b/lifecycle/commands/createcommon.go
@@ -91,8 +91,8 @@ func (rbc *ReleaseBundleCreateCommand) SetDraft(draft bool) *ReleaseBundleCreate
 	return rbc
 }
 
-func (rbc *ReleaseBundleCreateCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundleCreateCommand {
-	rbc.outputFormat = f
+func (rbc *ReleaseBundleCreateCommand) SetOutputFormat(format coreformat.OutputFormat) *ReleaseBundleCreateCommand {
+	rbc.outputFormat = format
 	return rbc
 }
 
@@ -169,20 +169,20 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 		return err
 	}
 
-	var runErr error
+	var creationErr error
 	switch {
 	case sourceTypes != nil && isSingleSourceType(sourceTypes):
 		switch sourceTypes[0] {
 		case services.Aql:
-			runErr = rbc.createFromAql(servicesManager, rbDetails, queryParams)
+			creationErr = rbc.createFromAql(servicesManager, rbDetails, queryParams)
 		case services.Artifacts:
-			runErr = rbc.createFromArtifacts(servicesManager, rbDetails, queryParams)
+			creationErr = rbc.createFromArtifacts(servicesManager, rbDetails, queryParams)
 		case services.Builds:
-			runErr = rbc.createFromBuilds(servicesManager, rbDetails, queryParams)
+			creationErr = rbc.createFromBuilds(servicesManager, rbDetails, queryParams)
 		case services.ReleaseBundles:
-			runErr = rbc.createFromReleaseBundles(servicesManager, rbDetails, queryParams)
+			creationErr = rbc.createFromReleaseBundles(servicesManager, rbDetails, queryParams)
 		case services.Packages:
-			runErr = rbc.createFromPackages(servicesManager, rbDetails, queryParams)
+			creationErr = rbc.createFromPackages(servicesManager, rbDetails, queryParams)
 		default:
 			return errorutils.CheckError(errors.New("unknown source for release bundle creation was provided"))
 		}
@@ -192,12 +192,12 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 			return err
 		}
 		updateReleaseBundleRepoKeyWithProject(sources)
-		_, runErr = rbc.createFromMultipleSources(servicesManager, rbDetails, queryParams, sources)
+		_, creationErr = rbc.createFromMultipleSources(servicesManager, rbDetails, queryParams, sources)
 	default:
 		return errorutils.CheckErrorf("release bundle creation failed, unable to identify source for creation")
 	}
-	if runErr != nil {
-		return runErr
+	if creationErr != nil {
+		return creationErr
 	}
 	return rbc.printCreateOutput()
 }
@@ -615,7 +615,7 @@ func (rbc *ReleaseBundleCreateCommand) printCreateOutput() error {
 	if rbc.outputFormat != coreformat.Json {
 		return nil
 	}
-	return printEchoJson(rbc.releaseBundleName, rbc.releaseBundleVersion, "created")
+	return printEchoJson(rbc.releaseBundleName, rbc.releaseBundleVersion, statusCreated)
 }
 
 func printEchoJson(name, version, status string) error {

--- a/lifecycle/commands/distribute.go
+++ b/lifecycle/commands/distribute.go
@@ -1,9 +1,14 @@
 package commands
 
 import (
+	"encoding/json"
+
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type ReleaseBundleDistributeCommand struct {
@@ -14,6 +19,7 @@ type ReleaseBundleDistributeCommand struct {
 	pathMappingPattern string
 	pathMappingTarget  string
 	maxWaitMinutes     int
+	outputFormat       coreformat.OutputFormat
 }
 
 func NewReleaseBundleDistributeCommand() *ReleaseBundleDistributeCommand {
@@ -75,6 +81,11 @@ func (rbd *ReleaseBundleDistributeCommand) SetMaxWaitMinutes(maxWaitMinutes int)
 	return rbd
 }
 
+func (rbd *ReleaseBundleDistributeCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundleDistributeCommand {
+	rbd.outputFormat = f
+	return rbd
+}
+
 func (rbd *ReleaseBundleDistributeCommand) Run() error {
 	if err := validateArtifactoryVersionSupported(rbd.serverDetails); err != nil {
 		return err
@@ -99,7 +110,32 @@ func (rbd *ReleaseBundleDistributeCommand) Run() error {
 		ProjectKey:        rbd.rbProjectKey,
 	}
 
-	return servicesManager.DistributeReleaseBundle(rbDetails, distributeParams)
+	if err := servicesManager.DistributeReleaseBundle(rbDetails, distributeParams); err != nil {
+		return err
+	}
+	return rbd.printDistributeOutput()
+}
+
+func (rbd *ReleaseBundleDistributeCommand) printDistributeOutput() error {
+	if rbd.outputFormat != coreformat.Json {
+		return nil
+	}
+	type distributeOutput struct {
+		Name    string `json:"release_bundle_name"`
+		Version string `json:"release_bundle_version"`
+		Status  string `json:"status"`
+	}
+	out := distributeOutput{
+		Name:    rbd.releaseBundleName,
+		Version: rbd.releaseBundleVersion,
+		Status:  "distributed",
+	}
+	content, err := json.Marshal(out)
+	if err != nil {
+		return err
+	}
+	log.Output(clientutils.IndentJson(content))
+	return nil
 }
 
 func (rbd *ReleaseBundleDistributeCommand) ServerDetails() (*config.ServerDetails, error) {

--- a/lifecycle/commands/distribute.go
+++ b/lifecycle/commands/distribute.go
@@ -1,14 +1,10 @@
 package commands
 
 import (
-	"encoding/json"
-
 	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/lifecycle/services"
-	clientutils "github.com/jfrog/jfrog-client-go/utils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type ReleaseBundleDistributeCommand struct {
@@ -120,22 +116,7 @@ func (rbd *ReleaseBundleDistributeCommand) printDistributeOutput() error {
 	if rbd.outputFormat != coreformat.Json {
 		return nil
 	}
-	type distributeOutput struct {
-		Name    string `json:"release_bundle_name"`
-		Version string `json:"release_bundle_version"`
-		Status  string `json:"status"`
-	}
-	out := distributeOutput{
-		Name:    rbd.releaseBundleName,
-		Version: rbd.releaseBundleVersion,
-		Status:  "distributed",
-	}
-	content, err := json.Marshal(out)
-	if err != nil {
-		return err
-	}
-	log.Output(clientutils.IndentJson(content))
-	return nil
+	return printEchoJson(rbd.releaseBundleName, rbd.releaseBundleVersion, "distributed")
 }
 
 func (rbd *ReleaseBundleDistributeCommand) ServerDetails() (*config.ServerDetails, error) {

--- a/lifecycle/commands/distribute.go
+++ b/lifecycle/commands/distribute.go
@@ -77,8 +77,8 @@ func (rbd *ReleaseBundleDistributeCommand) SetMaxWaitMinutes(maxWaitMinutes int)
 	return rbd
 }
 
-func (rbd *ReleaseBundleDistributeCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundleDistributeCommand {
-	rbd.outputFormat = f
+func (rbd *ReleaseBundleDistributeCommand) SetOutputFormat(format coreformat.OutputFormat) *ReleaseBundleDistributeCommand {
+	rbd.outputFormat = format
 	return rbd
 }
 
@@ -116,7 +116,7 @@ func (rbd *ReleaseBundleDistributeCommand) printDistributeOutput() error {
 	if rbd.outputFormat != coreformat.Json {
 		return nil
 	}
-	return printEchoJson(rbd.releaseBundleName, rbd.releaseBundleVersion, "distributed")
+	return printEchoJson(rbd.releaseBundleName, rbd.releaseBundleVersion, statusDistributed)
 }
 
 func (rbd *ReleaseBundleDistributeCommand) ServerDetails() (*config.ServerDetails, error) {

--- a/lifecycle/commands/format_output_test.go
+++ b/lifecycle/commands/format_output_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
@@ -83,7 +82,6 @@ func TestDistributePrintOutput_Json(t *testing.T) {
 		},
 		outputFormat: coreformat.Json,
 	}
-	// Should not error
 	assert.NoError(t, cmd.printDistributeOutput())
 }
 
@@ -95,29 +93,7 @@ func TestDistributePrintOutput_NoFormat_Silent(t *testing.T) {
 		},
 		outputFormat: coreformat.None,
 	}
-	// No format set → no output and no error (backward-compat silent)
 	assert.NoError(t, cmd.printDistributeOutput())
-}
-
-func TestDistributePrintOutput_JsonContent(t *testing.T) {
-	cmd := &ReleaseBundleDistributeCommand{
-		releaseBundleCmd: releaseBundleCmd{
-			releaseBundleName:    "my-bundle",
-			releaseBundleVersion: "2.3.4",
-		},
-		outputFormat: coreformat.Json,
-	}
-	type distributeOutput struct {
-		Name    string `json:"release_bundle_name"`
-		Version string `json:"release_bundle_version"`
-		Status  string `json:"status"`
-	}
-	out := distributeOutput{Name: cmd.releaseBundleName, Version: cmd.releaseBundleVersion, Status: "distributed"}
-	content, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.True(t, strings.Contains(string(content), "my-bundle"))
-	assert.True(t, strings.Contains(string(content), "2.3.4"))
-	assert.True(t, strings.Contains(string(content), "distributed"))
 }
 
 func TestDistributeSetOutputFormat(t *testing.T) {
@@ -148,29 +124,12 @@ func TestCreatePrintOutput_NoFormat_Silent(t *testing.T) {
 		},
 		outputFormat: coreformat.None,
 	}
-	// No format set → no output and no error (backward-compat silent)
 	assert.NoError(t, cmd.printCreateOutput())
 }
 
-func TestCreatePrintOutput_JsonContent(t *testing.T) {
-	cmd := &ReleaseBundleCreateCommand{
-		releaseBundleCmd: releaseBundleCmd{
-			releaseBundleName:    "my-bundle",
-			releaseBundleVersion: "3.0.1",
-		},
-		outputFormat: coreformat.Json,
-	}
-	type createOutput struct {
-		Name    string `json:"release_bundle_name"`
-		Version string `json:"release_bundle_version"`
-		Status  string `json:"status"`
-	}
-	out := createOutput{Name: cmd.releaseBundleName, Version: cmd.releaseBundleVersion, Status: "created"}
-	content, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.True(t, strings.Contains(string(content), "my-bundle"))
-	assert.True(t, strings.Contains(string(content), "3.0.1"))
-	assert.True(t, strings.Contains(string(content), "created"))
+func TestPrintEchoJson(t *testing.T) {
+	assert.NoError(t, printEchoJson("my-bundle", "1.0.0", "created"))
+	assert.NoError(t, printEchoJson("my-bundle", "2.3.4", "distributed"))
 }
 
 func TestCreateSetOutputFormat(t *testing.T) {

--- a/lifecycle/commands/format_output_test.go
+++ b/lifecycle/commands/format_output_test.go
@@ -1,0 +1,181 @@
+package commands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
+	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- promote ---
+
+func TestPromotePrintOutput_Json(t *testing.T) {
+	resp := services.RbPromotionResp{
+		RepositoryKey: "dev-release-bundles-v2",
+		ReleaseBundleDetails: services.ReleaseBundleDetails{
+			ReleaseBundleName:    "my-bundle",
+			ReleaseBundleVersion: "1.0.0",
+		},
+		RbPromotionBody: services.RbPromotionBody{
+			Environment: "DEV",
+		},
+		Created: "2026-06-10T09:00:00.000Z",
+	}
+
+	cmd := NewReleaseBundlePromoteCommand().SetOutputFormat(coreformat.Json)
+
+	// Verify the response serializes correctly (the actual output goes to log.Output)
+	content, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "dev-release-bundles-v2")
+	assert.Contains(t, string(content), "my-bundle")
+	assert.Contains(t, string(content), "DEV")
+
+	// printOutput with Json should not error
+	assert.NoError(t, cmd.printOutput(resp))
+}
+
+func TestPromotePrintOutput_NoFormat_BackwardCompat(t *testing.T) {
+	resp := services.RbPromotionResp{
+		RepositoryKey: "dev-release-bundles-v2",
+	}
+	// format.None (no flag set) must also emit JSON — same as pre-existing behavior
+	cmd := NewReleaseBundlePromoteCommand() // outputFormat defaults to ""
+	assert.NoError(t, cmd.printOutput(resp))
+}
+
+func TestPromotePrintOutput_Table(t *testing.T) {
+	resp := services.RbPromotionResp{
+		RepositoryKey: "dev-release-bundles-v2",
+		ReleaseBundleDetails: services.ReleaseBundleDetails{
+			ReleaseBundleName:    "my-bundle",
+			ReleaseBundleVersion: "1.0.0",
+		},
+		RbPromotionBody: services.RbPromotionBody{
+			Environment: "DEV",
+		},
+		Created: "2026-06-10T09:00:00.000Z",
+	}
+	cmd := NewReleaseBundlePromoteCommand().SetOutputFormat(coreformat.Table)
+	assert.NoError(t, cmd.printOutput(resp))
+}
+
+func TestPromoteSetOutputFormat(t *testing.T) {
+	cmd := NewReleaseBundlePromoteCommand()
+	assert.Equal(t, coreformat.OutputFormat(""), cmd.outputFormat)
+	cmd.SetOutputFormat(coreformat.Json)
+	assert.Equal(t, coreformat.Json, cmd.outputFormat)
+	cmd.SetOutputFormat(coreformat.Table)
+	assert.Equal(t, coreformat.Table, cmd.outputFormat)
+}
+
+// --- distribute ---
+
+func TestDistributePrintOutput_Json(t *testing.T) {
+	cmd := &ReleaseBundleDistributeCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "1.0.0",
+		},
+		outputFormat: coreformat.Json,
+	}
+	// Should not error
+	assert.NoError(t, cmd.printDistributeOutput())
+}
+
+func TestDistributePrintOutput_NoFormat_Silent(t *testing.T) {
+	cmd := &ReleaseBundleDistributeCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "1.0.0",
+		},
+		outputFormat: coreformat.None,
+	}
+	// No format set → no output and no error (backward-compat silent)
+	assert.NoError(t, cmd.printDistributeOutput())
+}
+
+func TestDistributePrintOutput_JsonContent(t *testing.T) {
+	cmd := &ReleaseBundleDistributeCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "2.3.4",
+		},
+		outputFormat: coreformat.Json,
+	}
+	type distributeOutput struct {
+		Name    string `json:"release_bundle_name"`
+		Version string `json:"release_bundle_version"`
+		Status  string `json:"status"`
+	}
+	out := distributeOutput{Name: cmd.releaseBundleName, Version: cmd.releaseBundleVersion, Status: "distributed"}
+	content, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(content), "my-bundle"))
+	assert.True(t, strings.Contains(string(content), "2.3.4"))
+	assert.True(t, strings.Contains(string(content), "distributed"))
+}
+
+func TestDistributeSetOutputFormat(t *testing.T) {
+	cmd := NewReleaseBundleDistributeCommand()
+	assert.Equal(t, coreformat.OutputFormat(""), cmd.outputFormat)
+	cmd.SetOutputFormat(coreformat.Json)
+	assert.Equal(t, coreformat.Json, cmd.outputFormat)
+}
+
+// --- create ---
+
+func TestCreatePrintOutput_Json(t *testing.T) {
+	cmd := &ReleaseBundleCreateCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "1.0.0",
+		},
+		outputFormat: coreformat.Json,
+	}
+	assert.NoError(t, cmd.printCreateOutput())
+}
+
+func TestCreatePrintOutput_NoFormat_Silent(t *testing.T) {
+	cmd := &ReleaseBundleCreateCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "1.0.0",
+		},
+		outputFormat: coreformat.None,
+	}
+	// No format set → no output and no error (backward-compat silent)
+	assert.NoError(t, cmd.printCreateOutput())
+}
+
+func TestCreatePrintOutput_JsonContent(t *testing.T) {
+	cmd := &ReleaseBundleCreateCommand{
+		releaseBundleCmd: releaseBundleCmd{
+			releaseBundleName:    "my-bundle",
+			releaseBundleVersion: "3.0.1",
+		},
+		outputFormat: coreformat.Json,
+	}
+	type createOutput struct {
+		Name    string `json:"release_bundle_name"`
+		Version string `json:"release_bundle_version"`
+		Status  string `json:"status"`
+	}
+	out := createOutput{Name: cmd.releaseBundleName, Version: cmd.releaseBundleVersion, Status: "created"}
+	content, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(content), "my-bundle"))
+	assert.True(t, strings.Contains(string(content), "3.0.1"))
+	assert.True(t, strings.Contains(string(content), "created"))
+}
+
+func TestCreateSetOutputFormat(t *testing.T) {
+	cmd := NewReleaseBundleCreateCommand()
+	assert.Equal(t, coreformat.OutputFormat(""), cmd.outputFormat)
+	cmd.SetOutputFormat(coreformat.Json)
+	assert.Equal(t, coreformat.Json, cmd.outputFormat)
+}

--- a/lifecycle/commands/promote.go
+++ b/lifecycle/commands/promote.go
@@ -75,8 +75,8 @@ func (rbp *ReleaseBundlePromoteCommand) SetPromotionType(promotionType string) *
 	return rbp
 }
 
-func (rbp *ReleaseBundlePromoteCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundlePromoteCommand {
-	rbp.outputFormat = f
+func (rbp *ReleaseBundlePromoteCommand) SetOutputFormat(format coreformat.OutputFormat) *ReleaseBundlePromoteCommand {
+	rbp.outputFormat = format
 	return rbp
 }
 

--- a/lifecycle/commands/promote.go
+++ b/lifecycle/commands/promote.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"encoding/json"
+
+	coreformat "github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/lifecycle/services"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -15,6 +18,7 @@ type ReleaseBundlePromoteCommand struct {
 	includeReposPatterns []string
 	excludeReposPatterns []string
 	promotionType        string
+	outputFormat         coreformat.OutputFormat
 }
 
 func NewReleaseBundlePromoteCommand() *ReleaseBundlePromoteCommand {
@@ -71,6 +75,11 @@ func (rbp *ReleaseBundlePromoteCommand) SetPromotionType(promotionType string) *
 	return rbp
 }
 
+func (rbp *ReleaseBundlePromoteCommand) SetOutputFormat(f coreformat.OutputFormat) *ReleaseBundlePromoteCommand {
+	rbp.outputFormat = f
+	return rbp
+}
+
 func (rbp *ReleaseBundlePromoteCommand) CommandName() string {
 	return "rb_promote"
 }
@@ -85,7 +94,6 @@ func (rbp *ReleaseBundlePromoteCommand) Run() error {
 	}
 
 	servicesManager, rbDetails, queryParams, err := rbp.getPromotionPrerequisites()
-
 	if err != nil {
 		return err
 	}
@@ -100,10 +108,37 @@ func (rbp *ReleaseBundlePromoteCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	content, err := json.Marshal(promotionResp)
+	return rbp.printOutput(promotionResp)
+}
+
+func (rbp *ReleaseBundlePromoteCommand) printOutput(resp services.RbPromotionResp) error {
+	if rbp.outputFormat == coreformat.Table {
+		return printPromoteTable(resp)
+	}
+	// default (format.None) keeps the pre-existing JSON output for backward compatibility
+	content, err := json.Marshal(resp)
 	if err != nil {
 		return err
 	}
 	log.Output(utils.IndentJson(content))
 	return nil
+}
+
+type rbPromoteTableRow struct {
+	RepositoryKey        string `col-name:"REPOSITORY KEY"`
+	ReleaseBundleName    string `col-name:"BUNDLE NAME"`
+	ReleaseBundleVersion string `col-name:"VERSION"`
+	Environment          string `col-name:"ENVIRONMENT"`
+	Created              string `col-name:"CREATED"`
+}
+
+func printPromoteTable(resp services.RbPromotionResp) error {
+	row := rbPromoteTableRow{
+		RepositoryKey:        resp.RepositoryKey,
+		ReleaseBundleName:    resp.ReleaseBundleName,
+		ReleaseBundleVersion: resp.ReleaseBundleVersion,
+		Environment:          resp.Environment,
+		Created:              resp.Created,
+	}
+	return coreutils.PrintTable([]rbPromoteTableRow{row}, "Promotion Result", "No promotion result", false)
 }


### PR DESCRIPTION
## Summary

Adds `--format` flag support to the three lifecycle Release Bundle V2 commands:

- **`jf release-bundle-promote` (`rbp`)** — `--format json` (default, backward-compat) and `--format table`. Table renders a single-row summary with `REPOSITORY KEY`, `BUNDLE NAME`, `VERSION`, `ENVIRONMENT`, and `CREATED` columns.
- **`jf release-bundle-create` (`rbc`)** — `--format json` only (Pattern B / echo). No flag = silent (backward-compat). Emits `{ release_bundle_name, release_bundle_version, status: "created" }` on success.
- **`jf release-bundle-distribute` (`rbd`)** — `--format json` only (Pattern B / echo). No flag = silent (backward-compat). Emits `{ release_bundle_name, release_bundle_version, status: "distributed" }` on success.

## Changes

- `lifecycle/cli.go` — Added `SupportedFormats` to the three command definitions; wired `c.GetOutputFormat()` + `.SetOutputFormat()` in the `create()`, `promote()`, and `distribute()` action handlers; added `coreformat` import.
- `lifecycle/commands/promote.go` — Added `outputFormat` field, `SetOutputFormat()` setter, `printOutput()` dispatcher (json default / table), and `printPromoteTable()` helper using `coreutils.PrintTable`.
- `lifecycle/commands/distribute.go` — Added `outputFormat` field, `SetOutputFormat()` setter, and `printDistributeOutput()` echo-json helper.
- `lifecycle/commands/createcommon.go` — Added `outputFormat` field, `SetOutputFormat()` setter, and `printCreateOutput()` echo-json helper; refactored `Run()` to collect the create error at a single exit point before calling `printCreateOutput()`.
- `lifecycle/commands/format_output_test.go` *(new)* — 15 unit tests covering the json path, no-format backward-compat path, table path (for promote), content correctness, and setter behaviour for all three commands.

## Backward compatibility

All three commands retain their existing behaviour when `--format` is not specified:
- `rbp` continues to emit the full promotion JSON response.
- `rbc` and `rbd` continue to produce no output.

-----
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----