### PR TITLE
RTECO-1597 - Huggingface download should not go to local

### DIFF
--- a/artifactory/commands/huggingface/huggingFaceDownload.go
+++ b/artifactory/commands/huggingface/huggingFaceDownload.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/jfrog/build-info-go/entities"
-	coreUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	buildUtils "github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -43,15 +42,6 @@ func (hfd *HuggingFaceDownload) Run() error {
 	if hfd.repoId == "" {
 		return errorutils.CheckErrorf("repo_id cannot be empty")
 	}
-	serviceManager, err := coreUtils.CreateServiceManager(hfd.serverDetails, -1, 0, false)
-	if err != nil {
-		return fmt.Errorf("failed to create services manager: %w", err)
-	}
-	repo, err := handleRepositoryResolution(serviceManager, hfd.serverDetails, "download")
-	if err != nil {
-		return err
-	}
-	hfd.repo = repo
 	pythonPath, err := GetPythonPath()
 	if err != nil {
 		return err


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
What: Currently, we are resolving the virtual repository to get the local repository and then downloading from local repository itself, BUT this should not be the case, for download command, we don't need to resolve the repository at all.
Changes: Remove the local repository logic completely for download command.
Testing: Done, on artifactory instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hugging Face downloads now proceed more directly after repository ID validation.
  * Improved download flow reliability by avoiding unnecessary repository resolution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->