### PR TITLE
Fix gradle v8.14.4 compatibility [AZ_PMCompatFixer]

### DIFF
--- a/artifactory/commands/gradle/gradle_test.go
+++ b/artifactory/commands/gradle/gradle_test.go
@@ -41,15 +41,15 @@ func TestGenerateInitScript(t *testing.T) {
 	assert.Contains(t, script, "clear()")
 	assert.Contains(t, script, "Clear any existing repositories")
 
-	// Verify metadataSources is not included (uses Gradle defaults)
-	assert.NotContains(t, script, "metadataSources")
-	assert.NotContains(t, script, "artifact()")
-	assert.NotContains(t, script, "mavenPom()")
+	// Verify metadataSources is included for Gradle 8.14+ repository resolution
+	assert.Contains(t, script, "metadataSources")
+	assert.Contains(t, script, "artifact()")
+	assert.Contains(t, script, "mavenPom()")
 
 	// Verify credentials and security configuration
 	assert.Contains(t, script, "credentials {")
 	assert.Contains(t, script, "allowInsecureProtocol")
-	assert.Contains(t, script, "gradleVersion >= GradleVersion.version")
+	assert.Contains(t, script, `artifactoryUrl.startsWith("http://")`)
 }
 
 func TestWriteInitScript(t *testing.T) {

--- a/artifactory/commands/gradle/resources/jfrog.init.gradle
+++ b/artifactory/commands/gradle/resources/jfrog.init.gradle
@@ -1,11 +1,8 @@
-import org.gradle.util.GradleVersion
-
 def artifactoryUrl = '{{ .ArtifactoryURL }}'
 def gradleRepoName = '{{ .GradleRepoName }}'
 def artifactoryUsername = '{{ .ArtifactoryUsername }}'
 def artifactoryAccessToken = '{{ .ArtifactoryAccessToken }}'
-def gradleVersion = GradleVersion.current()
-def allowInsecure = gradleVersion >= GradleVersion.version("6.2") && artifactoryUrl.startsWith("http://")
+def allowInsecure = artifactoryUrl.startsWith("http://")
 
 void configureMavenRepo(repositories, String rtUrl, String rtUser, String rtPass, boolean allowInsecure) {
     repositories.maven {
@@ -18,6 +15,10 @@ void configureMavenRepo(repositories, String rtUrl, String rtUser, String rtPass
         // This is used when Artifactory is running in HTTP mode
         if (allowInsecure) {
             allowInsecureProtocol = true
+        }
+        metadataSources {
+            mavenPom()
+            artifact()
         }
     }
 }


### PR DESCRIPTION
## Automated fix by AZ_PMCompatFixer

**PM:** `gradle` `v8.14.4`
**Failing run:** https://github.jfrog.info/JFROG/jfrog-cli-workflows/actions/runs/639894
**Tested against:** jfrog-cli @ `master`

This PR was generated by the AZ_PMCompatFixer agent diagnosing a gradle compatibility
test failure and applying a fix to the JFrog Gradle integration.

---
_Raised automatically by AZ_PMCompatFixer (PM Version Monitor auto-fix). Please review before merging._
