### PR TITLE
RTECO-1647 - Add support for Maven Wrapper in native mode

### DIFF
--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -35,6 +35,8 @@ type MvnCommand struct {
 	deploymentDisabled bool
 	// File path for Maven extractor in which all build's artifacts details will be listed at the end of the build.
 	buildArtifactsDetailsFile string
+	// Only consulted in native (FlexPack) mode; set by jf mvnw to require a Maven Wrapper.
+	preferWrapper bool
 }
 
 func NewMvnCommand() *MvnCommand {
@@ -68,6 +70,13 @@ func (mc *MvnCommand) SetThreads(threads int) *MvnCommand {
 
 func (mc *MvnCommand) SetInsecureTls(insecureTls bool) *MvnCommand {
 	mc.insecureTls = insecureTls
+	return mc
+}
+
+// SetPreferWrapper is only consulted in native (FlexPack) mode. jf mvnw sets this to true,
+// requiring a Maven Wrapper (mvnw/mvnw.cmd) to be present; legacy (config-file) mode ignores it.
+func (mc *MvnCommand) SetPreferWrapper(preferWrapper bool) *MvnCommand {
+	mc.preferWrapper = preferWrapper
 	return mc
 }
 
@@ -182,7 +191,8 @@ func (mc *MvnCommand) Run() error {
 		mvnParams := NewMvnUtils().
 			SetConfigPath(mc.configPath).
 			SetGoals(mc.goals).
-			SetBuildConf(mc.configuration)
+			SetBuildConf(mc.configuration).
+			SetPreferWrapper(mc.preferWrapper)
 		return RunMvn(mvnParams)
 	}
 

--- a/artifactory/commands/mvn/utils.go
+++ b/artifactory/commands/mvn/utils.go
@@ -34,6 +34,7 @@ type MvnUtils struct {
 	insecureTls               bool
 	disableDeploy             bool
 	outputWriter              io.Writer
+	preferWrapper             bool
 }
 
 func NewMvnUtils() *MvnUtils {
@@ -85,16 +86,54 @@ func (mu *MvnUtils) SetOutputWriter(writer io.Writer) *MvnUtils {
 	return mu
 }
 
+// SetPreferWrapper controls Maven executable resolution in native (FlexPack) mode.
+// When true (jf mvnw), a Maven Wrapper (mvnw/mvnw.cmd) must be found upward from the
+// working directory, or the command fails. When false (jf mvn), a wrapper is never
+// used; native mode always runs "mvn" from PATH.
+func (mu *MvnUtils) SetPreferWrapper(preferWrapper bool) *MvnUtils {
+	mu.preferWrapper = preferWrapper
+	return mu
+}
+
+// resolveMavenExecutable determines which Maven executable native (FlexPack) mode should run.
+// jf mvn (preferWrapper=false) always uses "mvn" from PATH, unchanged from prior behavior.
+// jf mvnw (preferWrapper=true) searches upward from the working directory for a project root
+// containing ".mvn" (the Maven Wrapper marker directory) and requires mvnw/mvnw.cmd there;
+// it fails rather than silently falling back to PATH "mvn".
+func resolveMavenExecutable(preferWrapper bool) (string, error) {
+	if !preferWrapper {
+		return "mvn", nil
+	}
+	projectRoot, exists, err := fileutils.FindUpstream(".mvn", fileutils.Dir)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if exists {
+		wrapperName := "mvnw"
+		if coreutils.IsWindows() {
+			wrapperName = "mvnw.cmd"
+		}
+		wrapperPath := filepath.Join(projectRoot, wrapperName)
+		if _, statErr := os.Stat(wrapperPath); statErr == nil {
+			return wrapperPath, nil
+		}
+	}
+	return "", errorutils.CheckErrorf("mvnw invoked but no Maven Wrapper (mvnw/mvnw.cmd) was found in the current directory or any parent directory")
+}
+
 func RunMvn(mu *MvnUtils) error {
 	// FlexPack completely bypasses traditional Maven Build Info Extractor
 	if utils.ShouldRunNative(mu.configPath) {
 		log.Debug("Maven native implementation activated")
+		mavenExecutable, err := resolveMavenExecutable(mu.preferWrapper)
+		if err != nil {
+			return err
+		}
 		// Execute native Maven command directly (no JFrog Maven plugin)
-		cmd := exec.Command("mvn", mu.goals...)
+		cmd := exec.Command(mavenExecutable, mu.goals...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		err := cmd.Run()
-		if err != nil {
+		if err = cmd.Run(); err != nil {
 			log.Error("Failed to execute package manager command: " + err.Error())
 			return errorutils.CheckError(err)
 		}

--- a/artifactory/commands/mvn/utils_test.go
+++ b/artifactory/commands/mvn/utils_test.go
@@ -94,9 +94,15 @@ func TestResolveMavenExecutable(t *testing.T) {
 				assert.Equal(t, tt.expectedExe, exe)
 				return
 			}
-			resolvedRoot, err := filepath.EvalSymlinks(wrapperRoot)
+			// Compare file identity rather than the path string: Windows CI runners can report
+			// the same directory via a short (8.3) alias (e.g. "RUNNER~1" vs "runneradmin"),
+			// which would make a plain string comparison fail even though exe correctly points
+			// at the wrapper script.
+			expectedInfo, err := os.Stat(filepath.Join(wrapperRoot, wrapperName))
 			require.NoError(t, err)
-			assert.Equal(t, filepath.Join(resolvedRoot, wrapperName), exe)
+			actualInfo, err := os.Stat(exe)
+			require.NoError(t, err)
+			assert.True(t, os.SameFile(expectedInfo, actualInfo), "resolved executable %q does not refer to the expected wrapper in %q", exe, wrapperRoot)
 		})
 	}
 }

--- a/artifactory/commands/mvn/utils_test.go
+++ b/artifactory/commands/mvn/utils_test.go
@@ -1,0 +1,108 @@
+package mvn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMavenExecutable(t *testing.T) {
+	wrapperName := "mvnw"
+	if coreutils.IsWindows() {
+		wrapperName = "mvnw.cmd"
+	}
+
+	tests := []struct {
+		name          string
+		preferWrapper bool
+		// setupCwd creates the fixture and returns the directory to chdir into, plus the
+		// directory the wrapper was actually placed in ("" if no wrapper was created).
+		setupCwd    func(t *testing.T) (cwd string, wrapperRoot string)
+		expectedExe string
+		expectErr   bool
+	}{
+		{
+			name:          "jf mvn without wrapper present - falls back to PATH mvn",
+			preferWrapper: false,
+			setupCwd: func(t *testing.T) (string, string) {
+				return t.TempDir(), ""
+			},
+			expectedExe: "mvn",
+		},
+		{
+			name:          "jf mvn with wrapper present - still uses PATH mvn (opt-in only via mvnw)",
+			preferWrapper: false,
+			setupCwd: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				createWrapperFixture(t, root, wrapperName)
+				return root, root
+			},
+			expectedExe: "mvn",
+		},
+		{
+			name:          "jf mvnw with wrapper in cwd - uses wrapper",
+			preferWrapper: true,
+			setupCwd: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				createWrapperFixture(t, root, wrapperName)
+				return root, root
+			},
+		},
+		{
+			name:          "jf mvnw with wrapper only in parent dir - upward search finds it",
+			preferWrapper: true,
+			setupCwd: func(t *testing.T) (string, string) {
+				root := t.TempDir()
+				createWrapperFixture(t, root, wrapperName)
+				subDir := filepath.Join(root, "module-a")
+				require.NoError(t, os.MkdirAll(subDir, 0755))
+				return subDir, root
+			},
+		},
+		{
+			name:          "jf mvnw without wrapper anywhere - errors, no fallback",
+			preferWrapper: true,
+			setupCwd: func(t *testing.T) (string, string) {
+				return t.TempDir(), ""
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origWd, err := os.Getwd()
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, os.Chdir(origWd))
+			}()
+
+			cwd, wrapperRoot := tt.setupCwd(t)
+			require.NoError(t, os.Chdir(cwd))
+
+			exe, err := resolveMavenExecutable(tt.preferWrapper)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.expectedExe != "" {
+				assert.Equal(t, tt.expectedExe, exe)
+				return
+			}
+			resolvedRoot, err := filepath.EvalSymlinks(wrapperRoot)
+			require.NoError(t, err)
+			assert.Equal(t, filepath.Join(resolvedRoot, wrapperName), exe)
+		})
+	}
+}
+
+// createWrapperFixture creates a minimal Maven Wrapper marker (.mvn dir + wrapper script) at root.
+func createWrapperFixture(t *testing.T, root, wrapperName string) {
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mvn", "wrapper"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, wrapperName), []byte("#!/bin/sh\n"), 0755))
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
