### PR TITLE
RTECO-1723 - Fix windows plugins publish

### DIFF
--- a/agent/common/publish_zip.go
+++ b/agent/common/publish_zip.go
@@ -164,7 +164,11 @@ func CollectPublishFiles(sourceDir string) (files []ZipFileEntry, maxMtime time.
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].RelPath < files[j].RelPath })
+	// Sort on the slash form so entry order matches the names written to the zip,
+	// keeping output identical across Windows and Unix.
+	sort.Slice(files, func(i, j int) bool {
+		return filepath.ToSlash(files[i].RelPath) < filepath.ToSlash(files[j].RelPath)
+	})
 	return files, maxMtime, nil
 }
 
@@ -172,7 +176,9 @@ func addFileToZip(zipWriter *zip.Writer, sourceDir string, fileEntry ZipFileEntr
 	absPath := filepath.Join(sourceDir, fileEntry.RelPath)
 
 	header := &zip.FileHeader{
-		Name:     fileEntry.RelPath,
+		// The zip format requires forward slashes, while filepath.Rel yields the
+		// OS separator, which is a backslash on Windows.
+		Name:     filepath.ToSlash(fileEntry.RelPath),
 		Method:   zip.Deflate,
 		Modified: uniformTime,
 	}

--- a/agent/common/publish_zip_test.go
+++ b/agent/common/publish_zip_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -120,9 +121,14 @@ func TestZipPublishBundleUsesForwardSlashPaths(t *testing.T) {
 		}
 	}
 
+	gotNames := make([]string, 0, len(zr.File))
 	names := make(map[string]bool, len(zr.File))
 	for _, file := range zr.File {
+		gotNames = append(gotNames, file.Name)
 		names[file.Name] = true
+	}
+	if !sort.StringsAreSorted(gotNames) {
+		t.Fatalf("ZIP entries must be sorted ascending by forward-slash path, got %v", gotNames)
 	}
 
 	wantNames := []string{"plugin.json", "skills/greeting/SKILL.md", "skills/math/SKILL.md"}

--- a/agent/common/publish_zip_test.go
+++ b/agent/common/publish_zip_test.go
@@ -41,7 +41,7 @@ func TestZipPublishBundleSkipsExcluded(t *testing.T) {
 	for _, file := range zr.File {
 		names[file.Name] = true
 	}
-	if !names["README.md"] || !names[filepath.Join("src", "main.go")] {
+	if !names["README.md"] || !names["src/main.go"] {
 		t.Fatalf("expected included files, got %v", names)
 	}
 	for name := range names {
@@ -86,6 +86,50 @@ func mustMkdir(t *testing.T, root, rel string) {
 	full := filepath.Join(root, rel)
 	if err := os.MkdirAll(full, DefaultDirMode); err != nil {
 		t.Fatalf("mkdir: %v", err)
+	}
+}
+
+func TestZipPublishBundleUsesForwardSlashPaths(t *testing.T) {
+	dir := t.TempDir()
+	mustWritePublishTestFile(t, dir, "plugin.json", `{"name":"demo","version":"1.0.0"}`)
+	mustWritePublishTestFile(t, dir, "skills/greeting/SKILL.md", "# Greeting")
+	mustWritePublishTestFile(t, dir, "skills/math/SKILL.md", "# Math")
+
+	zipPath, tmpDir, _, err := ZipPublishBundle(ZipPublishOptions{
+		SourceDir:      dir,
+		Slug:           "demo",
+		Version:        "1.0.0",
+		TempDirPrefix:  "agent-plugin-publish-",
+		ContentLabel:   "plugin",
+		HashWhileWrite: false,
+	})
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	for _, file := range zr.File {
+		if strings.Contains(file.Name, "\\") {
+			t.Fatalf("ZIP entry contains backslash (should be forward slash): %s", file.Name)
+		}
+	}
+
+	names := make(map[string]bool, len(zr.File))
+	for _, file := range zr.File {
+		names[file.Name] = true
+	}
+
+	wantNames := []string{"plugin.json", "skills/greeting/SKILL.md", "skills/math/SKILL.md"}
+	for _, want := range wantNames {
+		if !names[want] {
+			t.Fatalf("expected entry %q in zip, got %v", want, names)
+		}
 	}
 }
 

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -397,7 +397,7 @@ func RunInstall(c *components.Context) error {
 		return err
 	}
 
-	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: false})
+	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: true})
 	if err != nil {
 		return err
 	}

--- a/agent/plugins/commands/install/install.go
+++ b/agent/plugins/commands/install/install.go
@@ -397,7 +397,7 @@ func RunInstall(c *components.Context) error {
 		return err
 	}
 
-	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: true})
+	flags, err := agentcommon.ValidateInstallFlags(c, plugincommon.Agents, agentcommon.PluginsAgentsKey, plugincommon.RegistryHelp, agentcommon.InstallFlagsOptions{DefaultGlobalScope: false})
 	if err != nil {
 		return err
 	}

--- a/agent/plugins/commands/publish/publish_test.go
+++ b/agent/plugins/commands/publish/publish_test.go
@@ -184,7 +184,8 @@ func TestZipPluginFolderSkipsExcluded(t *testing.T) {
 	for _, file := range zr.File {
 		names[file.Name] = true
 	}
-	if !names["README.md"] || !names[filepath.Join("src", "main.go")] {
+	// Zip entry names always use forward slashes, regardless of host OS.
+	if !names["README.md"] || !names["src/main.go"] {
 		t.Fatalf("expected included files, got %v", names)
 	}
 	for name := range names {

--- a/agent/skills/commands/publish/publish.go
+++ b/agent/skills/commands/publish/publish.go
@@ -1,17 +1,10 @@
 package publish
 
 import (
-	"archive/zip"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"runtime"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/jfrog/build-info-go/entities"
 	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
@@ -27,14 +20,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
-
-var zipExcludes = map[string]bool{
-	".git":         true,
-	".jfrog":       true,
-	"__pycache__":  true,
-	"node_modules": true,
-	".DS_Store":    true,
-}
 
 type PublishCommand struct {
 	serverDetails       *config.ServerDetails
@@ -151,19 +136,22 @@ func (pc *PublishCommand) Run() error {
 
 	log.Info(fmt.Sprintf("Publishing skill '%s' version '%s'", slug, version))
 
-	zipPath, err := pc.resolveZip(slug, version)
+	zipPath, zipTmpDir, sha256Hex, err := pc.resolveZip(slug, version)
+	// The temp dir is created before the archive is written, so it can exist even
+	// when the write fails. Register cleanup before checking err.
+	defer func() {
+		if zipTmpDir != "" {
+			_ = os.RemoveAll(zipTmpDir) // best-effort temp cleanup after upload
+		}
+	}()
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if !isPrebuiltZip(pc.skillDir, slug, version) {
-			_ = os.Remove(zipPath)
+	if sha256Hex == "" {
+		// Prebuilt zips bypass the streaming hasher; hash on disk in that case.
+		if sha256Hex, err = agentcommon.ComputeSHA256(zipPath); err != nil {
+			return fmt.Errorf("failed to compute SHA256: %w", err)
 		}
-	}()
-
-	sha256Hex, err := computeSHA256(zipPath)
-	if err != nil {
-		return fmt.Errorf("failed to compute SHA256: %w", err)
 	}
 
 	collectBuildInfo := false
@@ -194,10 +182,13 @@ func (pc *PublishCommand) Run() error {
 	}
 
 	log.Info("Upload complete. Attaching evidence...")
-	pc.attachEvidence(slug, version, sha256Hex)
+	// The upload is flat, so the artifact keeps the zip's base name. Prebuilt zips
+	// use a different name than generated ones, so derive it instead of rebuilding it.
+	zipName := filepath.Base(zipPath)
+	pc.attachEvidence(slug, version, sha256Hex, fmt.Sprintf("%s/%s/%s/%s", pc.repoKey, slug, version, zipName))
 
 	// Post-publish Xray scan gate check
-	artifactPath := fmt.Sprintf("%s/%s/%s-%s.zip", slug, version, slug, version)
+	artifactPath := fmt.Sprintf("%s/%s/%s", slug, version, zipName)
 	if err := common.CheckXrayGate(common.XrayGateParams{
 		ServerDetails:       pc.serverDetails,
 		RepoKey:             pc.repoKey,
@@ -298,202 +289,27 @@ func (pc *PublishCommand) resolveVersionCollision(slug, version string) (string,
 	}
 }
 
-func (pc *PublishCommand) resolveZip(slug, version string) (string, error) {
-	if strings.Contains(version, "..") || strings.ContainsAny(version, "/\\") {
-		return "", fmt.Errorf("invalid version '%s': contains path traversal characters", version)
+// resolveZip locates or builds the publish zip and, when it was built locally,
+// also returns the temp directory holding the zip and its SHA256 (computed in the
+// same pass as the write). zipTmpDir is empty for prebuilt zips; callers should
+// defer os.RemoveAll(zipTmpDir) when non-empty, including on error, because the
+// temp directory is created before the archive is written. The result order mirrors
+// agentcommon.ZipPublishBundle so the values cannot be transposed on their way out.
+func (pc *PublishCommand) resolveZip(slug, version string) (zipPath, zipTmpDir, sha256Hex string, err error) {
+	if agentcommon.IsPrebuiltPublishZip(pc.skillDir, slug, version) {
+		prebuiltPath := agentcommon.PrebuiltPublishZipPath(pc.skillDir, slug, version)
+		log.Info("Using pre-built zip:", prebuiltPath)
+		return prebuiltPath, "", "", nil
 	}
-	prebuilt := filepath.Clean(filepath.Join(pc.skillDir, "zip", fmt.Sprintf("%s_%s.zip", slug, version)))
-	if _, err := os.Stat(prebuilt); err == nil {
-		log.Info("Using pre-built zip:", prebuilt)
-		return prebuilt, nil
-	}
 
-	return zipSkillFolder(pc.skillDir, slug, version)
-}
-
-func isPrebuiltZip(skillDir, slug, version string) bool {
-	prebuilt := filepath.Join(skillDir, "zip", fmt.Sprintf("%s_%s.zip", slug, version))
-	_, err := os.Stat(prebuilt)
-	return err == nil
-}
-
-// zipEpoch is the earliest valid timestamp in ZIP format (MS-DOS epoch).
-// Used as a fallback when all file mtimes are zero.
-var zipEpoch = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
-
-type skillFile struct {
-	relPath string
-	mode    os.FileMode
-}
-
-// collectFiles walks the skill directory and returns a sorted list of included
-// files with their permissions, plus the max mtime across all included files.
-// Sorting ensures deterministic zip output regardless of filesystem traversal order.
-// The max mtime is used as a uniform timestamp for all zip entries.
-func collectFiles(skillDir string) (files []skillFile, maxMtime time.Time, err error) {
-	err = filepath.Walk(skillDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel(skillDir, path)
-		if err != nil {
-			return err
-		}
-		if shouldExclude(relPath, info) {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !info.IsDir() {
-			files = append(files, skillFile{relPath: relPath, mode: info.Mode()})
-			if info.ModTime().After(maxMtime) {
-				maxMtime = info.ModTime()
-			}
-		}
-		return nil
+	return agentcommon.ZipPublishBundle(agentcommon.ZipPublishOptions{
+		SourceDir:      pc.skillDir,
+		Slug:           slug,
+		Version:        version,
+		TempDirPrefix:  "skill-publish-",
+		ContentLabel:   "skill",
+		HashWhileWrite: true,
 	})
-	if err != nil {
-		return
-	}
-	// Sort on the slash form so entry order matches the names written to the zip,
-	// keeping output identical across Windows and Unix.
-	sort.Slice(files, func(i, j int) bool {
-		return filepath.ToSlash(files[i].relPath) < filepath.ToSlash(files[j].relPath)
-	})
-	return
-}
-
-// addFileToZip writes a single file into the zip writer with a deterministic header.
-// Timestamps are set to uniformTime (for both modern and legacy MS-DOS fields),
-// Extra field is stripped to remove platform-specific metadata, and file permissions
-// are preserved from the mode captured during collection (no second os.Stat).
-func addFileToZip(w *zip.Writer, skillDir string, sf skillFile, uniformTime time.Time) error {
-	absPath := filepath.Join(skillDir, sf.relPath)
-
-	header := &zip.FileHeader{
-		// The zip format requires forward slashes, while filepath.Rel yields the
-		// OS separator, which is a backslash on Windows.
-		Name:     filepath.ToSlash(sf.relPath),
-		Method:   zip.Deflate,
-		Modified: uniformTime,
-	}
-	header.SetModTime(uniformTime) //nolint:staticcheck // sets legacy MS-DOS ModifiedDate/ModifiedTime fields
-	header.SetMode(normalizeFileMode(sf.mode))
-	header.Extra = nil
-
-	writer, err := w.CreateHeader(header)
-	if err != nil {
-		return err
-	}
-
-	// #nosec G304 -- absPath is from user-provided skill directory joined with a walked relative path
-	file, err := os.Open(absPath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	_, err = io.Copy(writer, file)
-	return err
-}
-
-// normalizeFileMode returns a consistent Unix file mode for zip entry headers.
-// On Windows, os.Stat returns 0666 for all files (no execute bit support), so
-// we default to 0644 for regular files. On Unix, the real mode is preserved.
-func normalizeFileMode(mode os.FileMode) os.FileMode {
-	if runtime.GOOS == "windows" {
-		return 0644
-	}
-	return mode
-}
-
-func zipSkillFolder(skillDir, slug, version string) (zipPath string, err error) {
-	if strings.Contains(version, "..") || strings.ContainsAny(version, "/\\") {
-		return "", fmt.Errorf("invalid version '%s': contains path traversal characters", version)
-	}
-
-	// Collect and sort file paths for deterministic zip output.
-	// The max mtime is used as a uniform timestamp for all zip entries so that
-	// the zip is byte-identical when rebuilt with the same content and mtimes.
-	files, maxMtime, err := collectFiles(skillDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to collect skill files: %w", err)
-	}
-	if len(files) == 0 {
-		return "", fmt.Errorf("no files found in skill directory %s (all files may have been excluded)", skillDir)
-	}
-	// Guard against zero mtime (e.g. files with epoch timestamps) which produces
-	// invalid MS-DOS dates before the ZIP format's 1980-01-01 minimum.
-	if maxMtime.IsZero() {
-		maxMtime = zipEpoch
-	}
-
-	tmpDir, err := os.MkdirTemp("", "skill-publish-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir: %w", err)
-	}
-
-	zipPath = filepath.Clean(filepath.Join(tmpDir, fmt.Sprintf("%s-%s.zip", slug, version)))
-	zipFile, err := os.Create(zipPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to create zip file: %w", err)
-	}
-	defer func() {
-		_ = zipFile.Close()
-	}()
-
-	w := zip.NewWriter(zipFile)
-	defer func() {
-		if cerr := w.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("failed to finalize zip: %w", cerr)
-		}
-	}()
-
-	for _, sf := range files {
-		if err = addFileToZip(w, skillDir, sf, maxMtime); err != nil {
-			return "", fmt.Errorf("failed to add %s to zip: %w", sf.relPath, err)
-		}
-	}
-
-	return
-}
-
-func shouldExclude(relPath string, info os.FileInfo) bool {
-	name := info.Name()
-
-	if zipExcludes[name] {
-		return true
-	}
-	if strings.HasSuffix(name, ".pyc") {
-		return true
-	}
-	if relPath == "." {
-		return false
-	}
-	return false
-}
-
-func computeSHA256(path string) (string, error) {
-	if strings.Contains(path, "..") {
-		return "", fmt.Errorf("invalid path: contains traversal sequence")
-	}
-	cleanPath := filepath.Clean(path)
-	f, err := os.Open(cleanPath)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (pc *PublishCommand) upload(zipPath, target string, collectBuildInfo bool) (*content.ContentReader, error) {
@@ -534,7 +350,7 @@ func (pc *PublishCommand) upload(zipPath, target string, collectBuildInfo bool) 
 	return nil, err
 }
 
-func (pc *PublishCommand) attachEvidence(slug, version, sha256Hex string) {
+func (pc *PublishCommand) attachEvidence(slug, version, sha256Hex, subjectRepoPath string) {
 	// Flags take precedence over environment variables
 	keyPath := pc.signingKey
 	if keyPath == "" {
@@ -574,8 +390,6 @@ func (pc *PublishCommand) attachEvidence(slug, version, sha256Hex string) {
 		log.Warn("Failed to generate attestation markdown:", err.Error())
 		return
 	}
-
-	subjectRepoPath := fmt.Sprintf("%s/%s/%s/%s-%s.zip", pc.repoKey, slug, version, slug, version)
 
 	opts := agentcommon.CreateEvidenceOpts{
 		SubjectRepoPath: subjectRepoPath,

--- a/agent/skills/commands/publish/publish.go
+++ b/agent/skills/commands/publish/publish.go
@@ -356,7 +356,11 @@ func collectFiles(skillDir string) (files []skillFile, maxMtime time.Time, err e
 	if err != nil {
 		return
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].relPath < files[j].relPath })
+	// Sort on the slash form so entry order matches the names written to the zip,
+	// keeping output identical across Windows and Unix.
+	sort.Slice(files, func(i, j int) bool {
+		return filepath.ToSlash(files[i].relPath) < filepath.ToSlash(files[j].relPath)
+	})
 	return
 }
 
@@ -368,7 +372,9 @@ func addFileToZip(w *zip.Writer, skillDir string, sf skillFile, uniformTime time
 	absPath := filepath.Join(skillDir, sf.relPath)
 
 	header := &zip.FileHeader{
-		Name:     sf.relPath,
+		// The zip format requires forward slashes, while filepath.Rel yields the
+		// OS separator, which is a backslash on Windows.
+		Name:     filepath.ToSlash(sf.relPath),
 		Method:   zip.Deflate,
 		Modified: uniformTime,
 	}

--- a/agent/skills/commands/publish/publish_test.go
+++ b/agent/skills/commands/publish/publish_test.go
@@ -11,9 +11,21 @@ import (
 	"testing"
 	"time"
 
+	agentcommon "github.com/jfrog/jfrog-cli-artifactory/agent/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func zipSkillFolder(skillDir string) (zipPath, tmpDir, hash string, err error) {
+	return agentcommon.ZipPublishBundle(agentcommon.ZipPublishOptions{
+		SourceDir:      skillDir,
+		Slug:           "test",
+		Version:        "1.0.0",
+		TempDirPrefix:  "skill-publish-",
+		ContentLabel:   "skill",
+		HashWhileWrite: true,
+	})
+}
 
 func TestParseSkillMeta(t *testing.T) {
 	dir := t.TempDir()
@@ -296,9 +308,9 @@ func TestZipSkillFolder(t *testing.T) {
 	// Create excludable files
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.pyc"), []byte("compiled"), 0644))
 
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath, tmpDir, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath) }()
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	info, err := os.Stat(zipPath)
 	require.NoError(t, err)
@@ -312,6 +324,70 @@ func TestZipSkillFolder(t *testing.T) {
 	}
 }
 
+func TestResolveZipBuildsBundle(t *testing.T) {
+	dir := createSkillDir(t)
+	pc := NewPublishCommand().SetSkillDir(dir)
+
+	zipPath, zipTmpDir, sha256Hex, err := pc.resolveZip("test", "1.0.0")
+	require.NoError(t, err)
+	// Guards against a leak if an assertion below fails before the explicit cleanup.
+	defer func() { _ = os.RemoveAll(zipTmpDir) }()
+
+	assert.Regexp(t, "^[0-9a-f]{64}$", sha256Hex, "third return value must be the SHA256 digest")
+
+	require.NotEmpty(t, zipTmpDir)
+	assert.Equal(t, zipTmpDir, filepath.Dir(zipPath), "second return value must be the temp dir holding the zip")
+
+	onDisk, err := agentcommon.ComputeSHA256(zipPath)
+	require.NoError(t, err)
+	assert.Equal(t, onDisk, sha256Hex)
+
+	require.NoError(t, os.RemoveAll(zipTmpDir))
+	_, err = os.Stat(zipPath)
+	assert.True(t, os.IsNotExist(err), "removing the returned temp dir must delete the zip")
+}
+
+func TestResolveZipReturnsTempDirOnWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks on Windows requires elevated privileges")
+	}
+
+	dir := createSkillDir(t)
+	// A dangling symlink is collected as a regular entry but fails to open during
+	// the write, after the temp dir has already been created.
+	require.NoError(t, os.Symlink(filepath.Join(dir, "missing.py"), filepath.Join(dir, "broken.py")))
+
+	pc := NewPublishCommand().SetSkillDir(dir)
+
+	_, zipTmpDir, _, err := pc.resolveZip("test", "1.0.0")
+	require.Error(t, err)
+	require.NotEmpty(t, zipTmpDir, "temp dir must be returned on failure so the caller can remove it")
+	defer func() { _ = os.RemoveAll(zipTmpDir) }()
+
+	_, statErr := os.Stat(zipTmpDir)
+	assert.NoError(t, statErr, "temp dir is left on disk and would leak without caller cleanup")
+}
+
+func TestResolveZipUsesPrebuiltWhenPresent(t *testing.T) {
+	dir := createSkillDir(t)
+	zipDir := filepath.Join(dir, "zip")
+	require.NoError(t, os.MkdirAll(zipDir, 0755))
+	prebuilt := filepath.Join(zipDir, "test_1.0.0.zip")
+	require.NoError(t, os.WriteFile(prebuilt, []byte("prebuilt-content"), 0644))
+
+	pc := NewPublishCommand().SetSkillDir(dir)
+
+	zipPath, zipTmpDir, sha256Hex, err := pc.resolveZip("test", "1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, prebuilt, zipPath)
+	assert.Empty(t, sha256Hex, "prebuilt zips are hashed by the caller")
+	assert.Empty(t, zipTmpDir, "prebuilt zips have no temp dir to clean up")
+
+	// The flat upload keeps this base name, so evidence and the Xray gate must use
+	// it rather than assuming the generated "{slug}-{version}.zip" form.
+	assert.Equal(t, "test_1.0.0.zip", filepath.Base(zipPath))
+}
+
 func TestZipSkillFolderUsesForwardSlashPaths(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: test\n---"), 0644))
@@ -319,9 +395,9 @@ func TestZipSkillFolderUsesForwardSlashPaths(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "run.py"), []byte("print(1)"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "helpers", "util.py"), []byte("pass"), 0644))
 
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath, tmpDir, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(filepath.Dir(zipPath)) }()
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	r, err := zip.OpenReader(zipPath)
 	require.NoError(t, err)
@@ -343,7 +419,7 @@ func TestComputeSHA256(t *testing.T) {
 	testFile := filepath.Join(dir, "test.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("hello world"), 0644))
 
-	hash, err := computeSHA256(testFile)
+	hash, err := agentcommon.ComputeSHA256(testFile)
 	require.NoError(t, err)
 	assert.Len(t, hash, 64)
 	// SHA256 of "hello world"
@@ -369,7 +445,7 @@ func TestShouldExclude(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			info := fakeFileInfo{name: filepath.Base(tt.relPath), dir: tt.isDir}
-			assert.Equal(t, tt.exclude, shouldExclude(tt.relPath, info))
+			assert.Equal(t, tt.exclude, agentcommon.ShouldExcludePublishPath(tt.relPath, info))
 		})
 	}
 }
@@ -401,12 +477,10 @@ func createSkillDir(t *testing.T) string {
 
 func zipAndHash(t *testing.T, dir string) string {
 	t.Helper()
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	_, tmpDir, hash, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	// Clean up both the zip file and its parent temp directory.
-	defer func() { _ = os.RemoveAll(filepath.Dir(zipPath)) }()
-	hash, err := computeSHA256(zipPath)
-	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	require.NotEmpty(t, hash)
 	return hash
 }
 
@@ -438,9 +512,9 @@ func TestZipDeterministic_AllEntriesShareMaxMtime(t *testing.T) {
 	require.NoError(t, os.Chtimes(filepath.Join(dir, "main.py"), newest, newest))
 	require.NoError(t, os.Chtimes(filepath.Join(dir, "utils", "helper.py"), past, past))
 
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath, tmpDir, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath) }()
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	r, err := zip.OpenReader(zipPath)
 	require.NoError(t, err)
@@ -458,12 +532,12 @@ func TestZipDeterministic_ExtraFieldConsistent(t *testing.T) {
 	// Zip twice and verify the Extra fields are identical across runs.
 	// Go's zip writer adds a UT (Unix Timestamp) extra field via CreateHeader;
 	// since our timestamps are uniform (max mtime), the extra bytes are deterministic.
-	zipPath1, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath1, tmpDir1, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath1) }()
-	zipPath2, err := zipSkillFolder(dir, "test", "1.0.0")
+	defer func() { _ = os.RemoveAll(tmpDir1) }()
+	zipPath2, tmpDir2, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath2) }()
+	defer func() { _ = os.RemoveAll(tmpDir2) }()
 
 	r1, err := zip.OpenReader(zipPath1)
 	require.NoError(t, err)
@@ -484,9 +558,9 @@ func TestZipDeterministic_PermissionsPreserved(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		// Windows normalizes all files to 0644 since it doesn't support Unix permissions.
-		zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+		zipPath, tmpDir, _, err := zipSkillFolder(dir)
 		require.NoError(t, err)
-		defer func() { _ = os.Remove(zipPath) }()
+		defer func() { _ = os.RemoveAll(tmpDir) }()
 		r, err := zip.OpenReader(zipPath)
 		require.NoError(t, err)
 		defer func() { _ = r.Close() }()
@@ -500,9 +574,9 @@ func TestZipDeterministic_PermissionsPreserved(t *testing.T) {
 	}
 
 	require.NoError(t, os.Chmod(filepath.Join(dir, "main.py"), 0755))
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath, tmpDir, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath) }()
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 	r, err := zip.OpenReader(zipPath)
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
@@ -538,9 +612,9 @@ func TestZipDeterministic_FilesSorted(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "zzz.py"), []byte("last"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "aaa.py"), []byte("first"), 0644))
 
-	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	zipPath, tmpDir, _, err := zipSkillFolder(dir)
 	require.NoError(t, err)
-	defer func() { _ = os.Remove(zipPath) }()
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	r, err := zip.OpenReader(zipPath)
 	require.NoError(t, err)
@@ -563,16 +637,16 @@ func TestCollectFiles_ExcludesCorrectly(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".jfrog"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".jfrog", "skill-info.json"), []byte("{}"), 0644))
 
-	files, _, err := collectFiles(dir)
+	files, _, err := agentcommon.CollectPublishFiles(dir)
 	require.NoError(t, err)
 
 	var names []string
 	for _, f := range files {
-		names = append(names, f.relPath)
-		assert.NotContains(t, f.relPath, ".pyc", "should exclude .pyc files")
-		assert.NotContains(t, f.relPath, ".DS_Store", "should exclude .DS_Store")
-		assert.NotContains(t, f.relPath, "__pycache__", "should exclude __pycache__")
-		assert.NotContains(t, f.relPath, ".jfrog", "should exclude .jfrog")
+		names = append(names, f.RelPath)
+		assert.NotContains(t, f.RelPath, ".pyc", "should exclude .pyc files")
+		assert.NotContains(t, f.RelPath, ".DS_Store", "should exclude .DS_Store")
+		assert.NotContains(t, f.RelPath, "__pycache__", "should exclude __pycache__")
+		assert.NotContains(t, f.RelPath, ".jfrog", "should exclude .jfrog")
 	}
 	assert.Contains(t, names, "SKILL.md")
 	assert.Contains(t, names, "main.py")
@@ -583,10 +657,10 @@ func TestCollectFiles_Sorted(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "zzz.py"), []byte("z"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "aaa.py"), []byte("a"), 0644))
 
-	files, _, err := collectFiles(dir)
+	files, _, err := agentcommon.CollectPublishFiles(dir)
 	require.NoError(t, err)
 	for i := 1; i < len(files); i++ {
-		assert.True(t, files[i-1].relPath < files[i].relPath,
-			"files should be sorted: %s should come before %s", files[i-1].relPath, files[i].relPath)
+		assert.True(t, filepath.ToSlash(files[i-1].RelPath) < filepath.ToSlash(files[i].RelPath),
+			"files should be sorted: %s should come before %s", files[i-1].RelPath, files[i].RelPath)
 	}
 }

--- a/agent/skills/commands/publish/publish_test.go
+++ b/agent/skills/commands/publish/publish_test.go
@@ -312,6 +312,32 @@ func TestZipSkillFolder(t *testing.T) {
 	}
 }
 
+func TestZipSkillFolderUsesForwardSlashPaths(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: test\n---"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "scripts", "helpers"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "run.py"), []byte("print(1)"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "helpers", "util.py"), []byte("pass"), 0644))
+
+	zipPath, err := zipSkillFolder(dir, "test", "1.0.0")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(filepath.Dir(zipPath)) }()
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	names := make(map[string]bool, len(r.File))
+	for _, file := range r.File {
+		assert.NotContains(t, file.Name, "\\", "zip entry must use forward slashes")
+		names[file.Name] = true
+	}
+
+	for _, want := range []string{"SKILL.md", "scripts/run.py", "scripts/helpers/util.py"} {
+		assert.True(t, names[want], "expected entry %q in zip, got %v", want, names)
+	}
+}
+
 func TestComputeSHA256(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "test.txt")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- ZIP archives now use consistent forward-slash paths across operating systems.
- ZIP entry ordering is deterministic across Windows and Unix.
- Publishing handles generated and prebuilt archives more reliably.
- Temporary files are cleaned up after archive creation.

## Tests
- Updated ZIP assertions for OS-independent entry names.
- Added coverage for archive paths, ordering, prebuilt archives, cleanup, and expected contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Removes redundant functions and uses common functions