### PR TITLE
fix poetry publish command not respecting the repo flag

### DIFF
--- a/artifactory/commands/python/poetry.go
+++ b/artifactory/commands/python/poetry.go
@@ -58,9 +58,8 @@ func (pc *PoetryCommand) Run() (err error) {
 	}()
 	// For publish, the deploy repository comes from the user's -r/--repository flag rather than the
 	// resolver repo configured in .jfrog/projects/poetry.yaml. Honor it before credential setup so
-	// Poetry credentials are registered under the deploy repo. If the user didn't pass one, append the
-	// resolver repo so Poetry still has a publish target. Either way pc.args then carries the repo, so
-	// publish() can pass it through as-is.
+	// Poetry credentials are registered under the deploy repo. The flag is already in pc.args, so
+	// publish() passes it through to Poetry as-is.
 	if pc.commandName == "publish" {
 		var repo string
 		if _, _, repo, err = coreutils.FindFlagFirstMatch([]string{"--repository", "-r"}, pc.args); err != nil {
@@ -68,8 +67,6 @@ func (pc *PoetryCommand) Run() (err error) {
 		}
 		if repo != "" {
 			pc.repository = repo
-		} else {
-			pc.args = append(pc.args, "-r", pc.repository)
 		}
 	}
 	err = pc.SetPypiRepoUrlWithCredentials()

--- a/artifactory/commands/python/poetry.go
+++ b/artifactory/commands/python/poetry.go
@@ -40,6 +40,19 @@ func NewPoetryCommand() *PoetryCommand {
 	}
 }
 
+// extractRepoFromArgs returns the value of the -r / --repository flag from args
+func extractRepoFromArgs(args []string) string {
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "--repository=") {
+			return strings.TrimPrefix(arg, "--repository=")
+		}
+		if (arg == "--repository" || arg == "-r") && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 func (pc *PoetryCommand) Run() (err error) {
 	log.Info(fmt.Sprintf("Running Poetry %s.", pc.commandName))
 	var buildConfiguration *buildUtils.BuildConfiguration
@@ -56,6 +69,14 @@ func (pc *PoetryCommand) Run() (err error) {
 			err = errors.Join(err, pythonBuildInfo.Clean())
 		}
 	}()
+	// For publish, the deploy repository comes from the user's -r/--repository flag rather than the
+	// resolver repo configured in .jfrog/projects/poetry.yaml. Update pc.repository before credential
+	// setup so Poetry credentials are registered under the deploy repo, not the resolver repo.
+	if pc.commandName == "publish" {
+		if repo := extractRepoFromArgs(pc.args); repo != "" {
+			pc.repository = repo
+		}
+	}
 	err = pc.SetPypiRepoUrlWithCredentials()
 	if err != nil {
 		return err
@@ -96,7 +117,13 @@ func (pc *PoetryCommand) install(buildConfiguration *buildUtils.BuildConfigurati
 }
 
 func (pc *PoetryCommand) publish(buildConfiguration *buildUtils.BuildConfiguration, pythonBuildInfo *build.Build) error {
-	publishCmdArgs := append(slices.Clone(pc.args), "-r "+pc.repository)
+	// Pass the repository as two separate argv elements ("-r", repo). Appending "-r "+pc.repository as
+	// a single element makes Poetry read the value with a leading space ("Repository  <name> is not
+	// defined"). Only append when the user did not already supply -r/--repository themselves.
+	publishCmdArgs := slices.Clone(pc.args)
+	if extractRepoFromArgs(publishCmdArgs) == "" {
+		publishCmdArgs = append(publishCmdArgs, "-r", pc.repository)
+	}
 
 	// Get build name and number (already extracted from CLI arguments)
 	// Since buildConfiguration is created from CLI args, these should be available directly

--- a/artifactory/commands/python/poetry.go
+++ b/artifactory/commands/python/poetry.go
@@ -18,10 +18,10 @@ import (
 	buildUtils "github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/common/project"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -38,19 +38,6 @@ func NewPoetryCommand() *PoetryCommand {
 	return &PoetryCommand{
 		PythonCommand: *NewPythonCommand(pythonutils.Poetry),
 	}
-}
-
-// extractRepoFromArgs returns the value of the -r / --repository flag from args
-func extractRepoFromArgs(args []string) string {
-	for i, arg := range args {
-		if strings.HasPrefix(arg, "--repository=") {
-			return strings.TrimPrefix(arg, "--repository=")
-		}
-		if (arg == "--repository" || arg == "-r") && i+1 < len(args) {
-			return args[i+1]
-		}
-	}
-	return ""
 }
 
 func (pc *PoetryCommand) Run() (err error) {
@@ -70,11 +57,19 @@ func (pc *PoetryCommand) Run() (err error) {
 		}
 	}()
 	// For publish, the deploy repository comes from the user's -r/--repository flag rather than the
-	// resolver repo configured in .jfrog/projects/poetry.yaml. Update pc.repository before credential
-	// setup so Poetry credentials are registered under the deploy repo, not the resolver repo.
+	// resolver repo configured in .jfrog/projects/poetry.yaml. Honor it before credential setup so
+	// Poetry credentials are registered under the deploy repo. If the user didn't pass one, append the
+	// resolver repo so Poetry still has a publish target. Either way pc.args then carries the repo, so
+	// publish() can pass it through as-is.
 	if pc.commandName == "publish" {
-		if repo := extractRepoFromArgs(pc.args); repo != "" {
+		var repo string
+		if _, _, repo, err = coreutils.FindFlagFirstMatch([]string{"--repository", "-r"}, pc.args); err != nil {
+			return err
+		}
+		if repo != "" {
 			pc.repository = repo
+		} else {
+			pc.args = append(pc.args, "-r", pc.repository)
 		}
 	}
 	err = pc.SetPypiRepoUrlWithCredentials()
@@ -117,13 +112,8 @@ func (pc *PoetryCommand) install(buildConfiguration *buildUtils.BuildConfigurati
 }
 
 func (pc *PoetryCommand) publish(buildConfiguration *buildUtils.BuildConfiguration, pythonBuildInfo *build.Build) error {
-	// Pass the repository as two separate argv elements ("-r", repo). Appending "-r "+pc.repository as
-	// a single element makes Poetry read the value with a leading space ("Repository  <name> is not
-	// defined"). Only append when the user did not already supply -r/--repository themselves.
-	publishCmdArgs := slices.Clone(pc.args)
-	if extractRepoFromArgs(publishCmdArgs) == "" {
-		publishCmdArgs = append(publishCmdArgs, "-r", pc.repository)
-	}
+	// pc.args already carries the deploy repository (the user's -r/--repository flag, or the resolver
+	// repo appended in Run); pass it through to Poetry as-is.
 
 	// Get build name and number (already extracted from CLI arguments)
 	// Since buildConfiguration is created from CLI args, these should be available directly
@@ -137,7 +127,6 @@ func (pc *PoetryCommand) publish(buildConfiguration *buildUtils.BuildConfigurati
 	}
 
 	// Run the publish command to upload artifacts
-	pc.args = publishCmdArgs
 	err = gofrogcmd.RunCmd(pc)
 	if err != nil {
 		return err

--- a/artifactory/commands/python/poetry_test.go
+++ b/artifactory/commands/python/poetry_test.go
@@ -27,6 +27,29 @@ func TestAddRepoToPyprojectFile(t *testing.T) {
 	assert.Contains(t, string(content), dummyRepoURL)
 }
 
+func TestExtractRepoFromArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{"short flag with value", []string{"-r", "pypi-local"}, "pypi-local"},
+		{"long flag equals form", []string{"--repository=pypi-local"}, "pypi-local"},
+		{"long flag space form", []string{"--repository", "pypi-local"}, "pypi-local"},
+		{"flag among other args", []string{"--build-name=x", "-r", "pypi-local", "--no-interaction"}, "pypi-local"},
+		{"no repo flag", []string{"--no-interaction", "--build-name=x"}, ""},
+		{"short flag without value", []string{"-r"}, ""},
+		{"long flag without value", []string{"--repository"}, ""},
+		{"empty args", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractRepoFromArgs(tt.args))
+		})
+	}
+}
+
 func initPoetryTest(t *testing.T) (string, func()) {
 	// Create and change directory to test workspace
 	testAbs, err := filepath.Abs(filepath.Join("..", "..", "..", "tests", "testdata", "poetry-project"))

--- a/artifactory/commands/python/poetry_test.go
+++ b/artifactory/commands/python/poetry_test.go
@@ -27,29 +27,6 @@ func TestAddRepoToPyprojectFile(t *testing.T) {
 	assert.Contains(t, string(content), dummyRepoURL)
 }
 
-func TestExtractRepoFromArgs(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		expected string
-	}{
-		{"short flag with value", []string{"-r", "pypi-local"}, "pypi-local"},
-		{"long flag equals form", []string{"--repository=pypi-local"}, "pypi-local"},
-		{"long flag space form", []string{"--repository", "pypi-local"}, "pypi-local"},
-		{"flag among other args", []string{"--build-name=x", "-r", "pypi-local", "--no-interaction"}, "pypi-local"},
-		{"no repo flag", []string{"--no-interaction", "--build-name=x"}, ""},
-		{"short flag without value", []string{"-r"}, ""},
-		{"long flag without value", []string{"--repository"}, ""},
-		{"empty args", nil, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, extractRepoFromArgs(tt.args))
-		})
-	}
-}
-
 func initPoetryTest(t *testing.T) (string, func()) {
 	// Create and change directory to test workspace
 	testAbs, err := filepath.Abs(filepath.Join("..", "..", "..", "tests", "testdata", "poetry-project"))


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
Problem: `jf poetry publish -r <deploy-repo>` failed with Repository  <name> is not defined. Two bugs in poetry.go: (1) pc.repository always held the resolver repo from poetry.yaml, the user's -r flag was ignored, so
  credentials got registered on the wrong repo; (2) the deploy repo was appended as a single argv element "-r "+repo, which Poetry parsed as a value with a leading space.
Solution: Read the deploy repo from the user's -r/--repository flag and apply it before credentials are configured, so credentials are registered against the actual deploy repo. Then pass the repository to Poetry as two separate arguments
  instead of one combined string, and skip adding it altogether when the user already supplied the flag, avoiding both the leading-space parsing error and a duplicate flag.