### PR TITLE
RTECO-1074 - Remove redundant functions in agent namespace(1/2)

### DIFF
--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -864,3 +864,53 @@ jobs:
       - name: Run Distribution tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.distribution --jfrog.url=${{ secrets.EPLUS_PLATFORM_URL }} --jfrog.adminToken=${{ secrets.EPLUS_ADMIN_TOKEN }} --jfrog.user=${{ secrets.PLATFORM_USER }} --ci.runId=${{ runner.os }}-distribution
+
+  Agent-Plugins-Tests:
+    name: agent-plugins ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout jfrog-cli-artifactory
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          build_info_go_repo: ${{ needs.Detect-Deps.outputs.build_info_go_repo }}
+          build_info_go_ref: ${{ needs.Detect-Deps.outputs.build_info_go_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run agent plugins tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.agentPlugins

--- a/agent/common/agents.go
+++ b/agent/common/agents.go
@@ -140,6 +140,28 @@ func ResolveAgentInstallDir(spec AgentSpec, projectDir string, global bool) (str
 	return filepath.Abs(filepath.Join(projectDir, spec.Config.ProjectDir))
 }
 
+// ParseHarnessList parses comma-separated harness names (trim, lowercase, reject empty/duplicates).
+func ParseHarnessList(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("--harness is required (comma-separated list of harness names)")
+	}
+
+	seen := make(map[string]struct{})
+	var result []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name == "" {
+			return nil, fmt.Errorf("--harness contains an empty name in %q", raw)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("--harness lists %q more than once", name)
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
 // SupportedAgentsList is comma-separated names from registry or built-ins.
 func SupportedAgentsList(builtIns map[string]AgentConfig, configSectionKey string) string {
 	registry, err := LoadAgentRegistry(builtIns, configSectionKey)

--- a/agent/common/agents_test.go
+++ b/agent/common/agents_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHarnessList(t *testing.T) {
+	got, err := ParseHarnessList("cursor, Claude")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cursor", "claude"}, got)
+}
+
+func TestParseHarnessList_EmptyAndDuplicates(t *testing.T) {
+	_, err := ParseHarnessList("")
+	require.Error(t, err)
+
+	_, err = ParseHarnessList("cursor,,claude")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty name")
+
+	_, err = ParseHarnessList("cursor,cursor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than once")
+}

--- a/agent/common/agents_test.go
+++ b/agent/common/agents_test.go
@@ -7,12 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestParseHarnessList verifies that a comma-separated harness list is split,
+// trimmed, and lowercased correctly.
 func TestParseHarnessList(t *testing.T) {
 	got, err := ParseHarnessList("cursor, Claude")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"cursor", "claude"}, got)
 }
 
+// TestParseHarnessList_EmptyAndDuplicates verifies that an empty string, a
+// segment that resolves to an empty name after trimming, and a repeated harness
+// name are all rejected with descriptive errors.
 func TestParseHarnessList_EmptyAndDuplicates(t *testing.T) {
 	_, err := ParseHarnessList("")
 	require.Error(t, err)

--- a/agent/common/install_targets.go
+++ b/agent/common/install_targets.go
@@ -25,7 +25,14 @@ type InstallTarget struct {
 }
 
 // ResolveAgentTargets resolves per-agent install destinations for a slug.
+// Parameters:
+//   - slug: package name to install (e.g., "web")
+//   - path: absolute path for --path mode (empty string for harness mode)
+//   - agents: list of target agents (nil for --path mode)
+//   - projectDirAbs: absolute project directory (empty for --global mode)
+//   - isGlobal: true for global scope, false for project scope
 func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs string, isGlobal bool) ([]InstallTarget, error) {
+	// --path mode: return single synthetic agent at specified path
 	if path != "" {
 		target, err := BuildPathInstallTarget(slug, path)
 		if err != nil {
@@ -34,6 +41,7 @@ func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs st
 		return []InstallTarget{target}, nil
 	}
 
+	// Harness mode: determine scope (project or global)
 	scope := InstallScopeProject
 	if isGlobal {
 		scope = InstallScopeGlobal
@@ -42,6 +50,7 @@ func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs st
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
 
+	// Build target directory for each agent
 	targets := make([]InstallTarget, 0, len(agents))
 	for _, agent := range agents {
 		base, err := ResolveAgentInstallDir(agent, projectDirAbs, isGlobal)

--- a/agent/common/install_targets.go
+++ b/agent/common/install_targets.go
@@ -24,6 +24,39 @@ type InstallTarget struct {
 	DestinationDir string
 }
 
+// ResolveAgentTargets resolves per-agent install destinations for a slug.
+func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs string, isGlobal bool) ([]InstallTarget, error) {
+	if path != "" {
+		target, err := BuildPathInstallTarget(slug, path)
+		if err != nil {
+			return nil, err
+		}
+		return []InstallTarget{target}, nil
+	}
+
+	scope := InstallScopeProject
+	if isGlobal {
+		scope = InstallScopeGlobal
+	}
+	if scope == InstallScopeProject && projectDirAbs == "" {
+		return nil, fmt.Errorf("project directory is required for project-scoped install")
+	}
+
+	targets := make([]InstallTarget, 0, len(agents))
+	for _, agent := range agents {
+		base, err := ResolveAgentInstallDir(agent, projectDirAbs, isGlobal)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, InstallTarget{
+			Agent:          agent,
+			Scope:          scope,
+			DestinationDir: filepath.Join(base, slug),
+		})
+	}
+	return targets, nil
+}
+
 // BuildPathInstallTarget returns a ScopePath install target at path/slug.
 func BuildPathInstallTarget(slug, path string) (InstallTarget, error) {
 	base, err := filepath.Abs(path)

--- a/agent/common/install_targets_test.go
+++ b/agent/common/install_targets_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestResolveAgentTargets_PathMode verifies that when an explicit base directory
+// is provided (path mode), a single target is returned whose destination is
+// base/packageName and whose scope is InstallScopePath.
 func TestResolveAgentTargets_PathMode(t *testing.T) {
 	base := t.TempDir()
 	targets, err := ResolveAgentTargets("my-package", base, nil, "", false)
@@ -18,6 +21,9 @@ func TestResolveAgentTargets_PathMode(t *testing.T) {
 	assert.Equal(t, InstallScopePath, targets[0].Scope)
 }
 
+// TestResolveAgentTargets_Project verifies that when an agent spec with a
+// project-scoped directory is provided, the target destination is resolved
+// relative to the project root and the scope is InstallScopeProject.
 func TestResolveAgentTargets_Project(t *testing.T) {
 	projectRoot := t.TempDir()
 	spec := AgentSpec{Name: "claude", Config: AgentConfig{ProjectDir: ".claude/plugins"}}

--- a/agent/common/install_targets_test.go
+++ b/agent/common/install_targets_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResolveAgentTargets_PathMode(t *testing.T) {
+	base := t.TempDir()
+	targets, err := ResolveAgentTargets("my-package", base, nil, "", false)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(base, "my-package"), targets[0].DestinationDir)
+	assert.Equal(t, PathAgentName, targets[0].Agent.Name)
+	assert.Equal(t, InstallScopePath, targets[0].Scope)
+}
+
+func TestResolveAgentTargets_Project(t *testing.T) {
+	projectRoot := t.TempDir()
+	spec := AgentSpec{Name: "claude", Config: AgentConfig{ProjectDir: ".claude/plugins"}}
+	targets, err := ResolveAgentTargets("my-package", "", []AgentSpec{spec}, projectRoot, false)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(projectRoot, ".claude", "plugins", "my-package"), targets[0].DestinationDir)
+	assert.Equal(t, InstallScopeProject, targets[0].Scope)
+}
+
 func TestBuildPathInstallTarget(t *testing.T) {
 	base := t.TempDir()
 	target, err := BuildPathInstallTarget("my-package", base)

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -266,13 +266,13 @@ func (ic *InstallCommand) handleEvidenceVerification() error {
 
 func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentTarget, error) {
 	if ic.installPath != "" {
-		return plugincommon.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
+		return agentcommon.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
 	}
 	if ic.scope == agentcommon.InstallScopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
 	isGlobal := ic.scope == agentcommon.InstallScopeGlobal
-	return plugincommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
+	return agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
 }
 
 func (ic *InstallCommand) writePluginInfoManifest(target plugincommon.AgentTarget) error {

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -266,12 +266,16 @@ func (ic *InstallCommand) handleEvidenceVerification() error {
 
 func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentTarget, error) {
 	if ic.installPath != "" {
+		// projectDirAbs is "" because --path mode uses an absolute path directly
+		// e.g., jf agent plugins install web --path /home/user/plugins
 		return agentcommon.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
 	}
 	if ic.scope == agentcommon.InstallScopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
 	isGlobal := ic.scope == agentcommon.InstallScopeGlobal
+	// Path is "" because harness mode uses project or global scope
+	// e.g., jf agent plugins install web --harness claude --global
 	return agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
 }
 

--- a/agent/plugins/commands/list/list.go
+++ b/agent/plugins/commands/list/list.go
@@ -423,7 +423,7 @@ func RunList(c *components.Context) error {
 
 	var agentNames []string
 	if rawHarness != "" {
-		agentNames, err = pluginscommon.ParseHarnessList(rawHarness)
+		agentNames, err = agentcommon.ParseHarnessList(rawHarness)
 		if err != nil {
 			return err
 		}

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -140,7 +140,7 @@ func newUpdate(c *components.Context) (update, error) {
 
 // runUpdateOnSlug updates a single slug across all resolved targets.
 func runUpdateOnSlug(opts update, slug, requestedVersion string) error {
-	targets, err := plugincommon.ResolveAgentTargets(slug, opts.flags.AbsoluteInstallBaseDir, opts.flags.Specs, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
+	targets, err := agentcommon.ResolveAgentTargets(slug, opts.flags.AbsoluteInstallBaseDir, opts.flags.Specs, opts.flags.ProjectDirAbs, opts.flags.IsGlobal)
 	if err != nil {
 		return err
 	}

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -1,9 +1,6 @@
 package common
 
 import (
-	"fmt"
-	"strings"
-
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 )
 
@@ -24,26 +21,4 @@ var RegistryHelp = agentcommon.AgentRegistryHelpExample{
 	ConfigSectionKey:  agentcommon.PluginsAgentsKey,
 	ExampleProjectDir: ".my-agent/plugins",
 	ExampleGlobalDir:  "~/.my-agent/plugins",
-}
-
-// ParseHarnessList parses comma-separated harness names (trim, lowercase, reject empty/duplicates).
-func ParseHarnessList(raw string) ([]string, error) {
-	if strings.TrimSpace(raw) == "" {
-		return nil, fmt.Errorf("--harness is required (comma-separated list of harness names)")
-	}
-
-	seen := make(map[string]struct{})
-	var result []string
-	for _, part := range strings.Split(raw, ",") {
-		name := strings.ToLower(strings.TrimSpace(part))
-		if name == "" {
-			return nil, fmt.Errorf("--harness contains an empty name in %q", raw)
-		}
-		if _, dup := seen[name]; dup {
-			return nil, fmt.Errorf("--harness lists %q more than once", name)
-		}
-		seen[name] = struct{}{}
-		result = append(result, name)
-	}
-	return result, nil
 }

--- a/agent/plugins/common/agents_test.go
+++ b/agent/plugins/common/agents_test.go
@@ -73,25 +73,6 @@ func TestLoadAgentRegistry_RejectsEmptyEntry(t *testing.T) {
 	assert.Contains(t, err.Error(), "must define globalDir and/or projectDir")
 }
 
-func TestParseHarnessList(t *testing.T) {
-	got, err := ParseHarnessList("cursor, Claude")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"cursor", "claude"}, got)
-}
-
-func TestParseHarnessList_EmptyAndDuplicates(t *testing.T) {
-	_, err := ParseHarnessList("")
-	require.Error(t, err)
-
-	_, err = ParseHarnessList("cursor,,claude")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty name")
-
-	_, err = ParseHarnessList("cursor,cursor")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "more than once")
-}
-
 func TestResolveAgent_Unknown(t *testing.T) {
 	testutil.WithJfrogHome(t)
 	registry, err := agentcommon.LoadAgentRegistry(Agents, agentcommon.PluginsAgentsKey)

--- a/agent/plugins/common/install_targets.go
+++ b/agent/plugins/common/install_targets.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
@@ -49,7 +48,7 @@ func ValidateInstallFlags(c *components.Context) (agentcommon.InstallFlagsResult
 		return agentcommon.InstallFlagsResult{}, fmt.Errorf("--harness is required unless --path is set. Supported harnesses: %s", agentcommon.AgentNames(registry))
 	}
 
-	harnessNames, err := ParseHarnessList(rawHarness)
+	harnessNames, err := agentcommon.ParseHarnessList(rawHarness)
 	if err != nil {
 		return agentcommon.InstallFlagsResult{}, err
 	}
@@ -71,38 +70,4 @@ func ValidateInstallFlags(c *components.Context) (agentcommon.InstallFlagsResult
 		ProjectDirAbs: projectDirAbs,
 		IsGlobal:      isGlobal,
 	}, nil
-}
-
-// ResolveAgentTargets resolves per-agent install destinations for a plugin.
-// When path is non-empty, a single ScopePath target is returned.
-func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs string, isGlobal bool) ([]AgentTarget, error) {
-	if path != "" {
-		target, err := agentcommon.BuildPathInstallTarget(slug, path)
-		if err != nil {
-			return nil, err
-		}
-		return []AgentTarget{target}, nil
-	}
-
-	scope := ScopeProject
-	if isGlobal {
-		scope = ScopeGlobal
-	}
-	if scope == ScopeProject && projectDirAbs == "" {
-		return nil, fmt.Errorf("project directory is required for project-scoped install")
-	}
-
-	targets := make([]AgentTarget, 0, len(agents))
-	for _, agent := range agents {
-		base, err := agentcommon.ResolveAgentInstallDir(agent, projectDirAbs, isGlobal)
-		if err != nil {
-			return nil, err
-		}
-		targets = append(targets, AgentTarget{
-			Agent:          agent,
-			Scope:          scope,
-			DestinationDir: filepath.Join(base, slug),
-		})
-	}
-	return targets, nil
 }

--- a/agent/plugins/common/install_targets_test.go
+++ b/agent/plugins/common/install_targets_test.go
@@ -136,25 +136,3 @@ func TestValidateInstallFlags_ConflictingFlags(t *testing.T) {
 		})
 	}
 }
-
-func TestResolveAgentTargets_PathMode(t *testing.T) {
-	base := t.TempDir()
-	targets, err := ResolveAgentTargets("my-plugin", base, nil, "", false)
-	require.NoError(t, err)
-	require.Len(t, targets, 1)
-	target := targets[0]
-	assert.Equal(t, filepath.Join(base, "my-plugin"), target.DestinationDir)
-	assert.Equal(t, PathAgentName, target.Agent.Name)
-	assert.Equal(t, ScopePath, target.Scope)
-}
-
-func TestResolveAgentTargets_Project(t *testing.T) {
-	projectRoot := t.TempDir()
-	spec := AgentSpec{Name: "claude", Config: AgentConfig{ProjectDir: ".claude/plugins"}}
-	targets, err := ResolveAgentTargets("my-plugin", "", []AgentSpec{spec}, projectRoot, false)
-	require.NoError(t, err)
-	require.Len(t, targets, 1)
-	target := targets[0]
-	assert.Equal(t, filepath.Join(projectRoot, ".claude", "plugins", "my-plugin"), target.DestinationDir)
-	assert.Equal(t, ScopeProject, target.Scope)
-}

--- a/agent/skills/commands/install/install.go
+++ b/agent/skills/commands/install/install.go
@@ -247,13 +247,13 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]common.AgentTarget,
 		return ic.explicitTargets, nil
 	}
 	if ic.installPath != "" {
-		return common.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
+		return agentcommon.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
 	}
 	if ic.scope == agentcommon.InstallScopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
 	isGlobal := ic.scope == agentcommon.InstallScopeGlobal
-	return common.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
+	return agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
 }
 
 func (ic *InstallCommand) writeSkillInfoManifest(target common.AgentTarget) error {

--- a/agent/skills/commands/install/install.go
+++ b/agent/skills/commands/install/install.go
@@ -247,12 +247,16 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]common.AgentTarget,
 		return ic.explicitTargets, nil
 	}
 	if ic.installPath != "" {
+		// projectDirAbs is "" because --path mode uses an absolute path directly
+		// e.g., jf agent skills install web --path /home/user/skills
 		return agentcommon.ResolveAgentTargets(ic.slug, ic.installPath, nil, "", false)
 	}
 	if ic.scope == agentcommon.InstallScopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
 	isGlobal := ic.scope == agentcommon.InstallScopeGlobal
+	// Path is "" because harness mode uses project or global scope
+	// e.g., jf agent skills install web --harness cursor --global
 	return agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
 }
 

--- a/agent/skills/commands/update/update.go
+++ b/agent/skills/commands/update/update.go
@@ -59,7 +59,7 @@ func RunUpdate(c *components.Context) error {
 		format = c.GetStringFlagValue("format")
 	}
 
-	targets, err := common.ResolveAgentTargets(slug, flags.AbsoluteInstallBaseDir, flags.Specs, flags.ProjectDirAbs, flags.IsGlobal)
+	targets, err := agentcommon.ResolveAgentTargets(slug, flags.AbsoluteInstallBaseDir, flags.Specs, flags.ProjectDirAbs, flags.IsGlobal)
 	if err != nil {
 		return err
 	}

--- a/agent/skills/common/agents.go
+++ b/agent/skills/common/agents.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 )
@@ -12,7 +11,6 @@ type AgentConfig = agentcommon.AgentConfig
 type AgentSpec = agentcommon.AgentSpec
 
 // Agents is built-in defaults; merged with ~/.jfrog/agents/agent-config.json.
-// Reference: https://github.com/vercel-labs/skills/pull/76/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172
 var Agents = map[string]AgentConfig{
 	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},
 	"cursor":         {GlobalDir: "~/.cursor/skills", ProjectDir: ".cursor/skills"},
@@ -29,31 +27,9 @@ var RegistryHelp = agentcommon.AgentRegistryHelpExample{
 	ExampleGlobalDir:  "~/.my-agent/skills",
 }
 
-// ParseHarnessList parses comma-separated harness names (trim, lowercase, reject empty/duplicates).
-func ParseHarnessList(raw string) ([]string, error) {
-	if strings.TrimSpace(raw) == "" {
-		return nil, fmt.Errorf("--harness is required (comma-separated list of harness names)")
-	}
-
-	seen := make(map[string]struct{})
-	var result []string
-	for _, part := range strings.Split(raw, ",") {
-		name := strings.ToLower(strings.TrimSpace(part))
-		if name == "" {
-			return nil, fmt.Errorf("--harness contains an empty name in %q", raw)
-		}
-		if _, dup := seen[name]; dup {
-			return nil, fmt.Errorf("--harness lists %q more than once", name)
-		}
-		seen[name] = struct{}{}
-		result = append(result, name)
-	}
-	return result, nil
-}
-
 // ParseHarnessForList parses --harness for list (exactly one harness name; commas are rejected).
 func ParseHarnessForList(raw string) (string, error) {
-	names, err := ParseHarnessList(raw)
+	names, err := agentcommon.ParseHarnessList(raw)
 	if err != nil {
 		return "", err
 	}

--- a/agent/skills/common/agents_test.go
+++ b/agent/skills/common/agents_test.go
@@ -79,12 +79,6 @@ func TestLoadAgentRegistry_RejectsBadJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse agent config")
 }
 
-func TestParseHarnessList(t *testing.T) {
-	got, err := ParseHarnessList("cursor, Claude-Code")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"cursor", "claude-code"}, got)
-}
-
 func TestParseHarnessForList_Single(t *testing.T) {
 	got, err := ParseHarnessForList("cursor")
 	require.NoError(t, err)
@@ -95,19 +89,6 @@ func TestParseHarnessForList_RejectsCommaSeparated(t *testing.T) {
 	_, err := ParseHarnessForList("cursor,claude-code")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "one harness name")
-}
-
-func TestParseHarnessList_EmptyAndDuplicates(t *testing.T) {
-	_, err := ParseHarnessList("")
-	require.Error(t, err)
-
-	_, err = ParseHarnessList("cursor,,claude-code")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty name")
-
-	_, err = ParseHarnessList("cursor,cursor")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "more than once")
 }
 
 func TestResolveAgent_Unknown(t *testing.T) {

--- a/agent/skills/common/install_targets.go
+++ b/agent/skills/common/install_targets.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
@@ -49,7 +48,7 @@ func ValidateInstallFlags(c *components.Context) (agentcommon.InstallFlagsResult
 		return agentcommon.InstallFlagsResult{}, fmt.Errorf("--harness is required unless --path is set. Supported harnesses: %s", agentcommon.AgentNames(registry))
 	}
 
-	harnessNames, err := ParseHarnessList(rawHarness)
+	harnessNames, err := agentcommon.ParseHarnessList(rawHarness)
 	if err != nil {
 		return agentcommon.InstallFlagsResult{}, err
 	}
@@ -71,38 +70,4 @@ func ValidateInstallFlags(c *components.Context) (agentcommon.InstallFlagsResult
 		ProjectDirAbs: projectDirAbs,
 		IsGlobal:      isGlobal,
 	}, nil
-}
-
-// ResolveAgentTargets resolves per-agent install destinations.
-// When path is non-empty, a single ScopePath target is returned.
-func ResolveAgentTargets(slug, path string, agents []AgentSpec, projectDirAbs string, isGlobal bool) ([]AgentTarget, error) {
-	if path != "" {
-		target, err := agentcommon.BuildPathInstallTarget(slug, path)
-		if err != nil {
-			return nil, err
-		}
-		return []AgentTarget{target}, nil
-	}
-
-	scope := ScopeProject
-	if isGlobal {
-		scope = ScopeGlobal
-	}
-	if scope == ScopeProject && projectDirAbs == "" {
-		return nil, fmt.Errorf("project directory is required for project-scoped install")
-	}
-
-	targets := make([]AgentTarget, 0, len(agents))
-	for _, agent := range agents {
-		base, err := agentcommon.ResolveAgentInstallDir(agent, projectDirAbs, isGlobal)
-		if err != nil {
-			return nil, err
-		}
-		targets = append(targets, AgentTarget{
-			Agent:          agent,
-			Scope:          scope,
-			DestinationDir: filepath.Join(base, slug),
-		})
-	}
-	return targets, nil
 }

--- a/agent/skills/common/install_targets_test.go
+++ b/agent/skills/common/install_targets_test.go
@@ -11,16 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolveAgentTargets_PathMode(t *testing.T) {
-	base := t.TempDir()
-	targets, err := ResolveAgentTargets("my-skill", base, nil, "", false)
-	require.NoError(t, err)
-	require.Len(t, targets, 1)
-	assert.Equal(t, filepath.Join(base, "my-skill"), targets[0].DestinationDir)
-	assert.Equal(t, PathAgentName, targets[0].Agent.Name)
-	assert.Equal(t, ScopePath, targets[0].Scope)
-}
-
 func TestValidateInstallFlags_Errors(t *testing.T) {
 	validPath := t.TempDir()
 	projectDir := t.TempDir()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary
**Removes wrapper functions that were duplicating logic between agent/plugins/common and agent/skills/common. Specifically:**

- Moved ResolveAgentTargets, CopyExtractedToTargets, and related helpers up to agent/common (the single source of truth)
- Deleted the per-namespace copies in plugins/common and skills/common
- Updated all callers in install.go, update.go, list.go to call agentcommon.* directly
- Moved tests to agent/common