### PR TITLE
Fix pip.conf world-readable permissions after jf setup

### DIFF
--- a/artifactory/commands/python/pip.go
+++ b/artifactory/commands/python/pip.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/python/dependencies"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 )
 
 type PipCommand struct {
@@ -54,9 +56,47 @@ func CreatePipConfigManually(customPipConfigPath, repoWithCredsUrl string) error
 	if err := os.MkdirAll(filepath.Dir(cleanPath), os.ModePerm); err != nil {
 		return err
 	}
-	// Write the configuration to pip.conf.
+	// Write the configuration to pip.conf with owner-only permissions — the
+	// index-url may embed credentials (user:token@host).
 	configContent := fmt.Sprintf("[global]\nindex-url = %s\n", repoWithCredsUrl)
-	return os.WriteFile(cleanPath, []byte(configContent), 0644)
+	return os.WriteFile(cleanPath, []byte(configContent), 0600)
+}
+
+// ResolvePipConfigPath returns the pip config file path that `jf setup pip`
+// writes. Honors PIP_CONFIG_FILE; otherwise uses the platform default that
+// `pip config set` targets (Windows: %APPDATA%/pip/pip.ini, else ~/.config/pip/pip.conf).
+func ResolvePipConfigPath() (string, error) {
+	if custom := os.Getenv("PIP_CONFIG_FILE"); custom != "" {
+		return filepath.Clean(custom), nil
+	}
+	if coreutils.IsWindows() {
+		appData := filepath.Clean(os.Getenv("APPDATA"))
+		if appData == "" || appData == "." {
+			return "", errorutils.CheckErrorf("APPDATA environment variable not set")
+		}
+		return filepath.Join(appData, "pip", "pip.ini"), nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", errorutils.CheckErrorf("failed to determine home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".config", "pip", "pip.conf"), nil
+}
+
+// HardenPipConfigPermissions forces the resolved pip config file to 0600 so a
+// cleartext token in index-url is not left world-readable after `pip config set`.
+func HardenPipConfigPermissions() error {
+	confPath, err := ResolvePipConfigPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(confPath); err != nil {
+		if os.IsNotExist(err) {
+			return errorutils.CheckErrorf("pip config file missing after setup: %s", confPath)
+		}
+		return errorutils.CheckError(err)
+	}
+	return errorutils.CheckError(os.Chmod(confPath, 0600))
 }
 
 func (pc *PipCommand) CommandName() string {

--- a/artifactory/commands/python/pip_test.go
+++ b/artifactory/commands/python/pip_test.go
@@ -1,15 +1,17 @@
 package python
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreatePipConfigManually(t *testing.T) {
 	// Define the test parameters
-	customConfigPath := filepath.Join(t.TempDir(), "/tmp/test/pip.conf")
+	customConfigPath := filepath.Join(t.TempDir(), "tmp", "test", "pip.conf")
 	// #nosec G101 -- False positive - no hardcoded credentials.
 	repoWithCredsUrl := "https://example.com/simple/"
 	expectedContent := "[global]\nindex-url = https://example.com/simple/\n"
@@ -24,4 +26,40 @@ func TestCreatePipConfigManually(t *testing.T) {
 	fileContent, err := os.ReadFile(customConfigPath)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContent, string(fileContent))
+
+	info, err := os.Stat(customConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestResolvePipConfigPath_PIP_CONFIG_FILE(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "custom-pip.conf")
+	t.Setenv("PIP_CONFIG_FILE", custom)
+
+	got, err := ResolvePipConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(custom), got)
+}
+
+func TestHardenPipConfigPermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "pip")
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	conf := filepath.Join(dir, "pip.conf")
+	require.NoError(t, os.WriteFile(conf, []byte("[global]\nindex-url = https://x\n"), 0644))
+	t.Setenv("PIP_CONFIG_FILE", conf)
+
+	require.NoError(t, HardenPipConfigPermissions())
+
+	info, err := os.Stat(conf)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestHardenPipConfigPermissions_MissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.conf")
+	t.Setenv("PIP_CONFIG_FILE", missing)
+
+	err := HardenPipConfigPermissions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
 }

--- a/artifactory/commands/setup/setup.go
+++ b/artifactory/commands/setup/setup.go
@@ -237,6 +237,11 @@ func (sc *SetupCommand) configurePip() error {
 	if err := python.RunConfigCommand(project.Pip, []string{"set", "global.index-url", repoWithCredsUrl}); err != nil {
 		return fmt.Errorf("failed to configure pip index-url: %w", err)
 	}
+	// pip config set creates the file with umask-derived permissions (often 0644);
+	// harden to 0600 because index-url embeds credentials.
+	if err := python.HardenPipConfigPermissions(); err != nil {
+		return fmt.Errorf("failed to harden pip config permissions: %w", err)
+	}
 	return nil
 }
 

--- a/artifactory/commands/setup/setup_test.go
+++ b/artifactory/commands/setup/setup_test.go
@@ -211,6 +211,10 @@ func testSetupCommandPip(t *testing.T, packageManager project.ProjectType, custo
 			assert.NoError(t, err)
 			pipConfigContent := string(pipConfigContentBytes)
 
+			info, err := os.Stat(pipConfFilePath)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "pip config must be owner-only readable")
+
 			switch {
 			case testCase.accessToken != "":
 				// Validate token-based authentication.


### PR DESCRIPTION
## Overview

`jf setup pip` embeds credentials in `index-url` and previously left the config file world-readable (`0644`). This change forces owner-only permissions (`0600`) after setup, matching the existing Twine `.pypirc` pattern.

## Details

- `CreatePipConfigManually` (`PIP_CONFIG_FILE` path) now writes with mode `0600`.
- After the default `pip config set` path succeeds, `HardenPipConfigPermissions()` chmods the resolved config to `0600` (fail closed if the file is missing or chmod fails).
- `ResolvePipConfigPath()` honors `PIP_CONFIG_FILE`, otherwise uses `%APPDATA%/pip/pip.ini` on Windows and `~/.config/pip/pip.conf` elsewhere.

## Flow

```mermaid
flowchart TD
  start["configurePip"]
  custom{PIP_CONFIG_FILE set?}
  manual["CreatePipConfigManually 0600"]
  pipSet["pip config set"]
  harden["HardenPipConfigPermissions 0600"]
  done["return nil"]
  fail["return error"]
  start --> custom
  custom -->|yes| manual --> done
  custom -->|no| pipSet
  pipSet -->|ok| harden
  pipSet -->|err| fail
  harden -->|ok| done
  harden -->|err| fail
```

## Notes

- Verified with a local `jf` build (`replace` → this module) and `jf setup pip --server-id … --repo …`: resulting `pip.conf` mode is `0600`.
- Does not remove cleartext credentials from the URL; it only fixes file permissions.
- Related tracking: agent-hooks permission finding for pip vs npm (`jf setup npm` already lands at `0600`).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pip configuration files containing credentials are now restricted to owner-only access.
  * Existing configurations are hardened after setup, with clear errors for missing or inaccessible files.

* **Bug Fixes**
  * Pip configuration path detection now supports custom `PIP_CONFIG_FILE` locations and platform-specific defaults.

* **Tests**
  * Added coverage for configuration path resolution, permission enforcement, and missing-file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->