### PR TITLE
Fix gradle 8.3 compatibility

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+/home/runner/_work/AgentZero/AgentZero/az-targets/jfrog-cli-artifactory/.cursor/skills

--- a/artifactory/commands/gradle/resources/jfrog.init.gradle
+++ b/artifactory/commands/gradle/resources/jfrog.init.gradle
@@ -23,7 +23,8 @@ void configureMavenRepo(repositories, String rtUrl, String rtUser, String rtPass
 }
 
 // Configure the pluginManagement repositories
-gradle.settingsEvaluated { settings ->
+// beforeSettings is required for Gradle 8.x: pluginManagement is finalized before settingsEvaluated fires.
+gradle.beforeSettings { settings ->
     settings.pluginManagement {
         repositories {
             configureMavenRepo(it, "${artifactoryUrl}/${gradleRepoName}", artifactoryUsername, artifactoryAccessToken, allowInsecure)


### PR DESCRIPTION
## Automated fix by AZ_PMCompatFixer

**PM:** `gradle` `8.3`
**Failing run:** https://github.jfrog.info/JFROG/jfrog-cli-workflows/actions/runs/1134328
**Tested against:** jfrog-cli @ `master`

### What was fixed
Replace gradle.settingsEvaluated with gradle.beforeSettings in jfrog.init.gradle for Gradle 8.x pluginManagement compatibility

---
_Raised automatically by AZ_PMCompatFixer. Please review before merging._
