### PR TITLE
Add AI help coverage check to static analysis

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -45,7 +45,32 @@ jobs:
 
       - name: Run golangci linter
         uses: jfrog/.github/actions/golangci-lint@main
-        
+
+      - name: Check AI help coverage
+        uses: jfrog/.github/actions/ai-help-coverage@main
+        with:
+          # Commands still missing AI-oriented help. Remove each once a
+          # GetAIDescription() is added and wired through ResolveDescription.
+          skip-commands: |
+            agent plugins delete
+            agent plugins install
+            agent plugins list
+            agent plugins publish
+            agent plugins search
+            agent plugins update
+            agent skills delete
+            agent skills install
+            agent skills list
+            agent skills publish
+            agent skills search
+            agent skills update
+            skills delete
+            skills install
+            skills list
+            skills publish
+            skills search
+            skills update
+
   Go-Sec:
     name: Go-Sec ubuntu-latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the AI-help-coverage check to the Static Analysis workflow. It fails CI when a visible command ships without AI-oriented help, so agents never fall back to the short human description.

The `agent plugins`, `agent skills`, and `skills` commands do not yet have AI help and are listed under `skip-commands` for now — each entry should be removed as a `GetAIDescription()` is added.