### PR TITLE
RTECO-1560 - Fix agentplugins install issue

### DIFF
--- a/agent/common/install_flags.go
+++ b/agent/common/install_flags.go
@@ -42,8 +42,19 @@ func (r InstallFlagsResult) PathMode() bool {
 	return r.AbsoluteInstallBaseDir != ""
 }
 
+// InstallFlagsOptions configures harness install flag validation.
+type InstallFlagsOptions struct {
+	// DefaultGlobalScope uses global scope when neither --global nor --project-dir is set.
+	// Agent plugins (claude, cursor, codex) only support global installs.
+	DefaultGlobalScope bool
+}
+
 // ValidateInstallFlags validates `--path | (--harness [, --project-dir | --global])` for install/update.
-func ValidateInstallFlags(c *components.Context, builtIns map[string]AgentConfig, configSectionKey string, helpExample AgentRegistryHelpExample) (InstallFlagsResult, error) {
+func ValidateInstallFlags(c *components.Context, builtIns map[string]AgentConfig, configSectionKey string, helpExample AgentRegistryHelpExample, opts ...InstallFlagsOptions) (InstallFlagsResult, error) {
+	var options InstallFlagsOptions
+	if len(opts) > 0 {
+		options = opts[0]
+	}
 	input := InstallFlagInput{
 		PathInstallBase: strings.TrimSpace(c.GetStringFlagValue(InstallPathFlag)),
 		RawHarness:      strings.TrimSpace(c.GetStringFlagValue(InstallHarnessFlag)),
@@ -53,7 +64,7 @@ func ValidateInstallFlags(c *components.Context, builtIns map[string]AgentConfig
 	if result, done, err := validatePathInstallFlags(input); done {
 		return result, err
 	}
-	return validateHarnessInstallFlags(input, builtIns, configSectionKey, helpExample)
+	return validateHarnessInstallFlags(input, builtIns, configSectionKey, helpExample, options.DefaultGlobalScope)
 }
 
 // validatePathInstallFlags resolves --path mode when set; done is true when validation finished or failed.
@@ -69,7 +80,7 @@ func validatePathInstallFlags(input InstallFlagInput) (result InstallFlagsResult
 }
 
 // validateHarnessInstallFlags resolves --harness targets and project/global scope.
-func validateHarnessInstallFlags(input InstallFlagInput, builtIns map[string]AgentConfig, configSectionKey string, helpExample AgentRegistryHelpExample) (InstallFlagsResult, error) {
+func validateHarnessInstallFlags(input InstallFlagInput, builtIns map[string]AgentConfig, configSectionKey string, helpExample AgentRegistryHelpExample, defaultGlobalScope bool) (InstallFlagsResult, error) {
 	registry, err := LoadAgentRegistry(builtIns, configSectionKey)
 	if err != nil {
 		return InstallFlagsResult{}, err
@@ -83,15 +94,32 @@ func validateHarnessInstallFlags(input InstallFlagInput, builtIns map[string]Age
 		return InstallFlagsResult{}, err
 	}
 
-	projectDirAbs, err := ResolveInstallProjectDir(input.ProjectDir, input.IsGlobal)
+	isGlobal, projectDirAbs, err := resolveInstallScope(input, defaultGlobalScope)
 	if err != nil {
 		return InstallFlagsResult{}, err
 	}
 	return InstallFlagsResult{
 		Specs:         specs,
 		ProjectDirAbs: projectDirAbs,
-		IsGlobal:      input.IsGlobal,
+		IsGlobal:      isGlobal,
 	}, nil
+}
+
+// resolveInstallScope picks global vs project scope from install flags.
+func resolveInstallScope(input InstallFlagInput, defaultGlobalScope bool) (isGlobal bool, projectDirAbs string, err error) {
+	if input.IsGlobal {
+		projectDirAbs, err = ResolveInstallProjectDir(input.ProjectDir, true)
+		return true, projectDirAbs, err
+	}
+	if input.ProjectDir != "" {
+		projectDirAbs, err = ResolveInstallProjectDir(input.ProjectDir, false)
+		return false, projectDirAbs, err
+	}
+	if defaultGlobalScope {
+		return true, "", nil
+	}
+	projectDirAbs, err = ResolveInstallProjectDir("", false)
+	return false, projectDirAbs, err
 }
 
 // requireHarnessWhenNotPath ensures --harness is present when not using --path.

--- a/agent/common/install_flags_test.go
+++ b/agent/common/install_flags_test.go
@@ -174,7 +174,7 @@ func TestValidateInstallFlags_PluginsHarnessProjectOK(t *testing.T) {
 	c.AddStringFlag(InstallHarnessFlag, "claude")
 	c.AddStringFlag(InstallProjectDirFlag, projectDir)
 
-	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp)
+	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp, InstallFlagsOptions{DefaultGlobalScope: true})
 	require.NoError(t, err)
 	assert.False(t, flags.PathMode())
 	require.Len(t, flags.Specs, 1)
@@ -191,11 +191,35 @@ func TestValidateInstallFlags_PluginsHarnessGlobalOK(t *testing.T) {
 	c.AddStringFlag(InstallHarnessFlag, "cursor")
 	c.AddBoolFlag(InstallGlobalFlag, true)
 
-	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp)
+	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp, InstallFlagsOptions{DefaultGlobalScope: true})
 	require.NoError(t, err)
 	require.Len(t, flags.Specs, 1)
 	assert.Equal(t, "cursor", flags.Specs[0].Name)
 	assert.Empty(t, flags.ProjectDirAbs)
+	assert.True(t, flags.IsGlobal)
+}
+
+func TestValidateInstallFlags_PluginsHarnessDefaultGlobalWhenUnscoped(t *testing.T) {
+	testutil.WithJfrogHome(t)
+	c := testutil.NewCLIContext()
+	c.AddStringFlag(InstallHarnessFlag, "cursor")
+
+	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp, InstallFlagsOptions{DefaultGlobalScope: true})
+	require.NoError(t, err)
+	require.Len(t, flags.Specs, 1)
+	assert.Equal(t, "cursor", flags.Specs[0].Name)
+	assert.Empty(t, flags.ProjectDirAbs)
+	assert.True(t, flags.IsGlobal)
+}
+
+func TestValidateInstallFlags_PluginsHarnessDefaultGlobalForClaude(t *testing.T) {
+	testutil.WithJfrogHome(t)
+	c := testutil.NewCLIContext()
+	c.AddStringFlag(InstallHarnessFlag, "claude")
+
+	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp, InstallFlagsOptions{DefaultGlobalScope: true})
+	require.NoError(t, err)
+	require.Len(t, flags.Specs, 1)
 	assert.True(t, flags.IsGlobal)
 }
 
@@ -206,7 +230,7 @@ func TestValidateInstallFlags_PluginsCommaSeparatedHarnesses(t *testing.T) {
 	c.AddStringFlag(InstallHarnessFlag, "claude,cursor")
 	c.AddStringFlag(InstallProjectDirFlag, projectDir)
 
-	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp)
+	flags, err := ValidateInstallFlags(c, testPluginsAgents, PluginsAgentsKey, testPluginsHelp, InstallFlagsOptions{DefaultGlobalScope: true})
 	require.NoError(t, err)
 	require.Len(t, flags.Specs, 2)
 	assert.Equal(t, "claude", flags.Specs[0].Name)

--- a/agent/common/install_flags_test.go
+++ b/agent/common/install_flags_test.go
@@ -17,8 +17,8 @@ var testSkillsAgents = map[string]AgentConfig{
 }
 
 var testPluginsAgents = map[string]AgentConfig{
-	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ".claude/plugins"},
-	"cursor": {GlobalDir: "~/.cursor/plugins", ProjectDir: ".cursor/plugins"},
+	"claude": {GlobalDir: "~/.claude/plugins/local/jfrog", ProjectDir: ".claude/plugins"},
+	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ".cursor/plugins"},
 }
 
 var testSkillsHelp = AgentRegistryHelpExample{

--- a/agent/common/install_flags_test.go
+++ b/agent/common/install_flags_test.go
@@ -17,7 +17,7 @@ var testSkillsAgents = map[string]AgentConfig{
 }
 
 var testPluginsAgents = map[string]AgentConfig{
-	"claude": {GlobalDir: "~/.claude/plugins", ProjectDir: ".claude/plugins"},
+	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ".claude/plugins"},
 	"cursor": {GlobalDir: "~/.cursor/plugins", ProjectDir: ".cursor/plugins"},
 }
 

--- a/agent/common/install_summary.go
+++ b/agent/common/install_summary.go
@@ -9,6 +9,27 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// WarningError wraps an error that should be reported as a warning, not a fatal failure.
+type WarningError struct {
+	msg string
+}
+
+// NewWarningError creates a warning error that is not fatal but should be reported to the user.
+func NewWarningError(msg string) *WarningError {
+	return &WarningError{msg: msg}
+}
+
+// Error implements the error interface.
+func (we *WarningError) Error() string {
+	return we.msg
+}
+
+// IsWarning returns true if an error is a WarningError.
+func IsWarning(err error) bool {
+	_, ok := err.(*WarningError)
+	return ok
+}
+
 // Summary row statuses for install/update tables and JSON output.
 const (
 	SummaryStatusOK        = "ok"
@@ -41,6 +62,18 @@ func InstallFailureRow(agentName, scope, destinationDir string, err error) Summa
 		Path:   destinationDir,
 		Status: SummaryStatusFailed,
 		Detail: err.Error(),
+	}
+}
+
+// InstallWarningRow builds a warning install/update summary row for one target.
+// Warning rows indicate partial success (e.g., files copied but native registration skipped).
+func InstallWarningRow(agentName, scope, destinationDir, detail string) SummaryRow {
+	return SummaryRow{
+		Agent:  agentName,
+		Scope:  scope,
+		Path:   destinationDir,
+		Status: SummaryStatusWarning,
+		Detail: detail,
 	}
 }
 

--- a/agent/common/install_summary.go
+++ b/agent/common/install_summary.go
@@ -14,6 +14,7 @@ const (
 	SummaryStatusOK        = "ok"
 	SummaryStatusFailed    = "failed"
 	SummaryStatusSkipped   = "skipped"
+	SummaryStatusWarning   = "warning"
 	SummaryDetailOKInstall = "Executed successfully with no issues."
 )
 

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -234,6 +234,11 @@ func (ic *InstallCommand) CopyExtractedToTargets(unzipDir string, installTargets
 			results = append(results, agentcommon.InstallFailureRow(target.Agent.Name, string(target.Scope), target.DestinationDir, err))
 			continue
 		}
+		if hookErr := plugincommon.RunPostInstallHook(target.Agent.Name, ic.slug, ic.version, target.DestinationDir, ic.repoKey); hookErr != nil {
+			log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
+		} else {
+			log.Info(fmt.Sprintf("post-install hook completed for agent %q", target.Agent.Name))
+		}
 		results = append(results, agentcommon.SummaryRow{
 			Agent:  target.Agent.Name,
 			Scope:  string(target.Scope),
@@ -273,10 +278,25 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentT
 	if ic.scope == agentcommon.InstallScopeProject && ic.projectDir == "" {
 		return nil, fmt.Errorf("project directory is required for project-scoped install")
 	}
+	if ic.scope == agentcommon.InstallScopeProject {
+		for _, agent := range ic.agents {
+			if strings.ToLower(agent.Name) == "cursor" {
+				return nil, fmt.Errorf(
+					"cursor does not support project-scoped plugin installs: " +
+						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. " +
+						"Use --global to install there instead.",
+				)
+			}
+		}
+	}
 	isGlobal := ic.scope == agentcommon.InstallScopeGlobal
 	// Path is "" because harness mode uses project or global scope
 	// e.g., jf agent plugins install web --harness claude --global
-	return agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
+	targets, err := agentcommon.ResolveAgentTargets(ic.slug, "", ic.agents, ic.projectDir, isGlobal)
+	if err != nil {
+		return nil, err
+	}
+	return plugincommon.InjectRepoKey(targets, ic.repoKey), nil
 }
 
 func (ic *InstallCommand) writePluginInfoManifest(target plugincommon.AgentTarget) error {

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -234,11 +234,11 @@ func (ic *InstallCommand) CopyExtractedToTargets(unzipDir string, installTargets
 			results = append(results, agentcommon.InstallFailureRow(target.Agent.Name, string(target.Scope), target.DestinationDir, err))
 			continue
 		}
-		if hookErr := plugincommon.RunPostInstallHook(target.Agent.Name, ic.slug, ic.version, target.DestinationDir, ic.repoKey); hookErr != nil {
-			log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
-		} else {
-			log.Info(fmt.Sprintf("post-install hook completed for agent %q", target.Agent.Name))
-		}
+	if hookErr := plugincommon.RunPostInstallHook(target.Agent.Name, ic.slug, ic.version, target.DestinationDir, ic.repoKey); hookErr != nil {
+		log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
+		results = append(results, agentcommon.InstallFailureRow(target.Agent.Name, string(target.Scope), target.DestinationDir, hookErr))
+	} else {
+		log.Info(fmt.Sprintf("post-install hook completed for agent %q", target.Agent.Name))
 		results = append(results, agentcommon.SummaryRow{
 			Agent:  target.Agent.Name,
 			Scope:  string(target.Scope),
@@ -246,6 +246,7 @@ func (ic *InstallCommand) CopyExtractedToTargets(unzipDir string, installTargets
 			Status: agentcommon.SummaryStatusOK,
 			Detail: agentcommon.SummaryDetailOKInstall,
 		})
+	}
 	}
 	return results
 }
@@ -283,22 +284,22 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentT
 			agentLower := strings.ToLower(agent.Name)
 			if agentLower == "claude" {
 				return nil, fmt.Errorf(
-					"claude does not support project-scoped plugin installs: "+
-						"Claude plugin configuration is user-scoped only (~/.claude/settings.json). "+
+					"claude does not support project-scoped plugin installs: " +
+						"Claude plugin configuration is user-scoped only (~/.claude/settings.json). " +
 						"Use --global to install there instead",
 				)
 			}
 			if agentLower == "cursor" {
 				return nil, fmt.Errorf(
-					"cursor does not support project-scoped plugin installs: "+
-						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. "+
+					"cursor does not support project-scoped plugin installs: " +
+						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. " +
 						"Use --global to install there instead",
 				)
 			}
 			if agentLower == "codex" {
 				return nil, fmt.Errorf(
-					"codex does not support project-scoped plugin installs: "+
-						"Codex plugin configuration is user-scoped only (~/.codex/config.toml). "+
+					"codex does not support project-scoped plugin installs: " +
+						"Codex plugin configuration is user-scoped only (~/.codex/config.toml). " +
 						"Use --global to install there instead",
 				)
 			}

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -151,7 +151,7 @@ func (ic *InstallCommand) Run() error {
 	}
 
 	for _, result := range results {
-		if result.Status != agentcommon.SummaryStatusOK {
+		if result.Status == agentcommon.SummaryStatusFailed {
 			return fmt.Errorf("installation failed for one or more agents (see summary above)")
 		}
 	}
@@ -235,8 +235,14 @@ func (ic *InstallCommand) CopyExtractedToTargets(unzipDir string, installTargets
 			continue
 		}
 	if hookErr := plugincommon.RunPostInstallHook(target.Agent.Name, ic.slug, ic.version, target.DestinationDir, ic.repoKey); hookErr != nil {
-		log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
-		results = append(results, agentcommon.InstallFailureRow(target.Agent.Name, string(target.Scope), target.DestinationDir, hookErr))
+		if agentcommon.IsWarning(hookErr) {
+			log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
+			results = append(results, agentcommon.InstallWarningRow(target.Agent.Name, string(target.Scope), target.DestinationDir,
+				fmt.Sprintf("Plugin files installed successfully but native registration incomplete: %s", hookErr.Error())))
+		} else {
+			log.Warn(fmt.Sprintf("post-install hook for agent %q: %s", target.Agent.Name, hookErr))
+			results = append(results, agentcommon.InstallFailureRow(target.Agent.Name, string(target.Scope), target.DestinationDir, hookErr))
+		}
 	} else {
 		log.Info(fmt.Sprintf("post-install hook completed for agent %q", target.Agent.Name))
 		results = append(results, agentcommon.SummaryRow{

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -35,7 +35,7 @@ type InstallCommand struct {
 }
 
 func NewInstallCommand() *InstallCommand {
-	return &InstallCommand{scope: agentcommon.InstallScopeProject}
+	return &InstallCommand{scope: agentcommon.InstallScopeGlobal}
 }
 
 func (ic *InstallCommand) SetServerDetails(details *config.ServerDetails) *InstallCommand {

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -283,23 +283,23 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentT
 			agentLower := strings.ToLower(agent.Name)
 			if agentLower == "claude" {
 				return nil, fmt.Errorf(
-					"claude does not support project-scoped plugin installs: " +
-						"Claude plugin configuration is user-scoped only (~/.claude/settings.json). " +
-						"Use --global to install there instead.",
+					"claude does not support project-scoped plugin installs: "+
+						"Claude plugin configuration is user-scoped only (~/.claude/settings.json). "+
+						"Use --global to install there instead",
 				)
 			}
 			if agentLower == "cursor" {
 				return nil, fmt.Errorf(
-					"cursor does not support project-scoped plugin installs: " +
-						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. " +
-						"Use --global to install there instead.",
+					"cursor does not support project-scoped plugin installs: "+
+						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. "+
+						"Use --global to install there instead",
 				)
 			}
 			if agentLower == "codex" {
 				return nil, fmt.Errorf(
-					"codex does not support project-scoped plugin installs: " +
-						"Codex plugin configuration is user-scoped only (~/.codex/config.toml). " +
-						"Use --global to install there instead.",
+					"codex does not support project-scoped plugin installs: "+
+						"Codex plugin configuration is user-scoped only (~/.codex/config.toml). "+
+						"Use --global to install there instead",
 				)
 			}
 		}

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -280,10 +280,25 @@ func (ic *InstallCommand) resolveAgentTargetDirectories() ([]plugincommon.AgentT
 	}
 	if ic.scope == agentcommon.InstallScopeProject {
 		for _, agent := range ic.agents {
-			if strings.ToLower(agent.Name) == "cursor" {
+			agentLower := strings.ToLower(agent.Name)
+			if agentLower == "claude" {
+				return nil, fmt.Errorf(
+					"claude does not support project-scoped plugin installs: " +
+						"Claude plugin configuration is user-scoped only (~/.claude/settings.json). " +
+						"Use --global to install there instead.",
+				)
+			}
+			if agentLower == "cursor" {
 				return nil, fmt.Errorf(
 					"cursor does not support project-scoped plugin installs: " +
 						"Cursor only auto-discovers full plugins from ~/.cursor/plugins/local/. " +
+						"Use --global to install there instead.",
+				)
+			}
+			if agentLower == "codex" {
+				return nil, fmt.Errorf(
+					"codex does not support project-scoped plugin installs: " +
+						"Codex plugin configuration is user-scoped only (~/.codex/config.toml). " +
 						"Use --global to install there instead.",
 				)
 			}

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -348,7 +348,7 @@ func RunInstall(c *components.Context) error {
 		return err
 	}
 
-	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp)
+	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: true})
 	if err != nil {
 		return err
 	}

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -13,9 +13,13 @@ import (
 )
 
 func init() {
-	// Prevent real agent CLI binaries from being invoked during unit tests.
-	plugincommon.ClaudeExec = func(_ ...string) {}
-	plugincommon.CodexExec = func(_ ...string) {}
+	// Prevent real agent CLI binaries from being invoked during unit tests, and make
+	// results independent of whether claude/codex happen to be installed on the
+	// machine running the tests (e.g. CI runners don't have them on PATH).
+	plugincommon.ClaudeExec = func(_ ...string) error { return nil }
+	plugincommon.CodexExec = func(_ ...string) error { return nil }
+	plugincommon.LookPathClaude = func() (string, error) { return "/usr/bin/claude", nil }
+	plugincommon.LookPathCodex = func() (string, error) { return "/usr/bin/codex", nil }
 }
 
 func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	// Prevent real agent CLI binaries from being invoked during unit tests.
+	plugincommon.ClaudeExec = func(_ ...string) {}
+	plugincommon.CodexExec = func(_ ...string) {}
+}
+
 func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {
 	projectRoot := t.TempDir()
 	cmd := NewInstallCommand().

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -33,6 +33,22 @@ func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {
 	assert.Contains(t, err.Error(), "claude does not support project-scoped plugin installs")
 }
 
+func TestResolveAgentTargetDirectories_DefaultScopeUsesGlobalForCursor(t *testing.T) {
+	globalBase := filepath.Join(t.TempDir(), "global", ".cursor", "plugins", "local")
+	wantBase, err := filepath.Abs(globalBase)
+	require.NoError(t, err)
+
+	cmd := NewInstallCommand().
+		SetSlug("jfrog-plugin-timepass").
+		SetAgents([]plugincommon.AgentSpec{{Name: "cursor", Config: plugincommon.AgentConfig{GlobalDir: globalBase}}})
+
+	targets, err := cmd.resolveAgentTargetDirectories()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, filepath.Join(wantBase, "jfrog-plugin-timepass"), targets[0].DestinationDir)
+	assert.Equal(t, plugincommon.ScopeGlobal, targets[0].Scope)
+}
+
 func TestResolveAgentTargetDirectories_GlobalScope(t *testing.T) {
 	globalBase := filepath.Join(t.TempDir(), "global", ".cursor", "plugins")
 	wantBase, err := filepath.Abs(globalBase)

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -23,7 +23,8 @@ func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {
 	cmd := NewInstallCommand().
 		SetSlug("my-plugin").
 		SetAgents([]plugincommon.AgentSpec{{Name: "claude", Config: plugincommon.AgentConfig{ProjectDir: ".claude/plugins"}}}).
-		SetProjectDir(projectRoot)
+		SetProjectDir(projectRoot).
+		SetGlobal(false) // Explicitly set to project scope
 
 	// Claude does not support project scope - should error
 	targets, err := cmd.resolveAgentTargetDirectories()

--- a/agent/plugins/commands/install/install_test.go
+++ b/agent/plugins/commands/install/install_test.go
@@ -25,10 +25,11 @@ func TestResolveAgentTargetDirectories_ProjectScope(t *testing.T) {
 		SetAgents([]plugincommon.AgentSpec{{Name: "claude", Config: plugincommon.AgentConfig{ProjectDir: ".claude/plugins"}}}).
 		SetProjectDir(projectRoot)
 
+	// Claude does not support project scope - should error
 	targets, err := cmd.resolveAgentTargetDirectories()
-	require.NoError(t, err)
-	require.Len(t, targets, 1)
-	assert.Equal(t, filepath.Join(projectRoot, ".claude", "plugins", "my-plugin"), targets[0].DestinationDir)
+	require.Error(t, err)
+	assert.Nil(t, targets)
+	assert.Contains(t, err.Error(), "claude does not support project-scoped plugin installs")
 }
 
 func TestResolveAgentTargetDirectories_GlobalScope(t *testing.T) {

--- a/agent/plugins/commands/update/update.go
+++ b/agent/plugins/commands/update/update.go
@@ -110,7 +110,7 @@ type update struct {
 }
 
 func newUpdate(c *components.Context) (update, error) {
-	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp)
+	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: true})
 	if err != nil {
 		return update{}, err
 	}

--- a/agent/plugins/commands/update/update_test.go
+++ b/agent/plugins/commands/update/update_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	// Prevent real agent CLI binaries from being invoked during unit tests.
+	plugincommon.ClaudeExec = func(_ ...string) {}
+	plugincommon.CodexExec = func(_ ...string) {}
+}
+
 func TestReserveUpdateBackupPath(t *testing.T) {
 	base := t.TempDir()
 	reservedBackupPath, err := reserveUpdateBackupPath(base, "plugin-a")
@@ -148,7 +154,8 @@ func TestUpdateOnePlugin_SuccessRemovesBackup(t *testing.T) {
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	assert.ElementsMatch(t, []string{"web"}, names)
+	// .claude-plugin/ is created by the Claude post-install hook (marketplace.json).
+	assert.ElementsMatch(t, []string{".claude-plugin", "web"}, names)
 
 	backupRoot := filepath.Join(filepath.Dir(dir), pluginBackupDirName)
 	_, statErr := os.Stat(backupRoot)

--- a/agent/plugins/commands/update/update_test.go
+++ b/agent/plugins/commands/update/update_test.go
@@ -17,9 +17,13 @@ import (
 )
 
 func init() {
-	// Prevent real agent CLI binaries from being invoked during unit tests.
-	plugincommon.ClaudeExec = func(_ ...string) {}
-	plugincommon.CodexExec = func(_ ...string) {}
+	// Prevent real agent CLI binaries from being invoked during unit tests, and make
+	// results independent of whether claude/codex happen to be installed on the
+	// machine running the tests (e.g. CI runners don't have them on PATH).
+	plugincommon.ClaudeExec = func(_ ...string) error { return nil }
+	plugincommon.CodexExec = func(_ ...string) error { return nil }
+	plugincommon.LookPathClaude = func() (string, error) { return "/usr/bin/claude", nil }
+	plugincommon.LookPathCodex = func() (string, error) { return "/usr/bin/codex", nil }
 }
 
 func TestReserveUpdateBackupPath(t *testing.T) {

--- a/agent/plugins/common/agent_hooks.go
+++ b/agent/plugins/common/agent_hooks.go
@@ -9,20 +9,11 @@ import "strings"
 // return nil — the file installation already succeeded.
 type PostInstallFn func(slug, version, installDir, repoKey string) error
 
-// PostDeleteFn is called after plugin files are removed from installDir.
-type PostDeleteFn func(slug, installDir, repoKey string) error
-
 // agentPostInstallHooks maps lowercase agent names to their post-install hook.
 // Agents without an entry have no native CLI integration and no hook runs.
 var agentPostInstallHooks = map[string]PostInstallFn{
 	"claude": claudePostInstall,
 	"codex":  codexPostInstall,
-}
-
-// agentPostDeleteHooks maps lowercase agent names to their post-delete hook.
-var agentPostDeleteHooks = map[string]PostDeleteFn{
-	"claude": claudePostDelete,
-	"codex":  codexPostDelete,
 }
 
 // RunPostInstallHook executes the registered post-install hook for agentName.
@@ -33,14 +24,4 @@ func RunPostInstallHook(agentName, slug, version, installDir, repoKey string) er
 		return nil
 	}
 	return fn(slug, version, installDir, repoKey)
-}
-
-// RunPostDeleteHook executes the registered post-delete hook for agentName.
-// Returns nil if no hook is registered.
-func RunPostDeleteHook(agentName, slug, installDir, repoKey string) error {
-	fn, ok := agentPostDeleteHooks[strings.ToLower(agentName)]
-	if !ok {
-		return nil
-	}
-	return fn(slug, installDir, repoKey)
 }

--- a/agent/plugins/common/agent_hooks.go
+++ b/agent/plugins/common/agent_hooks.go
@@ -1,0 +1,46 @@
+package common
+
+import "strings"
+
+// PostInstallFn is called after plugin files are copied to installDir.
+// repoKey is the Artifactory repository the plugin was installed from and is
+// used as the marketplace name so each repo gets its own isolated marketplace.
+// If the native agent CLI is absent the function should log a warning and
+// return nil — the file installation already succeeded.
+type PostInstallFn func(slug, version, installDir, repoKey string) error
+
+// PostDeleteFn is called after plugin files are removed from installDir.
+type PostDeleteFn func(slug, installDir, repoKey string) error
+
+// agentPostInstallHooks maps lowercase agent names to their post-install hook.
+// Agents without an entry have no native CLI integration and no hook runs.
+var agentPostInstallHooks = map[string]PostInstallFn{
+	"claude": claudePostInstall,
+	"codex":  codexPostInstall,
+}
+
+// agentPostDeleteHooks maps lowercase agent names to their post-delete hook.
+var agentPostDeleteHooks = map[string]PostDeleteFn{
+	"claude": claudePostDelete,
+	"codex":  codexPostDelete,
+}
+
+// RunPostInstallHook executes the registered post-install hook for agentName.
+// Returns nil if no hook is registered.
+func RunPostInstallHook(agentName, slug, version, installDir, repoKey string) error {
+	fn, ok := agentPostInstallHooks[strings.ToLower(agentName)]
+	if !ok {
+		return nil
+	}
+	return fn(slug, version, installDir, repoKey)
+}
+
+// RunPostDeleteHook executes the registered post-delete hook for agentName.
+// Returns nil if no hook is registered.
+func RunPostDeleteHook(agentName, slug, installDir, repoKey string) error {
+	fn, ok := agentPostDeleteHooks[strings.ToLower(agentName)]
+	if !ok {
+		return nil
+	}
+	return fn(slug, installDir, repoKey)
+}

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -11,17 +11,20 @@ type AgentSpec = agentcommon.AgentSpec
 // Agents is the hardcoded set of agents currently supported by `jf agent plugins`.
 // User overrides come from agent-config.json -> "plugins-agents".
 var Agents = map[string]AgentConfig{
-	// For Claude and Codex, GlobalDir and ProjectDir are BASE directories.
+	// For Claude, Cursor, and Codex, GlobalDir is the BASE directory.
 	// The Artifactory repo key is injected as a subdirectory at install time so
 	// each repo gets its own isolated marketplace directory:
 	//   Claude: <GlobalDir>/<repoKey>/<slug>
+	//   Cursor: <GlobalDir>/<repoKey>/<slug>
 	//   Codex:  <GlobalDir>/<repoKey>/plugins/<slug>
 	//
-	// Cursor project-scope installs are unsupported because .cursor/skills/ only
-	// loads SKILL.md-based skills, not full plugins.
-	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ".claude/plugins"},
+	// All agents support global scope only. Project scope is not supported because:
+	//   - Claude: Plugin config is user-scoped only (~/.claude/settings.json)
+	//   - Cursor: Only auto-discovers full plugins from ~/.cursor/plugins/local/
+	//   - Codex:  Plugin config is user-scoped only (~/.codex/config.toml)
+	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ""},
 	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ""},
-	"codex":  {GlobalDir: "~/.agents/marketplaces", ProjectDir: ".agents/marketplaces"},
+	"codex":  {GlobalDir: "~/.agents/marketplaces", ProjectDir: ""},
 }
 
 // RegistryHelp configures agent-config.json help text for plugins harness resolution.

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -16,7 +16,7 @@ var Agents = map[string]AgentConfig{
 	// each repo gets its own isolated marketplace directory:
 	//   Claude: <GlobalDir>/<repoKey>/<slug>
 	//   Cursor: <GlobalDir>/<repoKey>/<slug>
-	//   Codex:  <GlobalDir>/<repoKey>/plugins/<slug>
+	//   Codex:  <GlobalDir>/<repoKey>/<slug>
 	//
 	// All agents support global scope only. Project scope is not supported because:
 	//   - Claude: Plugin config is user-scoped only (~/.claude/settings.json)

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -21,7 +21,7 @@ var Agents = map[string]AgentConfig{
 	// loads SKILL.md-based skills, not full plugins.
 	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ".claude/plugins"},
 	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ""},
-	"codex":  {GlobalDir: "~/.agents", ProjectDir: ".agents"},
+	"codex":  {GlobalDir: "~/.agents/marketplaces", ProjectDir: ".agents/marketplaces"},
 }
 
 // RegistryHelp configures agent-config.json help text for plugins harness resolution.

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -11,12 +11,13 @@ type AgentSpec = agentcommon.AgentSpec
 // Agents is the hardcoded set of agents currently supported by `jf agent plugins`.
 // User overrides come from agent-config.json -> "plugins-agents".
 var Agents = map[string]AgentConfig{
-	// For Claude, Cursor, and Codex, GlobalDir is the BASE directory.
-	// The Artifactory repo key is injected as a subdirectory at install time so
-	// each repo gets its own isolated marketplace directory:
-	//   Claude: <GlobalDir>/<repoKey>/<slug>
-	//   Cursor: <GlobalDir>/<repoKey>/<slug>
-	//   Codex:  <GlobalDir>/<repoKey>/<slug>
+	// GlobalDir behavior varies by agent:
+	// - Claude & Codex: The Artifactory repo key is injected as a subdirectory at install time
+	//   so each repo gets its own isolated marketplace directory:
+	//     Claude: <GlobalDir>/<repoKey>/<slug>
+	//     Codex:  <GlobalDir>/<repoKey>/<slug>
+	// - Cursor: No repo key injection; paths are used as-is:
+	//     Cursor: <GlobalDir>/<slug>
 	//
 	// All agents support global scope only. Project scope is not supported because:
 	//   - Claude: Plugin config is user-scoped only (~/.claude/settings.json)

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -19,13 +19,15 @@ var Agents = map[string]AgentConfig{
 	// - Cursor: No repo key injection; paths are used as-is:
 	//     Cursor: <GlobalDir>/<slug>
 	//
+	// Paths ending in /jfrog are rooted under ~/.jfrog for JFrog-specific plugin configurations.
+	//
 	// All agents support global scope only. Project scope is not supported because:
 	//   - Claude: Plugin config is user-scoped only (~/.claude/settings.json)
 	//   - Cursor: Only auto-discovers full plugins from ~/.cursor/plugins/local/
 	//   - Codex:  Plugin config is user-scoped only (~/.codex/config.toml)
-	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ""},
+	"claude": {GlobalDir: "~/.claude/plugins/local/jfrog", ProjectDir: ""},
 	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ""},
-	"codex":  {GlobalDir: "~/.agents/plugins/local", ProjectDir: ""},
+	"codex":  {GlobalDir: "~/.agents/plugins/local/jfrog", ProjectDir: ""},
 }
 
 // RegistryHelp configures agent-config.json help text for plugins harness resolution.

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -24,7 +24,7 @@ var Agents = map[string]AgentConfig{
 	//   - Codex:  Plugin config is user-scoped only (~/.codex/config.toml)
 	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ""},
 	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ""},
-	"codex":  {GlobalDir: "~/.agents/marketplaces", ProjectDir: ""},
+	"codex":  {GlobalDir: "~/.agents/plugins/local", ProjectDir: ""},
 }
 
 // RegistryHelp configures agent-config.json help text for plugins harness resolution.

--- a/agent/plugins/common/agents.go
+++ b/agent/plugins/common/agents.go
@@ -11,9 +11,17 @@ type AgentSpec = agentcommon.AgentSpec
 // Agents is the hardcoded set of agents currently supported by `jf agent plugins`.
 // User overrides come from agent-config.json -> "plugins-agents".
 var Agents = map[string]AgentConfig{
-	"claude": {GlobalDir: "~/.claude/plugins", ProjectDir: ".claude/plugins"},
-	"cursor": {GlobalDir: "~/.cursor/plugins", ProjectDir: ".cursor/plugins"},
-	"codex":  {GlobalDir: "~/.codex/plugins", ProjectDir: ".codex/plugins"},
+	// For Claude and Codex, GlobalDir and ProjectDir are BASE directories.
+	// The Artifactory repo key is injected as a subdirectory at install time so
+	// each repo gets its own isolated marketplace directory:
+	//   Claude: <GlobalDir>/<repoKey>/<slug>
+	//   Codex:  <GlobalDir>/<repoKey>/plugins/<slug>
+	//
+	// Cursor project-scope installs are unsupported because .cursor/skills/ only
+	// loads SKILL.md-based skills, not full plugins.
+	"claude": {GlobalDir: "~/.claude/plugins/local", ProjectDir: ".claude/plugins"},
+	"cursor": {GlobalDir: "~/.cursor/plugins/local", ProjectDir: ""},
+	"codex":  {GlobalDir: "~/.agents", ProjectDir: ".agents"},
 }
 
 // RegistryHelp configures agent-config.json help text for plugins harness resolution.

--- a/agent/plugins/common/agents_test.go
+++ b/agent/plugins/common/agents_test.go
@@ -48,7 +48,7 @@ func TestLoadAgentRegistry_OverridesAndAdds(t *testing.T) {
 
 	claude := registry["claude"]
 	assert.False(t, claude.FromConfig)
-	assert.Equal(t, ".claude/plugins", claude.Config.ProjectDir)
+	assert.Equal(t, "", claude.Config.ProjectDir)
 }
 
 func TestLoadAgentRegistry_IgnoresSkillsAgents(t *testing.T) {

--- a/agent/plugins/common/hooks_claude.go
+++ b/agent/plugins/common/hooks_claude.go
@@ -28,43 +28,28 @@ func claudePostInstall(slug, version, installDir, repoKey string) error {
 	if err := upsertLocalMarketplaceEntry(marketplacePath, slug, version, repoKey); err != nil {
 		return err
 	}
-	if _, err := lookPathClaude(); err != nil {
+	_, err := lookPathClaude()
+	if err == nil {
+		// CLI found, proceed with registration
+		marketplaceDir := claudeMarketplaceDir(installDir)
+		log.Info(fmt.Sprintf("[claude] registering marketplace: claude plugin marketplace add %s", marketplaceDir))
+		ClaudeExec("plugin", "marketplace", "add", marketplaceDir)
+		log.Info(fmt.Sprintf("[claude] installing plugin: claude plugin install %s@%s", slug, repoKey))
+		// Include the @<repoKey> qualifier so Claude resolves the correct marketplace source.
+		ClaudeExec("plugin", "install", slug+"@"+repoKey)
+	} else {
+		// CLI not found, log warning but continue (not a fatal error)
 		log.Warn("[claude] claude CLI not found on PATH; skipping native marketplace registration. " +
 			"Install the Claude CLI to complete native plugin registration.")
-		return err
 	}
-	// Pass the marketplace root directory, not the .json file itself.
-	// `claude plugin marketplace add <dir>` reads <dir>/.claude-plugin/marketplace.json.
-	marketplaceDir := claudeMarketplaceDir(installDir)
-	log.Info(fmt.Sprintf("[claude] registering marketplace: claude plugin marketplace add %s", marketplaceDir))
-	ClaudeExec("plugin", "marketplace", "add", marketplaceDir)
-	log.Info(fmt.Sprintf("[claude] installing plugin: claude plugin install %s@%s", slug, repoKey))
-	// Include the @<repoKey> qualifier so Claude resolves the correct marketplace source.
-	ClaudeExec("plugin", "install", slug+"@"+repoKey)
-	return nil
-}
-
-// claudePostDelete removes the plugin from the JFrog marketplace file and
-// unregisters it from the native claude CLI (if available).
-func claudePostDelete(slug, installDir, repoKey string) error {
-	marketplacePath := claudeMarketplacePath(installDir)
-	log.Info(fmt.Sprintf("[claude] removing marketplace entry for '%s' from %s", slug, marketplacePath))
-	if err := removeLocalMarketplaceEntry(marketplacePath, slug); err != nil {
-		return err
-	}
-	if _, err := lookPathClaude(); err != nil {
-		return err
-	}
-	log.Info(fmt.Sprintf("[claude] uninstalling plugin: claude plugin uninstall %s@%s", slug, repoKey))
-	ClaudeExec("plugin", "uninstall", slug+"@"+repoKey)
 	return nil
 }
 
 // claudeMarketplacePath returns the path to the JFrog marketplace file inside
 // the marketplace root directory.
 //
-	//	installDir  = ~/.claude/plugins/local/jfrog-plugins/<slug>
-	//	marketplace = ~/.claude/plugins/local/jfrog-plugins/.claude-plugin/marketplace.json
+//	installDir  = ~/.claude/plugins/local/jfrog-plugins/<slug>
+//	marketplace = ~/.claude/plugins/local/jfrog-plugins/.claude-plugin/marketplace.json
 func claudeMarketplacePath(installDir string) string {
 	return filepath.Join(claudeMarketplaceDir(installDir), ".claude-plugin", "marketplace.json")
 }

--- a/agent/plugins/common/hooks_claude.go
+++ b/agent/plugins/common/hooks_claude.go
@@ -31,7 +31,7 @@ func claudePostInstall(slug, version, installDir, repoKey string) error {
 	if _, err := lookPathClaude(); err != nil {
 		log.Warn("[claude] claude CLI not found on PATH; skipping native marketplace registration. " +
 			"Install the Claude CLI to complete native plugin registration.")
-		return nil
+		return err
 	}
 	// Pass the marketplace root directory, not the .json file itself.
 	// `claude plugin marketplace add <dir>` reads <dir>/.claude-plugin/marketplace.json.
@@ -53,7 +53,7 @@ func claudePostDelete(slug, installDir, repoKey string) error {
 		return err
 	}
 	if _, err := lookPathClaude(); err != nil {
-		return nil
+		return err
 	}
 	log.Info(fmt.Sprintf("[claude] uninstalling plugin: claude plugin uninstall %s@%s", slug, repoKey))
 	ClaudeExec("plugin", "uninstall", slug+"@"+repoKey)

--- a/agent/plugins/common/hooks_claude.go
+++ b/agent/plugins/common/hooks_claude.go
@@ -16,9 +16,9 @@ const claudeNativeCmdTimeout = 30 * time.Second
 // claudePostInstall writes the plugin into the JFrog marketplace file and
 // registers it with the native claude CLI (if available).
 //
-// Directory layout produced by agents.go (GlobalDir = ~/.claude/plugins/local/jfrog-plugins):
+// Directory layout produced by agents.go (GlobalDir = ~/.claude/plugins/local/jfrog):
 //
-//	~/.claude/plugins/local/jfrog-plugins/
+//	~/.claude/plugins/local/jfrog/
 //	  .claude-plugin/
 //	    marketplace.json          ← written here
 //	  <slug>/                     ← installDir (plugin files copied by jf)
@@ -48,8 +48,8 @@ func claudePostInstall(slug, version, installDir, repoKey string) error {
 // claudeMarketplacePath returns the path to the JFrog marketplace file inside
 // the marketplace root directory.
 //
-//	installDir  = ~/.claude/plugins/local/jfrog-plugins/<slug>
-//	marketplace = ~/.claude/plugins/local/jfrog-plugins/.claude-plugin/marketplace.json
+//	installDir  = ~/.claude/plugins/local/jfrog/<slug>
+//	marketplace = ~/.claude/plugins/local/jfrog/.claude-plugin/marketplace.json
 func claudeMarketplacePath(installDir string) string {
 	return filepath.Join(claudeMarketplaceDir(installDir), ".claude-plugin", "marketplace.json")
 }

--- a/agent/plugins/common/hooks_claude.go
+++ b/agent/plugins/common/hooks_claude.go
@@ -1,0 +1,93 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const claudeNativeCmdTimeout = 30 * time.Second
+
+// claudePostInstall writes the plugin into the JFrog marketplace file and
+// registers it with the native claude CLI (if available).
+//
+// Directory layout produced by agents.go (GlobalDir = ~/.claude/plugins/local/jfrog-plugins):
+//
+//	~/.claude/plugins/local/jfrog-plugins/
+//	  .claude-plugin/
+//	    marketplace.json          ← written here
+//	  <slug>/                     ← installDir (plugin files copied by jf)
+func claudePostInstall(slug, version, installDir, repoKey string) error {
+	marketplacePath := claudeMarketplacePath(installDir)
+	log.Info(fmt.Sprintf("[claude] writing marketplace entry for '%s' → %s", slug, marketplacePath))
+	if err := upsertLocalMarketplaceEntry(marketplacePath, slug, version, repoKey); err != nil {
+		return err
+	}
+	if _, err := lookPathClaude(); err != nil {
+		log.Warn("[claude] claude CLI not found on PATH; skipping native marketplace registration. " +
+			"Install the Claude CLI to complete native plugin registration.")
+		return nil
+	}
+	// Pass the marketplace root directory, not the .json file itself.
+	// `claude plugin marketplace add <dir>` reads <dir>/.claude-plugin/marketplace.json.
+	marketplaceDir := claudeMarketplaceDir(installDir)
+	log.Info(fmt.Sprintf("[claude] registering marketplace: claude plugin marketplace add %s", marketplaceDir))
+	ClaudeExec("plugin", "marketplace", "add", marketplaceDir)
+	log.Info(fmt.Sprintf("[claude] installing plugin: claude plugin install %s@%s", slug, repoKey))
+	// Include the @<repoKey> qualifier so Claude resolves the correct marketplace source.
+	ClaudeExec("plugin", "install", slug+"@"+repoKey)
+	return nil
+}
+
+// claudePostDelete removes the plugin from the JFrog marketplace file and
+// unregisters it from the native claude CLI (if available).
+func claudePostDelete(slug, installDir, repoKey string) error {
+	marketplacePath := claudeMarketplacePath(installDir)
+	log.Info(fmt.Sprintf("[claude] removing marketplace entry for '%s' from %s", slug, marketplacePath))
+	if err := removeLocalMarketplaceEntry(marketplacePath, slug); err != nil {
+		return err
+	}
+	if _, err := lookPathClaude(); err != nil {
+		return nil
+	}
+	log.Info(fmt.Sprintf("[claude] uninstalling plugin: claude plugin uninstall %s@%s", slug, repoKey))
+	ClaudeExec("plugin", "uninstall", slug+"@"+repoKey)
+	return nil
+}
+
+// claudeMarketplacePath returns the path to the JFrog marketplace file inside
+// the marketplace root directory.
+//
+	//	installDir  = ~/.claude/plugins/local/jfrog-plugins/<slug>
+	//	marketplace = ~/.claude/plugins/local/jfrog-plugins/.claude-plugin/marketplace.json
+func claudeMarketplacePath(installDir string) string {
+	return filepath.Join(claudeMarketplaceDir(installDir), ".claude-plugin", "marketplace.json")
+}
+
+// claudeMarketplaceDir returns the marketplace root (the directory that contains
+// .claude-plugin/marketplace.json and all installed plugin subdirectories).
+func claudeMarketplaceDir(installDir string) string {
+	return filepath.Dir(installDir)
+}
+
+// lookPathClaude is a variable so tests can override it without hitting the real PATH.
+var lookPathClaude = func() (string, error) {
+	return exec.LookPath("claude")
+}
+
+// ClaudeExec is the function used to dispatch native claude CLI commands.
+// It is exported so that tests in other packages can swap it with a no-op to
+// avoid invoking the real claude binary (which would touch user state and emit warnings).
+var ClaudeExec = func(args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "claude", args...).CombinedOutput() // #nosec G204 -- args are tool-managed subcommand strings; slug is pre-validated by ValidateSlug
+	if err != nil {
+		log.Warn("claude " + strings.Join(args, " ") + ": " + string(out))
+	}
+}

--- a/agent/plugins/common/hooks_claude.go
+++ b/agent/plugins/common/hooks_claude.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
@@ -15,6 +16,8 @@ const claudeNativeCmdTimeout = 30 * time.Second
 
 // claudePostInstall writes the plugin into the JFrog marketplace file and
 // registers it with the native claude CLI (if available).
+// Returns an error if the marketplace write fails or if native registration fails when the CLI is found.
+// Returns a WarningError if the CLI is not found on PATH.
 //
 // Directory layout produced by agents.go (GlobalDir = ~/.claude/plugins/local/jfrog):
 //
@@ -28,19 +31,25 @@ func claudePostInstall(slug, version, installDir, repoKey string) error {
 	if err := upsertLocalMarketplaceEntry(marketplacePath, slug, version, repoKey); err != nil {
 		return err
 	}
-	_, err := lookPathClaude()
+	marketplaceDir := claudeMarketplaceDir(installDir)
+	_, err := LookPathClaude()
 	if err == nil {
 		// CLI found, proceed with registration
-		marketplaceDir := claudeMarketplaceDir(installDir)
 		log.Info(fmt.Sprintf("[claude] registering marketplace: claude plugin marketplace add %s", marketplaceDir))
-		ClaudeExec("plugin", "marketplace", "add", marketplaceDir)
+		if execErr := ClaudeExec("plugin", "marketplace", "add", marketplaceDir); execErr != nil {
+			return fmt.Errorf("native marketplace registration failed: %w", execErr)
+		}
 		log.Info(fmt.Sprintf("[claude] installing plugin: claude plugin install %s@%s", slug, repoKey))
 		// Include the @<repoKey> qualifier so Claude resolves the correct marketplace source.
-		ClaudeExec("plugin", "install", slug+"@"+repoKey)
+		if execErr := ClaudeExec("plugin", "install", slug+"@"+repoKey); execErr != nil {
+			return fmt.Errorf("native plugin installation failed: %w", execErr)
+		}
 	} else {
-		// CLI not found, log warning but continue (not a fatal error)
-		log.Warn("[claude] claude CLI not found on PATH; skipping native marketplace registration. " +
-			"Install the Claude CLI to complete native plugin registration.")
+		// CLI not found, return a warning so it's reported as a warning not a hard failure
+		return agentcommon.NewWarningError(
+			fmt.Sprintf("claude CLI not found on PATH; skipping native marketplace registration. "+
+				"Install the Claude CLI to complete native plugin registration at %s", marketplaceDir),
+		)
 	}
 	return nil
 }
@@ -60,19 +69,22 @@ func claudeMarketplaceDir(installDir string) string {
 	return filepath.Dir(installDir)
 }
 
-// lookPathClaude is a variable so tests can override it without hitting the real PATH.
-var lookPathClaude = func() (string, error) {
+// LookPathClaude is a variable so tests can override it without hitting the real PATH.
+// Exported so that tests in other packages can swap it to avoid depending on
+// whether the claude CLI happens to be installed on the machine running the tests.
+var LookPathClaude = func() (string, error) {
 	return exec.LookPath("claude")
 }
 
-// ClaudeExec is the function used to dispatch native claude CLI commands.
+// ClaudeExec is the function used to dispatch native claude CLI commands and returns an error if the command fails.
 // It is exported so that tests in other packages can swap it with a no-op to
 // avoid invoking the real claude binary (which would touch user state and emit warnings).
-var ClaudeExec = func(args ...string) {
+var ClaudeExec = func(args ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeNativeCmdTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "claude", args...).CombinedOutput() // #nosec G204 -- args are tool-managed subcommand strings; slug is pre-validated by ValidateSlug
 	if err != nil {
-		log.Warn("claude " + strings.Join(args, " ") + ": " + string(out))
+		return fmt.Errorf("claude %s: %s", strings.Join(args, " "), string(out))
 	}
+	return nil
 }

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -46,19 +46,22 @@ type codexPolicy struct {
 	Installation string `json:"installation,omitempty"`
 }
 
-// CodexExec dispatches native codex CLI commands.
+// CodexExec dispatches native codex CLI commands and returns an error if the command fails.
 // Exported so that tests in other packages can swap it with a no-op.
-var CodexExec = func(args ...string) {
+var CodexExec = func(args ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), codexNativeCmdTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "codex", args...).CombinedOutput() // #nosec G204 -- args are tool-managed subcommand strings; slug is pre-validated by ValidateSlug
 	if err != nil {
-		log.Warn("codex " + strings.Join(args, " ") + ": " + string(out))
+		return fmt.Errorf("codex %s: %s", strings.Join(args, " "), string(out))
 	}
+	return nil
 }
 
 // codexPostInstall writes the plugin into the Codex marketplace manifest and
 // registers it with the native codex CLI (if available).
+// Returns an error if the marketplace write fails or if native registration fails when the CLI is found.
+// Returns a WarningError if the CLI is not found on PATH.
 //
 // Directory layout produced by agents.go (GlobalDir = ~/.agents/plugins/local/jfrog):
 //
@@ -72,19 +75,25 @@ func codexPostInstall(slug, version, installDir, repoKey string) error {
 	if err := upsertCodexMarketplaceEntry(manifestPath, slug, repoKey); err != nil {
 		return err
 	}
-	_, err := lookPathCodex()
+	_, err := LookPathCodex()
 	if err == nil {
 		// CLI found, proceed with registration
 		root := codexMarketplaceRoot(installDir)
 		log.Info(fmt.Sprintf("[codex] registering marketplace: codex plugin marketplace add %s", root))
-		CodexExec("plugin", "marketplace", "add", root)
+		if execErr := CodexExec("plugin", "marketplace", "add", root); execErr != nil {
+			return fmt.Errorf("native marketplace registration failed: %w", execErr)
+		}
 		log.Info(fmt.Sprintf("[codex] installing plugin: codex plugin add %s@%s", slug, repoKey))
 		// Include the @<repoKey> qualifier so Codex resolves the correct marketplace source.
-		CodexExec("plugin", "add", slug+"@"+repoKey)
+		if execErr := CodexExec("plugin", "add", slug+"@"+repoKey); execErr != nil {
+			return fmt.Errorf("native plugin installation failed: %w", execErr)
+		}
 	} else {
-		// CLI not found, log warning but continue (not a fatal error)
-		log.Warn("[codex] codex CLI not found on PATH; skipping native marketplace registration. " +
-			"Run: codex plugin marketplace add " + codexMarketplaceRoot(installDir))
+		// CLI not found, return a warning so it's reported as a warning not a hard failure
+		return agentcommon.NewWarningError(
+			fmt.Sprintf("codex CLI not found on PATH; skipping native marketplace registration. "+
+				"Run: codex plugin marketplace add %s", codexMarketplaceRoot(installDir)),
+		)
 	}
 	return nil
 }
@@ -192,7 +201,9 @@ func writeCodexMarketplace(path string, m *codexMarketplace) error {
 	return nil
 }
 
-// lookPathCodex is a variable so tests can override it without hitting the real PATH.
-var lookPathCodex = func() (string, error) {
+// LookPathCodex is a variable so tests can override it without hitting the real PATH.
+// Exported so that tests in other packages can swap it to avoid depending on
+// whether the codex CLI happens to be installed on the machine running the tests.
+var LookPathCodex = func() (string, error) {
 	return exec.LookPath("codex")
 }

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -77,7 +77,7 @@ func codexPostInstall(slug, version, installDir, repoKey string) error {
 	if _, err := lookPathCodex(); err != nil {
 		log.Warn("[codex] codex CLI not found on PATH; skipping native marketplace registration. " +
 			"Run: codex plugin marketplace add " + codexMarketplaceRoot(installDir))
-		return nil
+		return err
 	}
 	root := codexMarketplaceRoot(installDir)
 	log.Info(fmt.Sprintf("[codex] registering marketplace: codex plugin marketplace add %s", root))
@@ -96,7 +96,7 @@ func codexPostDelete(slug, installDir, repoKey string) error {
 		log.Warn("codex post-delete: failed to update marketplace manifest:", err)
 	}
 	if _, err := lookPathCodex(); err != nil {
-		return nil
+		return err
 	}
 	log.Info(fmt.Sprintf("[codex] removing plugin: codex plugin remove %s@%s", slug, repoKey))
 	CodexExec("plugin", "remove", slug+"@"+repoKey)

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -1,0 +1,212 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const codexNativeCmdTimeout = 30 * time.Second
+
+// codexMarketplace is the on-disk shape of <marketplace-root>/.agents/plugins/marketplace.json.
+// This is the "supported manifest" that `codex plugin marketplace add <root>` reads.
+type codexMarketplace struct {
+	Name      string               `json:"name"`
+	Interface codexDisplayName     `json:"interface,omitempty"`
+	Plugins   []codexPluginEntry   `json:"plugins"`
+}
+
+type codexDisplayName struct {
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// codexPluginEntry is a single plugin record inside the Codex marketplace manifest.
+type codexPluginEntry struct {
+	Name   string          `json:"name"`
+	Source codexPluginSrc  `json:"source"`
+	Policy codexPolicy     `json:"policy,omitempty"`
+}
+
+// codexPluginSrc uses the object form that Codex requires.
+// path is relative to the marketplace root (e.g. "./plugins/my-plugin").
+type codexPluginSrc struct {
+	Source string `json:"source"` // always "local"
+	Path   string `json:"path"`   // "./plugins/<slug>"
+}
+
+type codexPolicy struct {
+	Installation string `json:"installation,omitempty"`
+}
+
+// CodexExec dispatches native codex CLI commands.
+// Exported so that tests in other packages can swap it with a no-op.
+var CodexExec = func(args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), codexNativeCmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "codex", args...).CombinedOutput() // #nosec G204 -- args are tool-managed subcommand strings; slug is pre-validated by ValidateSlug
+	if err != nil {
+		log.Warn("codex " + strings.Join(args, " ") + ": " + string(out))
+	}
+}
+
+// codexPostInstall writes the plugin into the Codex marketplace manifest and
+// registers it with the native codex CLI (if available).
+//
+// Directory layout produced by agents.go (GlobalDir = ~/.agents/jfrog-plugins/plugins):
+//
+//	~/.agents/jfrog-plugins/          ← marketplace root
+//	  .agents/plugins/
+//	    marketplace.json              ← written here
+//	  plugins/
+//	    <slug>/                       ← installDir (plugin files copied by jf)
+func codexPostInstall(slug, version, installDir, repoKey string) error {
+	manifestPath := codexMarketplaceManifestPath(installDir)
+	log.Info(fmt.Sprintf("[codex] writing marketplace entry for '%s' → %s", slug, manifestPath))
+	if err := upsertCodexMarketplaceEntry(manifestPath, slug, repoKey); err != nil {
+		log.Warn("codex post-install: failed to update marketplace manifest:", err)
+		return nil
+	}
+	if _, err := lookPathCodex(); err != nil {
+		log.Warn("[codex] codex CLI not found on PATH; skipping native marketplace registration. " +
+			"Run: codex plugin marketplace add " + codexMarketplaceRoot(installDir))
+		return nil
+	}
+	root := codexMarketplaceRoot(installDir)
+	log.Info(fmt.Sprintf("[codex] registering marketplace: codex plugin marketplace add %s", root))
+	CodexExec("plugin", "marketplace", "add", root)
+	log.Info(fmt.Sprintf("[codex] installing plugin: codex plugin add %s@%s", slug, repoKey))
+	// Include the @<repoKey> qualifier so Codex resolves the correct marketplace source.
+	CodexExec("plugin", "add", slug+"@"+repoKey)
+	return nil
+}
+
+// codexPostDelete removes the plugin from the Codex marketplace manifest.
+func codexPostDelete(slug, installDir, repoKey string) error {
+	manifestPath := codexMarketplaceManifestPath(installDir)
+	log.Info(fmt.Sprintf("[codex] removing marketplace entry for '%s' from %s", slug, manifestPath))
+	if err := removeCodexMarketplaceEntry(manifestPath, slug); err != nil {
+		log.Warn("codex post-delete: failed to update marketplace manifest:", err)
+	}
+	if _, err := lookPathCodex(); err != nil {
+		return nil
+	}
+	log.Info(fmt.Sprintf("[codex] removing plugin: codex plugin remove %s@%s", slug, repoKey))
+	CodexExec("plugin", "remove", slug+"@"+repoKey)
+	return nil
+}
+
+// codexMarketplaceRoot returns the marketplace root directory.
+//
+//	installDir = ~/.agents/jfrog-plugins/plugins/<slug>
+//	root       = ~/.agents/jfrog-plugins
+func codexMarketplaceRoot(installDir string) string {
+	return filepath.Dir(filepath.Dir(installDir))
+}
+
+// codexMarketplaceManifestPath returns the path to the Codex marketplace manifest.
+//
+//	installDir = ~/.agents/jfrog-plugins/plugins/<slug>
+//	manifest   = ~/.agents/jfrog-plugins/.agents/plugins/marketplace.json
+func codexMarketplaceManifestPath(installDir string) string {
+	return filepath.Join(codexMarketplaceRoot(installDir), ".agents", "plugins", "marketplace.json")
+}
+
+// upsertCodexMarketplaceEntry reads or creates the Codex marketplace manifest at path,
+// adds or replaces the entry for slug, then writes it back.
+// marketplaceName is set as the manifest's "name" field (typically the Artifactory repo key).
+func upsertCodexMarketplaceEntry(path, slug, marketplaceName string) error {
+	m, err := readOrCreateCodexMarketplace(path, marketplaceName)
+	if err != nil {
+		return err
+	}
+	entry := codexPluginEntry{
+		Name:   slug,
+		Source: codexPluginSrc{Source: "local", Path: "./plugins/" + slug},
+		Policy: codexPolicy{Installation: "AVAILABLE"},
+	}
+	found := false
+	for i, p := range m.Plugins {
+		if strings.EqualFold(p.Name, slug) {
+			m.Plugins[i] = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.Plugins = append(m.Plugins, entry)
+	}
+	return writeCodexMarketplace(path, m)
+}
+
+// removeCodexMarketplaceEntry removes the slug entry from the Codex marketplace manifest.
+// A missing file or missing slug entry is a no-op.
+func removeCodexMarketplaceEntry(path, slug string) error {
+	m, err := readOrCreateCodexMarketplace(path, "")
+	if err != nil {
+		return err
+	}
+	n := len(m.Plugins)
+	kept := m.Plugins[:0]
+	for _, p := range m.Plugins {
+		if !strings.EqualFold(p.Name, slug) {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) == n {
+		return nil
+	}
+	m.Plugins = kept
+	return writeCodexMarketplace(path, m)
+}
+
+// readOrCreateCodexMarketplace reads and parses path. When the file does not exist,
+// it returns an empty marketplace with the given name.
+func readOrCreateCodexMarketplace(path, marketplaceName string) (*codexMarketplace, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is tool-managed config under agent home
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &codexMarketplace{
+				Name:      marketplaceName,
+				Interface: codexDisplayName{DisplayName: "JFrog Plugins"},
+				Plugins:   []codexPluginEntry{},
+			}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m codexMarketplace
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if m.Plugins == nil {
+		m.Plugins = []codexPluginEntry{}
+	}
+	return &m, nil
+}
+
+// writeCodexMarketplace creates parent directories as needed and writes m to path.
+func writeCodexMarketplace(path string, m *codexMarketplace) error {
+	if err := os.MkdirAll(filepath.Dir(path), agentcommon.InstallDirMode); err != nil {
+		return fmt.Errorf("create dirs for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal codex marketplace: %w", err)
+	}
+	if err := os.WriteFile(path, data, agentcommon.InstallManifestFileMode); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// lookPathCodex is a variable so tests can override it without hitting the real PATH.
+var lookPathCodex = func() (string, error) {
+	return exec.LookPath("codex")
+}

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -60,9 +60,9 @@ var CodexExec = func(args ...string) {
 // codexPostInstall writes the plugin into the Codex marketplace manifest and
 // registers it with the native codex CLI (if available).
 //
-// Directory layout produced by agents.go (GlobalDir = ~/.agents/marketplaces/<repoKey>):
+// Directory layout produced by agents.go (GlobalDir = ~/.agents/plugins/local/<repoKey>):
 //
-//	~/.agents/marketplaces/<repoKey>/          ← marketplace root
+//	~/.agents/plugins/local/<repoKey>/          ← marketplace root
 //	  .agents/plugins/
 //	    marketplace.json                       ← written here
 //	  plugins/
@@ -105,16 +105,16 @@ func codexPostDelete(slug, installDir, repoKey string) error {
 
 // codexMarketplaceRoot returns the marketplace root directory.
 //
-//	installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
-//	root       = ~/.agents/marketplaces/<repoKey>
+//	installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+//	root       = ~/.agents/plugins/local/<repoKey>
 func codexMarketplaceRoot(installDir string) string {
 	return filepath.Dir(filepath.Dir(installDir))
 }
 
 // codexMarketplaceManifestPath returns the path to the Codex marketplace manifest.
 //
-//	installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
-//	manifest   = ~/.agents/marketplaces/<repoKey>/.agents/plugins/marketplace.json
+//	installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+//	manifest   = ~/.agents/plugins/local/<repoKey>/.agents/plugins/marketplace.json
 func codexMarketplaceManifestPath(installDir string) string {
 	return filepath.Join(codexMarketplaceRoot(installDir), ".agents", "plugins", "marketplace.json")
 }

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -19,9 +19,9 @@ const codexNativeCmdTimeout = 30 * time.Second
 // codexMarketplace is the on-disk shape of <marketplace-root>/.agents/plugins/marketplace.json.
 // This is the "supported manifest" that `codex plugin marketplace add <root>` reads.
 type codexMarketplace struct {
-	Name      string               `json:"name"`
-	Interface codexDisplayName     `json:"interface,omitempty"`
-	Plugins   []codexPluginEntry   `json:"plugins"`
+	Name      string             `json:"name"`
+	Interface codexDisplayName   `json:"interface,omitempty"`
+	Plugins   []codexPluginEntry `json:"plugins"`
 }
 
 type codexDisplayName struct {
@@ -30,9 +30,9 @@ type codexDisplayName struct {
 
 // codexPluginEntry is a single plugin record inside the Codex marketplace manifest.
 type codexPluginEntry struct {
-	Name   string          `json:"name"`
-	Source codexPluginSrc  `json:"source"`
-	Policy codexPolicy     `json:"policy,omitempty"`
+	Name   string         `json:"name"`
+	Source codexPluginSrc `json:"source"`
+	Policy codexPolicy    `json:"policy,omitempty"`
 }
 
 // codexPluginSrc uses the object form that Codex requires.
@@ -70,35 +70,22 @@ func codexPostInstall(slug, version, installDir, repoKey string) error {
 	manifestPath := codexMarketplaceManifestPath(installDir)
 	log.Info(fmt.Sprintf("[codex] writing marketplace entry for '%s' → %s", slug, manifestPath))
 	if err := upsertCodexMarketplaceEntry(manifestPath, slug, repoKey); err != nil {
-		log.Warn("codex post-install: failed to update marketplace manifest:", err)
-		return nil
+		return err
 	}
-	if _, err := lookPathCodex(); err != nil {
+	_, err := lookPathCodex()
+	if err == nil {
+		// CLI found, proceed with registration
+		root := codexMarketplaceRoot(installDir)
+		log.Info(fmt.Sprintf("[codex] registering marketplace: codex plugin marketplace add %s", root))
+		CodexExec("plugin", "marketplace", "add", root)
+		log.Info(fmt.Sprintf("[codex] installing plugin: codex plugin add %s@%s", slug, repoKey))
+		// Include the @<repoKey> qualifier so Codex resolves the correct marketplace source.
+		CodexExec("plugin", "add", slug+"@"+repoKey)
+	} else {
+		// CLI not found, log warning but continue (not a fatal error)
 		log.Warn("[codex] codex CLI not found on PATH; skipping native marketplace registration. " +
 			"Run: codex plugin marketplace add " + codexMarketplaceRoot(installDir))
-		return err
 	}
-	root := codexMarketplaceRoot(installDir)
-	log.Info(fmt.Sprintf("[codex] registering marketplace: codex plugin marketplace add %s", root))
-	CodexExec("plugin", "marketplace", "add", root)
-	log.Info(fmt.Sprintf("[codex] installing plugin: codex plugin add %s@%s", slug, repoKey))
-	// Include the @<repoKey> qualifier so Codex resolves the correct marketplace source.
-	CodexExec("plugin", "add", slug+"@"+repoKey)
-	return nil
-}
-
-// codexPostDelete removes the plugin from the Codex marketplace manifest.
-func codexPostDelete(slug, installDir, repoKey string) error {
-	manifestPath := codexMarketplaceManifestPath(installDir)
-	log.Info(fmt.Sprintf("[codex] removing marketplace entry for '%s' from %s", slug, manifestPath))
-	if err := removeCodexMarketplaceEntry(manifestPath, slug); err != nil {
-		log.Warn("codex post-delete: failed to update marketplace manifest:", err)
-	}
-	if _, err := lookPathCodex(); err != nil {
-		return err
-	}
-	log.Info(fmt.Sprintf("[codex] removing plugin: codex plugin remove %s@%s", slug, repoKey))
-	CodexExec("plugin", "remove", slug+"@"+repoKey)
 	return nil
 }
 

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -60,13 +60,13 @@ var CodexExec = func(args ...string) {
 // codexPostInstall writes the plugin into the Codex marketplace manifest and
 // registers it with the native codex CLI (if available).
 //
-// Directory layout produced by agents.go (GlobalDir = ~/.agents/jfrog-plugins/plugins):
+// Directory layout produced by agents.go (GlobalDir = ~/.agents/marketplaces/<repoKey>):
 //
-//	~/.agents/jfrog-plugins/          ← marketplace root
+//	~/.agents/marketplaces/<repoKey>/          ← marketplace root
 //	  .agents/plugins/
-//	    marketplace.json              ← written here
+//	    marketplace.json                       ← written here
 //	  plugins/
-//	    <slug>/                       ← installDir (plugin files copied by jf)
+//	    <slug>/                                ← installDir (plugin files copied by jf)
 func codexPostInstall(slug, version, installDir, repoKey string) error {
 	manifestPath := codexMarketplaceManifestPath(installDir)
 	log.Info(fmt.Sprintf("[codex] writing marketplace entry for '%s' → %s", slug, manifestPath))
@@ -105,16 +105,16 @@ func codexPostDelete(slug, installDir, repoKey string) error {
 
 // codexMarketplaceRoot returns the marketplace root directory.
 //
-//	installDir = ~/.agents/jfrog-plugins/plugins/<slug>
-//	root       = ~/.agents/jfrog-plugins
+//	installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
+//	root       = ~/.agents/marketplaces/<repoKey>
 func codexMarketplaceRoot(installDir string) string {
 	return filepath.Dir(filepath.Dir(installDir))
 }
 
 // codexMarketplaceManifestPath returns the path to the Codex marketplace manifest.
 //
-//	installDir = ~/.agents/jfrog-plugins/plugins/<slug>
-//	manifest   = ~/.agents/jfrog-plugins/.agents/plugins/marketplace.json
+//	installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
+//	manifest   = ~/.agents/marketplaces/<repoKey>/.agents/plugins/marketplace.json
 func codexMarketplaceManifestPath(installDir string) string {
 	return filepath.Join(codexMarketplaceRoot(installDir), ".agents", "plugins", "marketplace.json")
 }

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -65,8 +65,7 @@ var CodexExec = func(args ...string) {
 //	~/.agents/plugins/local/<repoKey>/          ← marketplace root
 //	  .agents/plugins/
 //	    marketplace.json                       ← written here
-//	  plugins/
-//	    <slug>/                                ← installDir (plugin files copied by jf)
+//	  <slug>/                                  ← installDir (plugin files copied by jf)
 func codexPostInstall(slug, version, installDir, repoKey string) error {
 	manifestPath := codexMarketplaceManifestPath(installDir)
 	log.Info(fmt.Sprintf("[codex] writing marketplace entry for '%s' → %s", slug, manifestPath))
@@ -105,15 +104,15 @@ func codexPostDelete(slug, installDir, repoKey string) error {
 
 // codexMarketplaceRoot returns the marketplace root directory.
 //
-//	installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+//	installDir = ~/.agents/plugins/local/<repoKey>/<slug>
 //	root       = ~/.agents/plugins/local/<repoKey>
 func codexMarketplaceRoot(installDir string) string {
-	return filepath.Dir(filepath.Dir(installDir))
+	return filepath.Dir(installDir)
 }
 
 // codexMarketplaceManifestPath returns the path to the Codex marketplace manifest.
 //
-//	installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+//	installDir = ~/.agents/plugins/local/<repoKey>/<slug>
 //	manifest   = ~/.agents/plugins/local/<repoKey>/.agents/plugins/marketplace.json
 func codexMarketplaceManifestPath(installDir string) string {
 	return filepath.Join(codexMarketplaceRoot(installDir), ".agents", "plugins", "marketplace.json")
@@ -129,7 +128,7 @@ func upsertCodexMarketplaceEntry(path, slug, marketplaceName string) error {
 	}
 	entry := codexPluginEntry{
 		Name:   slug,
-		Source: codexPluginSrc{Source: "local", Path: "./plugins/" + slug},
+		Source: codexPluginSrc{Source: "local", Path: "./" + slug},
 		Policy: codexPolicy{Installation: "AVAILABLE"},
 	}
 	found := false

--- a/agent/plugins/common/hooks_codex.go
+++ b/agent/plugins/common/hooks_codex.go
@@ -60,9 +60,9 @@ var CodexExec = func(args ...string) {
 // codexPostInstall writes the plugin into the Codex marketplace manifest and
 // registers it with the native codex CLI (if available).
 //
-// Directory layout produced by agents.go (GlobalDir = ~/.agents/plugins/local/<repoKey>):
+// Directory layout produced by agents.go (GlobalDir = ~/.agents/plugins/local/jfrog):
 //
-//	~/.agents/plugins/local/<repoKey>/          ← marketplace root
+//	~/.agents/plugins/local/jfrog/          ← marketplace root
 //	  .agents/plugins/
 //	    marketplace.json                       ← written here
 //	  <slug>/                                  ← installDir (plugin files copied by jf)
@@ -91,16 +91,16 @@ func codexPostInstall(slug, version, installDir, repoKey string) error {
 
 // codexMarketplaceRoot returns the marketplace root directory.
 //
-//	installDir = ~/.agents/plugins/local/<repoKey>/<slug>
-//	root       = ~/.agents/plugins/local/<repoKey>
+//	installDir = ~/.agents/plugins/local/jfrog/<slug>
+//	root       = ~/.agents/plugins/local/jfrog
 func codexMarketplaceRoot(installDir string) string {
 	return filepath.Dir(installDir)
 }
 
 // codexMarketplaceManifestPath returns the path to the Codex marketplace manifest.
 //
-//	installDir = ~/.agents/plugins/local/<repoKey>/<slug>
-//	manifest   = ~/.agents/plugins/local/<repoKey>/.agents/plugins/marketplace.json
+//	installDir = ~/.agents/plugins/local/jfrog/<slug>
+//	manifest   = ~/.agents/plugins/local/jfrog/.agents/plugins/marketplace.json
 func codexMarketplaceManifestPath(installDir string) string {
 	return filepath.Join(codexMarketplaceRoot(installDir), ".agents", "plugins", "marketplace.json")
 }

--- a/agent/plugins/common/hooks_marketplace.go
+++ b/agent/plugins/common/hooks_marketplace.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+)
+
+// localMarketplaceOwner identifies the publisher of a JFrog-managed marketplace.
+type localMarketplaceOwner struct {
+	Name string `json:"name"`
+}
+
+// localMarketplace is the on-disk shape of the JFrog-managed local marketplace.json.
+// The owner field is required by the Claude plugin schema; Codex accepts it too.
+type localMarketplace struct {
+	Name    string                  `json:"name"`
+	Owner   localMarketplaceOwner   `json:"owner"`
+	Plugins []localMarketplaceEntry `json:"plugins"`
+}
+
+// localMarketplaceEntry is a single plugin record in the local marketplace.json.
+type localMarketplaceEntry struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	// Source is a relative path from the marketplace root to the plugin directory
+	// (e.g. "./my-plugin"). Both Claude and Codex accept a plain string here.
+	Source string `json:"source"`
+}
+
+// upsertLocalMarketplaceEntry reads or creates the marketplace JSON at path,
+// adds or replaces the entry for slug, then writes it back.
+// marketplaceName is written as the manifest's "name" field (typically the Artifactory repo key).
+// source is set to "./<slug>" — a path relative to the marketplace root directory.
+func upsertLocalMarketplaceEntry(path, slug, version, marketplaceName string) error {
+	m, err := readOrCreateLocalMarketplace(path, marketplaceName)
+	if err != nil {
+		return err
+	}
+	entry := localMarketplaceEntry{
+		Name:    slug,
+		Version: version,
+		Source:  "./" + slug,
+	}
+	found := false
+	for i, p := range m.Plugins {
+		if strings.EqualFold(p.Name, slug) {
+			m.Plugins[i] = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.Plugins = append(m.Plugins, entry)
+	}
+	return writeLocalMarketplace(path, m)
+}
+
+// removeLocalMarketplaceEntry reads the marketplace JSON at path, removes the
+// entry for slug, and writes it back only if the slug was present.
+// A missing file or a missing slug entry is a no-op.
+func removeLocalMarketplaceEntry(path, slug string) error {
+	m, err := readOrCreateLocalMarketplace(path, "")
+	if err != nil {
+		return err
+	}
+	n := len(m.Plugins)
+	kept := m.Plugins[:0]
+	for _, p := range m.Plugins {
+		if !strings.EqualFold(p.Name, slug) {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) == n {
+		return nil // slug not present; nothing to write
+	}
+	m.Plugins = kept
+	return writeLocalMarketplace(path, m)
+}
+
+// readOrCreateLocalMarketplace reads and parses path. When the file does not exist,
+// it returns an empty marketplace with the given name.
+func readOrCreateLocalMarketplace(path, marketplaceName string) (*localMarketplace, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is tool-managed config under agent home
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &localMarketplace{
+				Name:    marketplaceName,
+				Owner:   localMarketplaceOwner{Name: "JFrog"},
+				Plugins: []localMarketplaceEntry{},
+			}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m localMarketplace
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if m.Plugins == nil {
+		m.Plugins = []localMarketplaceEntry{}
+	}
+	return &m, nil
+}
+
+// writeLocalMarketplace creates parent directories as needed and writes m to path.
+func writeLocalMarketplace(path string, m *localMarketplace) error {
+	if err := os.MkdirAll(filepath.Dir(path), agentcommon.InstallDirMode); err != nil {
+		return fmt.Errorf("create dirs for %s: %w", path, err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal marketplace: %w", err)
+	}
+	if err := os.WriteFile(path, data, agentcommon.InstallManifestFileMode); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	// Prevent real agent CLI binaries from being invoked during unit tests.
+	ClaudeExec = func(_ ...string) {}
+	CodexExec = func(_ ...string) {}
+	lookPathClaude = func() (string, error) { return "", nil }
+	lookPathCodex = func() (string, error) { return "", nil }
+}
+
+func TestUpsertLocalMarketplaceEntry_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "my-plugin", "1.0.0", "test-repo"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "my-plugin", m.Plugins[0].Name)
+	assert.Equal(t, "1.0.0", m.Plugins[0].Version)
+	assert.Equal(t, "./my-plugin", m.Plugins[0].Source)
+}
+
+func TestUpsertLocalMarketplaceEntry_SetsOwner(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "my-plugin", "1.0.0", "test-repo"))
+
+	m := readMarketplaceFile(t, path)
+	assert.Equal(t, "JFrog", m.Owner.Name)
+}
+
+func TestUpsertLocalMarketplaceEntry_UpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "my-plugin", "1.0.0", "test-repo"))
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "my-plugin", "2.0.0", "test-repo"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 1, "upsert should replace, not append")
+	assert.Equal(t, "2.0.0", m.Plugins[0].Version)
+}
+
+func TestUpsertLocalMarketplaceEntry_CaseInsensitiveMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "My-Plugin", "1.0.0", "test-repo"))
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "my-plugin", "2.0.0", "test-repo"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 1, "case-insensitive upsert should replace")
+	assert.Equal(t, "2.0.0", m.Plugins[0].Version)
+}
+
+func TestUpsertLocalMarketplaceEntry_MultiplePlugins(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "alpha", "1.0.0", "test-repo"))
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "beta", "2.0.0", "test-repo"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 2)
+}
+
+func TestRemoveLocalMarketplaceEntry_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "alpha", "1.0.0", "test-repo"))
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "beta", "2.0.0", "test-repo"))
+	require.NoError(t, removeLocalMarketplaceEntry(path, "alpha"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "beta", m.Plugins[0].Name)
+}
+
+func TestRemoveLocalMarketplaceEntry_MissingFileIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+	assert.NoError(t, removeLocalMarketplaceEntry(path, "any-plugin"))
+	assert.NoFileExists(t, path, "remove on a missing file should not create the file")
+}
+
+func TestRemoveLocalMarketplaceEntry_MissingEntryIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "alpha", "1.0.0", "test-repo"))
+	require.NoError(t, removeLocalMarketplaceEntry(path, "nonexistent"))
+
+	m := readMarketplaceFile(t, path)
+	require.Len(t, m.Plugins, 1, "unrelated entries should be untouched")
+}
+
+func TestReadOrCreateLocalMarketplace_MissingFileReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+	m, err := readOrCreateLocalMarketplace(path, "my-repo")
+	require.NoError(t, err)
+	assert.Equal(t, "my-repo", m.Name)
+	assert.Equal(t, "JFrog", m.Owner.Name)
+	assert.Empty(t, m.Plugins)
+}
+
+func TestReadOrCreateLocalMarketplace_ParsesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+	require.NoError(t, upsertLocalMarketplaceEntry(path, "alpha", "1.0.0", "test-repo"))
+
+	m, err := readOrCreateLocalMarketplace(path, "test-repo")
+	require.NoError(t, err)
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "alpha", m.Plugins[0].Name)
+}
+
+func TestClaudeMarketplacePath(t *testing.T) {
+	// After InjectRepoKey: installDir = ~/.claude/plugins/local/<repoKey>/<slug>
+	// marketplace = ~/.claude/plugins/local/<repoKey>/.claude-plugin/marketplace.json
+	installDir := filepath.Join("/home", "user", ".claude", "plugins", "my-repo", "my-plugin")
+	got := claudeMarketplacePath(installDir)
+	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "my-repo", ".claude-plugin", "marketplace.json"), got)
+}
+
+func TestClaudeMarketplaceDir(t *testing.T) {
+	installDir := filepath.Join("/home", "user", ".claude", "plugins", "my-repo", "my-plugin")
+	got := claudeMarketplaceDir(installDir)
+	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "my-repo"), got)
+}
+
+func TestCodexMarketplaceManifestPath(t *testing.T) {
+	// After InjectRepoKey: installDir = ~/.agents/<repoKey>/plugins/<slug>
+	// root     = ~/.agents/<repoKey>
+	// manifest = ~/.agents/<repoKey>/.agents/plugins/marketplace.json
+	installDir := filepath.Join("/home", "user", ".agents", "my-repo", "plugins", "my-plugin")
+	got := codexMarketplaceManifestPath(installDir)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "my-repo", ".agents", "plugins", "marketplace.json"), got)
+}
+
+func TestCodexMarketplaceRoot(t *testing.T) {
+	installDir := filepath.Join("/home", "user", ".agents", "my-repo", "plugins", "my-plugin")
+	got := codexMarketplaceRoot(installDir)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "my-repo"), got)
+}
+
+func TestUpsertCodexMarketplaceEntry_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+
+	require.NoError(t, upsertCodexMarketplaceEntry(path, "my-plugin", "my-repo"))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m codexMarketplace
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, "my-repo", m.Name)
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "my-plugin", m.Plugins[0].Name)
+	assert.Equal(t, "local", m.Plugins[0].Source.Source)
+	assert.Equal(t, "./plugins/my-plugin", m.Plugins[0].Source.Path)
+}
+
+func TestRemoveCodexMarketplaceEntry_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marketplace.json")
+	require.NoError(t, upsertCodexMarketplaceEntry(path, "alpha", "my-repo"))
+	require.NoError(t, upsertCodexMarketplaceEntry(path, "beta", "my-repo"))
+	require.NoError(t, removeCodexMarketplaceEntry(path, "alpha"))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m codexMarketplace
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "beta", m.Plugins[0].Name)
+}
+
+// readMarketplaceFile is a test helper that parses the JSON at path.
+func readMarketplaceFile(t *testing.T, path string) localMarketplace {
+	t.Helper()
+	data, err := os.ReadFile(path) // #nosec G304 -- test helper reading a known test path
+	require.NoError(t, err)
+	var m localMarketplace
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -141,18 +141,18 @@ func TestClaudeMarketplaceDir(t *testing.T) {
 }
 
 func TestCodexMarketplaceManifestPath(t *testing.T) {
-	// After InjectRepoKey: installDir = ~/.agents/<repoKey>/plugins/<slug>
-	// root     = ~/.agents/<repoKey>
-	// manifest = ~/.agents/<repoKey>/.agents/plugins/marketplace.json
-	installDir := filepath.Join("/home", "user", ".agents", "my-repo", "plugins", "my-plugin")
+	// After InjectRepoKey: installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
+	// root     = ~/.agents/marketplaces/<repoKey>
+	// manifest = ~/.agents/marketplaces/<repoKey>/.agents/plugins/marketplace.json
+	installDir := filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", "plugins", "my-plugin")
 	got := codexMarketplaceManifestPath(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".agents", "my-repo", ".agents", "plugins", "marketplace.json"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", ".agents", "plugins", "marketplace.json"), got)
 }
 
 func TestCodexMarketplaceRoot(t *testing.T) {
-	installDir := filepath.Join("/home", "user", ".agents", "my-repo", "plugins", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", "plugins", "my-plugin")
 	got := codexMarketplaceRoot(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".agents", "my-repo"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo"), got)
 }
 
 func TestUpsertCodexMarketplaceEntry_CreatesFile(t *testing.T) {

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -12,10 +12,10 @@ import (
 
 func init() {
 	// Prevent real agent CLI binaries from being invoked during unit tests.
-	ClaudeExec = func(_ ...string) {}
-	CodexExec = func(_ ...string) {}
-	lookPathClaude = func() (string, error) { return "", nil }
-	lookPathCodex = func() (string, error) { return "", nil }
+	ClaudeExec = func(_ ...string) error { return nil }
+	CodexExec = func(_ ...string) error { return nil }
+	LookPathClaude = func() (string, error) { return "", nil }
+	LookPathCodex = func() (string, error) { return "", nil }
 }
 
 func TestUpsertLocalMarketplaceEntry_CreatesFile(t *testing.T) {

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -141,16 +141,16 @@ func TestClaudeMarketplaceDir(t *testing.T) {
 }
 
 func TestCodexMarketplaceManifestPath(t *testing.T) {
-	// After InjectRepoKey: installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+	// After InjectRepoKey: installDir = ~/.agents/plugins/local/<repoKey>/<slug>
 	// root     = ~/.agents/plugins/local/<repoKey>
 	// manifest = ~/.agents/plugins/local/<repoKey>/.agents/plugins/marketplace.json
-	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "plugins", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "my-plugin")
 	got := codexMarketplaceManifestPath(installDir)
 	assert.Equal(t, filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", ".agents", "plugins", "marketplace.json"), got)
 }
 
 func TestCodexMarketplaceRoot(t *testing.T) {
-	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "plugins", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "my-plugin")
 	got := codexMarketplaceRoot(installDir)
 	assert.Equal(t, filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo"), got)
 }
@@ -169,7 +169,7 @@ func TestUpsertCodexMarketplaceEntry_CreatesFile(t *testing.T) {
 	require.Len(t, m.Plugins, 1)
 	assert.Equal(t, "my-plugin", m.Plugins[0].Name)
 	assert.Equal(t, "local", m.Plugins[0].Source.Source)
-	assert.Equal(t, "./plugins/my-plugin", m.Plugins[0].Source.Path)
+	assert.Equal(t, "./my-plugin", m.Plugins[0].Source.Path)
 }
 
 func TestRemoveCodexMarketplaceEntry_RemovesEntry(t *testing.T) {

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -129,15 +129,15 @@ func TestReadOrCreateLocalMarketplace_ParsesExistingFile(t *testing.T) {
 func TestClaudeMarketplacePath(t *testing.T) {
 	// After InjectRepoKey: installDir = ~/.claude/plugins/local/<repoKey>/<slug>
 	// marketplace = ~/.claude/plugins/local/<repoKey>/.claude-plugin/marketplace.json
-	installDir := filepath.Join("/home", "user", ".claude", "plugins", "my-repo", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".claude", "plugins", "local", "my-repo", "my-plugin")
 	got := claudeMarketplacePath(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "my-repo", ".claude-plugin", "marketplace.json"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "local", "my-repo", ".claude-plugin", "marketplace.json"), got)
 }
 
 func TestClaudeMarketplaceDir(t *testing.T) {
-	installDir := filepath.Join("/home", "user", ".claude", "plugins", "my-repo", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".claude", "plugins", "local", "my-repo", "my-plugin")
 	got := claudeMarketplaceDir(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "my-repo"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".claude", "plugins", "local", "my-repo"), got)
 }
 
 func TestCodexMarketplaceManifestPath(t *testing.T) {

--- a/agent/plugins/common/hooks_marketplace_test.go
+++ b/agent/plugins/common/hooks_marketplace_test.go
@@ -141,18 +141,18 @@ func TestClaudeMarketplaceDir(t *testing.T) {
 }
 
 func TestCodexMarketplaceManifestPath(t *testing.T) {
-	// After InjectRepoKey: installDir = ~/.agents/marketplaces/<repoKey>/plugins/<slug>
-	// root     = ~/.agents/marketplaces/<repoKey>
-	// manifest = ~/.agents/marketplaces/<repoKey>/.agents/plugins/marketplace.json
-	installDir := filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", "plugins", "my-plugin")
+	// After InjectRepoKey: installDir = ~/.agents/plugins/local/<repoKey>/plugins/<slug>
+	// root     = ~/.agents/plugins/local/<repoKey>
+	// manifest = ~/.agents/plugins/local/<repoKey>/.agents/plugins/marketplace.json
+	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "plugins", "my-plugin")
 	got := codexMarketplaceManifestPath(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", ".agents", "plugins", "marketplace.json"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", ".agents", "plugins", "marketplace.json"), got)
 }
 
 func TestCodexMarketplaceRoot(t *testing.T) {
-	installDir := filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo", "plugins", "my-plugin")
+	installDir := filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo", "plugins", "my-plugin")
 	got := codexMarketplaceRoot(installDir)
-	assert.Equal(t, filepath.Join("/home", "user", ".agents", "marketplaces", "my-repo"), got)
+	assert.Equal(t, filepath.Join("/home", "user", ".agents", "plugins", "local", "my-repo"), got)
 }
 
 func TestUpsertCodexMarketplaceEntry_CreatesFile(t *testing.T) {

--- a/agent/plugins/common/install_targets.go
+++ b/agent/plugins/common/install_targets.go
@@ -24,8 +24,8 @@ type AgentTarget = agentcommon.InstallTarget
 // own isolated marketplace directory so installs from different repos never
 // overwrite each other's marketplace registration.
 //
-//   Claude: <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
-//   Codex:  <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
+//	Claude: <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
+//	Codex:  <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
 //
 // Cursor and --path targets are returned unchanged.
 func InjectRepoKey(targets []AgentTarget, repoKey string) []AgentTarget {

--- a/agent/plugins/common/install_targets.go
+++ b/agent/plugins/common/install_targets.go
@@ -25,7 +25,7 @@ type AgentTarget = agentcommon.InstallTarget
 // overwrite each other's marketplace registration.
 //
 //   Claude: <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
-//   Codex:  <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/plugins/<slug>
+//   Codex:  <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
 //
 // Cursor and --path targets are returned unchanged.
 func InjectRepoKey(targets []AgentTarget, repoKey string) []AgentTarget {
@@ -39,7 +39,7 @@ func InjectRepoKey(targets []AgentTarget, repoKey string) []AgentTarget {
 		case "codex":
 			base := filepath.Dir(t.DestinationDir)
 			slug := filepath.Base(t.DestinationDir)
-			t.DestinationDir = filepath.Join(base, repoKey, "plugins", slug)
+			t.DestinationDir = filepath.Join(base, repoKey, slug)
 		}
 		result[i] = t
 	}

--- a/agent/plugins/common/install_targets.go
+++ b/agent/plugins/common/install_targets.go
@@ -1,6 +1,11 @@
 package common
 
-import agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+import (
+	"path/filepath"
+	"strings"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+)
 
 const PathAgentName = agentcommon.PathAgentName
 
@@ -13,3 +18,30 @@ const (
 )
 
 type AgentTarget = agentcommon.InstallTarget
+
+// InjectRepoKey rewrites the DestinationDir of Claude and Codex targets to
+// include the Artifactory repo key as a subdirectory. This gives each repo its
+// own isolated marketplace directory so installs from different repos never
+// overwrite each other's marketplace registration.
+//
+//   Claude: <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/<slug>
+//   Codex:  <GlobalDir>/<slug>  →  <GlobalDir>/<repoKey>/plugins/<slug>
+//
+// Cursor and --path targets are returned unchanged.
+func InjectRepoKey(targets []AgentTarget, repoKey string) []AgentTarget {
+	result := make([]AgentTarget, len(targets))
+	for i, t := range targets {
+		switch strings.ToLower(t.Agent.Name) {
+		case "claude":
+			base := filepath.Dir(t.DestinationDir)
+			slug := filepath.Base(t.DestinationDir)
+			t.DestinationDir = filepath.Join(base, repoKey, slug)
+		case "codex":
+			base := filepath.Dir(t.DestinationDir)
+			slug := filepath.Base(t.DestinationDir)
+			t.DestinationDir = filepath.Join(base, repoKey, "plugins", slug)
+		}
+		result[i] = t
+	}
+	return result
+}

--- a/agent/plugins/common/install_targets_test.go
+++ b/agent/plugins/common/install_targets_test.go
@@ -1,0 +1,162 @@
+package common
+
+import (
+	"path/filepath"
+	"testing"
+
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInjectRepoKey_Claude(t *testing.T) {
+	targets := []AgentTarget{
+		{
+			Agent:          AgentSpec{Name: "claude"},
+			DestinationDir: filepath.Join("/home/user/.claude/plugins/local", "my-plugin"),
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, filepath.Join("/home/user/.claude/plugins/local/my-repo", "my-plugin"), result[0].DestinationDir)
+}
+
+func TestInjectRepoKey_Codex(t *testing.T) {
+	targets := []AgentTarget{
+		{
+			Agent:          AgentSpec{Name: "codex"},
+			DestinationDir: filepath.Join("/home/user/.agents/plugins/local", "my-plugin"),
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, filepath.Join("/home/user/.agents/plugins/local/my-repo", "my-plugin"), result[0].DestinationDir)
+}
+
+func TestInjectRepoKey_Cursor_Unchanged(t *testing.T) {
+	originalPath := filepath.Join("/home/user/.cursor/plugins/local", "my-plugin")
+	targets := []AgentTarget{
+		{
+			Agent:          AgentSpec{Name: "cursor"},
+			DestinationDir: originalPath,
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, originalPath, result[0].DestinationDir, "Cursor targets should not be modified")
+}
+
+func TestInjectRepoKey_UnknownAgent_Unchanged(t *testing.T) {
+	originalPath := "/custom/install/path/my-plugin"
+	targets := []AgentTarget{
+		{
+			Agent:          AgentSpec{Name: "unknown-agent"},
+			DestinationDir: originalPath,
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, originalPath, result[0].DestinationDir, "Unknown agents should not be modified")
+}
+
+func TestInjectRepoKey_CaseInsensitive(t *testing.T) {
+	targets := []AgentTarget{
+		{
+			Agent:          AgentSpec{Name: "Claude"},
+			DestinationDir: filepath.Join("/home/user/.claude/plugins/local", "my-plugin"),
+		},
+		{
+			Agent:          AgentSpec{Name: "CODEX"},
+			DestinationDir: filepath.Join("/home/user/.agents/plugins/local", "my-plugin"),
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, filepath.Join("/home/user/.claude/plugins/local/my-repo", "my-plugin"), result[0].DestinationDir)
+	assert.Equal(t, filepath.Join("/home/user/.agents/plugins/local/my-repo", "my-plugin"), result[1].DestinationDir)
+}
+
+func TestInjectRepoKey_MultipleTargets(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentName      string
+		inputPath      string
+		expectedChange bool
+	}{
+		{
+			name:           "claude_modified",
+			agentName:      "claude",
+			inputPath:      "/home/user/.claude/plugins/local/plugin1",
+			expectedChange: true,
+		},
+		{
+			name:           "codex_modified",
+			agentName:      "codex",
+			inputPath:      "/home/user/.agents/plugins/local/plugin2",
+			expectedChange: true,
+		},
+		{
+			name:           "cursor_unchanged",
+			agentName:      "cursor",
+			inputPath:      "/home/user/.cursor/plugins/local/plugin3",
+			expectedChange: false,
+		},
+		{
+			name:           "unknown_agent_unchanged",
+			agentName:      "my-agent",
+			inputPath:      "/custom/path/plugin4",
+			expectedChange: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targets := []AgentTarget{
+				{
+					Agent:          AgentSpec{Name: tc.agentName},
+					DestinationDir: tc.inputPath,
+				},
+			}
+
+			result := InjectRepoKey(targets, "test-repo")
+
+			if tc.expectedChange {
+				expectedDir := filepath.Join(filepath.Dir(tc.inputPath), "test-repo", filepath.Base(tc.inputPath))
+				assert.Equal(t, expectedDir, result[0].DestinationDir)
+			} else {
+				assert.Equal(t, tc.inputPath, result[0].DestinationDir)
+			}
+		})
+	}
+}
+
+func TestInjectRepoKey_PreservesOtherFields(t *testing.T) {
+	originalAgent := AgentSpec{Name: "claude", Config: AgentConfig{GlobalDir: "~/.claude/plugins/local"}}
+	originalScope := agentcommon.InstallScopeGlobal
+	originalPath := "/home/user/.claude/plugins/local/my-plugin"
+
+	targets := []AgentTarget{
+		{
+			Agent:          originalAgent,
+			Scope:          originalScope,
+			DestinationDir: originalPath,
+		},
+	}
+
+	result := InjectRepoKey(targets, "my-repo")
+
+	assert.Equal(t, originalAgent.Name, result[0].Agent.Name)
+	assert.Equal(t, originalScope, result[0].Scope)
+	// Only DestinationDir should change for claude/codex
+	assert.NotEqual(t, originalPath, result[0].DestinationDir)
+	assert.Equal(t, filepath.Join("/home/user/.claude/plugins/local/my-repo", "my-plugin"), result[0].DestinationDir)
+}

--- a/agent/skills/common/agents.go
+++ b/agent/skills/common/agents.go
@@ -11,6 +11,7 @@ type AgentConfig = agentcommon.AgentConfig
 type AgentSpec = agentcommon.AgentSpec
 
 // Agents is built-in defaults; merged with ~/.jfrog/agents/agent-config.json.
+// Paths ending in /jfrog are rooted under ~/.jfrog for JFrog-specific agent configurations.
 var Agents = map[string]AgentConfig{
 	"claude-code":    {GlobalDir: "~/.claude/skills", ProjectDir: ".claude/skills"},
 	"cursor":         {GlobalDir: "~/.cursor/skills", ProjectDir: ".cursor/skills"},


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----


### PR Summary: Agent Plugins Installation Guide & Global-Only Scope Enforcement
**Overview**
Added comprehensive documentation and enforced installation scope constraints for JFrog CLI's jf agent plugins install command across three AI agents (Claude, Cursor, Codex).

**Key Changes**
1. Global-Only Installation Scope
All three agents now support global scope only - project-scoped installations are no longer supported
Added validation to reject --project-dir attempts with agent-specific error messages explaining the architectural constraints
Each agent provides clear guidance: Claude and Codex config are user-scoped only; Cursor only auto-discovers from global directory

2. Standardized Installation Paths
Claude: ~/.claude/plugins/local/jfrog/<repoKey>/<slug>/
Cursor: ~/.cursor/plugins/local/<repoKey>/<slug>/.  (because cursor only identifies the plugins installed under /local)
Codex: ~/.agents/plugins/local/jfrog/<repoKey>/<slug>/

3. Repo Key Isolation
Each Artifactory repository gets isolated subdirectories and marketplace manifests
Prevents plugin name collisions when installing from multiple repos
Allows multiple repos with same plugin names via @repoKey syntax

4. Comprehensive Installation Guide (INSTALL_GUIDE.md)
Documents complete installation flow: download → extract → register → metadata
Agent-specific marketplace structures and native CLI interactions
Scope constraints with rationale for each agent
Collision prevention strategies
Troubleshooting guide with real examples

**Files Modified**
agent/plugins/commands/install/install.go - Added project scope validation
agent/plugins/common/agents.go - Updated paths, marked as global-only
agent/plugins/common/hooks_claude.go - Updated for new paths
agent/plugins/common/hooks_codex.go - Updated for new paths
agent/plugins/INSTALL_GUIDE.md - NEW - Complete installation documentation

**Testing**
All agent/plugins/... unit tests pass
Agent plugin configurations properly validated
Marketplace structures correctly generated for each agent
