### PR TITLE
RTECO-0000 - Validate --repo inside SetupCommand.Run so usage reporting is never skipped

### DIFF
--- a/artifactory/commands/setup/setup.go
+++ b/artifactory/commands/setup/setup.go
@@ -143,10 +143,34 @@ func (sc *SetupCommand) SetProjectKey(projectKey string) *SetupCommand {
 	return sc
 }
 
+// validateRepoExistsFn is overridable so tests can stub out the network call.
+var validateRepoExistsFn = validateRepoExists
+
+// validateRepoExists checks that the repository explicitly requested via --repo exists in Artifactory,
+// so that a bad repo name fails fast with a clear error instead of surfacing later as a confusing
+// package-manager-specific failure.
+func validateRepoExists(sc *SetupCommand) error {
+	serviceDetails, err := sc.serverDetails.CreateArtAuthConfig()
+	if err != nil {
+		return err
+	}
+	return utils.ValidateRepoExists(sc.repoName, serviceDetails)
+}
+
 // Run executes the configuration method corresponding to the package manager specified for the command.
 func (sc *SetupCommand) Run() (err error) {
 	if !IsSupportedPackageManager(sc.packageManager) {
 		return errorutils.CheckErrorf("unsupported package manager: %s", sc.packageManager)
+	}
+
+	// Validate the explicitly provided repository up front. This runs inside Run() (rather than in the
+	// CLI layer before Run() is invoked) so that every return path from here on is covered by the single
+	// usage-report call site in commands.Exec/ExecWithPackageManager - no separate reporting is needed
+	// for this failure.
+	if sc.repoName != "" {
+		if err = validateRepoExistsFn(sc); err != nil {
+			return err
+		}
 	}
 
 	// If the repository name is not provided, and the package manager is not Docker or Podman, prompt the user to select a repository.

--- a/artifactory/commands/setup/setup_test.go
+++ b/artifactory/commands/setup/setup_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-client-go/auth"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,18 @@ import (
 const (
 	goProxyEnv = "GOPROXY"
 )
+
+// TestMain stubs out validateRepoExistsFn for every test in this package, since
+// createTestSetupCommand points serverDetails at a fake host (acme.jfrog.io)
+// that can't answer a real repo-existence check. Tests that specifically want
+// to exercise validateRepoExists restore the real function for their own scope.
+func TestMain(m *testing.M) {
+	realValidateRepoExistsFn := validateRepoExistsFn
+	validateRepoExistsFn = func(*SetupCommand) error { return nil }
+	code := m.Run()
+	validateRepoExistsFn = realValidateRepoExistsFn
+	os.Exit(code)
+}
 
 // testCredential returns a fake JWT-like string for testing. NOT a real credential.
 func testCredential() string {
@@ -65,6 +78,21 @@ func createTestSetupCommand(packageManager project.ProjectType) *SetupCommand {
 	cmd.serverDetails = &config.ServerDetails{Url: dummyUrl, ArtifactoryUrl: dummyUrl + "/artifactory"}
 
 	return cmd
+}
+
+// TestSetupCommand_RepoValidationFailure verifies that Run() returns the repo-validation
+// error immediately, before attempting any package-manager-specific configuration.
+func TestSetupCommand_RepoValidationFailure(t *testing.T) {
+	realValidateRepoExistsFn := validateRepoExistsFn
+	defer func() { validateRepoExistsFn = realValidateRepoExistsFn }()
+
+	expectedErr := errorutils.CheckErrorf("the repository 'test-repo' does not exist")
+	validateRepoExistsFn = func(*SetupCommand) error { return expectedErr }
+
+	cmd := createTestSetupCommand(project.Npm)
+	err := cmd.Run()
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
 }
 
 func TestSetupCommand_NotSupported(t *testing.T) {


### PR DESCRIPTION
## Summary
- `jf setup <package-manager> --repo <name>` validated the repo existed in the `jfrog-cli` CLI layer, before ever invoking `commands.ExecWithPackageManager` - the only call site that triggers a usage report for this command. Any invalid `--repo` therefore returned early and silently skipped the usage report for that invocation. Companion fix: jfrog/jfrog-cli#3609.
- This moves the repo-existence check into `SetupCommand.Run()` itself, after `IsSupportedPackageManager` and before the interactive-repo-selection / package-manager-configuration logic. Since `Run()` is always reached via `commands.ExecWithPackageManager`, every return path - including this validation - is now covered by that single usage-report call site. No CLI-side workaround is needed.
- `validateRepoExistsFn` is a package-level function var (same seam pattern as other overridable hooks in this codebase) so existing unit tests, which run `Run()` against a fake `acme.jfrog.io` server, aren't broken by the added network call. `setup_test.go`'s new `TestMain` stubs it to a no-op for all tests; `TestSetupCommand_RepoValidationFailure` restores the real seam to verify `Run()` surfaces a validation error immediately.

## Test plan
- [x] `go build ./artifactory/commands/setup/...`
- [x] `go vet ./artifactory/commands/setup/...`
- [x] `go test ./artifactory/commands/setup/...` - all pass except `TestSetupCommand_UV`, which fails identically on `main` due to an outdated local `uv` binary (unrelated to this change).
