### PR TITLE
Publish the jf setup package-manager capability table

### DIFF
--- a/artifactory/commands/setup/capabilities.go
+++ b/artifactory/commands/setup/capabilities.go
@@ -1,0 +1,145 @@
+package setup
+
+import (
+	"encoding/json"
+
+	"github.com/jfrog/jfrog-cli-core/v2/common/project"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// Roles a package manager can be configured for.
+const (
+	// RoleInstall means setup redirects dependency resolution through Artifactory.
+	RoleInstall = "install"
+	// RolePublish means setup configures uploads, not resolution.
+	RolePublish = "publish"
+)
+
+// Configuration-file groups. Every package manager in one group writes the SAME
+// file, so a caller setting up more than one of them must serialize those runs.
+const (
+	ConfigGroupPipConf     = "pip-conf"
+	ConfigGroupNugetConfig = "nuget-config"
+)
+
+// defaultVersionArg is what most clients accept to print their version.
+var defaultVersionArg = []string{"--version"}
+
+// Capability is the machine-readable description of one package manager that
+// `jf setup` supports.
+//
+// It exists because every downstream consumer had grown its own copy of this
+// table — Fly Desktop (TypeScript), the Fly client (Go) and the JFrog agent
+// hooks each hand-maintain a package-manager list, binary names, shared-config
+// groupings and which package managers need a client on PATH. None of those
+// copies can be checked against this package, so each one drifts silently the
+// day a package manager is added here. Publishing the table makes those copies
+// deletable.
+type Capability struct {
+	// PackageManager is the token accepted by `jf setup <package manager>`.
+	PackageManager string `json:"packageManager"`
+	// RepoPackageType is the Artifactory repository package type it resolves
+	// against, e.g. "pypi" for pip, pipenv, poetry, twine and uv.
+	RepoPackageType string `json:"repoPackageType"`
+	// Aliases are other accepted names for the same package manager.
+	Aliases []string `json:"aliases,omitempty"`
+	// ClientBinaries are the executables to look for on PATH, in preference order.
+	ClientBinaries []string `json:"clientBinaries"`
+	// VersionCmd is the argument list that makes the client print its version.
+	// Not every client accepts --version.
+	VersionCmd []string `json:"versionCmd"`
+	// MinVersion, when set, is the oldest client release setup can configure.
+	MinVersion string `json:"minVersion,omitempty"`
+	// RequiresClient reports whether setup runs the client. When false the
+	// configuration file is written directly and setup works with no client
+	// installed — which is what wrapper-only projects (./mvnw, ./gradlew) rely on.
+	RequiresClient bool `json:"requiresClient"`
+	// Role is RoleInstall or RolePublish.
+	Role string `json:"role"`
+	// CredentialsOnly reports that setup stores credentials without redirecting
+	// resolution, so an unqualified `docker pull alpine` still goes to Docker Hub.
+	CredentialsOnly bool `json:"credentialsOnly"`
+	// ConfigGroup, when set, names the configuration file shared with other
+	// package managers. Setups within one group must not run concurrently.
+	ConfigGroup string `json:"configGroup,omitempty"`
+	// ConfigLocation describes the configuration in the user's terms. It is not an
+	// absolute path: the real path is platform dependent and the package manager
+	// resolves it itself.
+	ConfigLocation string `json:"configLocation"`
+	// OverrideEnv, when set, is the environment variable that moves the
+	// configuration off its user-level default.
+	OverrideEnv string `json:"overrideEnv,omitempty"`
+}
+
+// GetCapabilities returns one Capability per supported package manager, in the
+// same order as GetSupportedPackageManagersList.
+func GetCapabilities() []Capability {
+	packageManagers := maps.Keys(packageManagerToRepositoryPackageType)
+	slices.SortFunc(packageManagers, func(a, b project.ProjectType) int {
+		return int(a) - int(b)
+	})
+
+	capabilities := make([]Capability, 0, len(packageManagers))
+	for _, packageManager := range packageManagers {
+		capabilities = append(capabilities, buildCapability(packageManager))
+	}
+	return capabilities
+}
+
+// GetCapability returns the Capability for one package manager, or an error when
+// `jf setup` does not support it.
+func GetCapability(packageManager project.ProjectType) (Capability, error) {
+	if !IsSupportedPackageManager(packageManager) {
+		return Capability{}, errorutils.CheckErrorf("unsupported package manager: %s", packageManager)
+	}
+	return buildCapability(packageManager), nil
+}
+
+// MarshalCapabilities renders the whole table as indented JSON, for callers that
+// read it as the output of a command rather than as a Go value.
+func MarshalCapabilities() (string, error) {
+	encoded, err := json.MarshalIndent(GetCapabilities(), "", "  ")
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	return string(encoded), nil
+}
+
+func buildCapability(packageManager project.ProjectType) Capability {
+	name := packageManager.String()
+	// A package manager present in packageManagerToRepositoryPackageType but absent
+	// from packageManagerConfigs yields the zero config, which would publish empty
+	// binaries and an empty location. TestGetCapabilities_EveryEntryIsFullyPopulated
+	// keeps the two maps in step, so that is a test failure rather than bad output.
+	config := packageManagerConfigs[packageManager]
+
+	clientBinaries := config.clientBinaries
+	if len(clientBinaries) == 0 {
+		clientBinaries = []string{name}
+	}
+	versionCmd := config.versionCmd
+	if len(versionCmd) == 0 {
+		versionCmd = defaultVersionArg
+	}
+	role := RoleInstall
+	if config.publishOnly {
+		role = RolePublish
+	}
+
+	return Capability{
+		PackageManager:  name,
+		RepoPackageType: packageManagerToRepositoryPackageType[packageManager],
+		Aliases:         slices.Clone(config.aliases),
+		ClientBinaries:  slices.Clone(clientBinaries),
+		VersionCmd:      slices.Clone(versionCmd),
+		MinVersion:      config.minVersion,
+		RequiresClient:  !config.configOnly,
+		Role:            role,
+		CredentialsOnly: config.credentialsOnly,
+		ConfigGroup:     config.configGroup,
+		ConfigLocation:  config.location,
+		OverrideEnv:     config.overrideEnv,
+	}
+}

--- a/artifactory/commands/setup/capabilities_test.go
+++ b/artifactory/commands/setup/capabilities_test.go
@@ -196,12 +196,13 @@ func TestGetCapabilities_GroupByRepoPackageType(t *testing.T) {
 	assert.ElementsMatch(t, []string{"docker", "podman"}, byRepoType["docker"])
 	assert.ElementsMatch(t, []string{"nuget", "dotnet"}, byRepoType["nuget"])
 
-	// Gradle is its own Artifactory package type here, NOT part of "maven".
-	// Pinned deliberately: downstream copies of this table disagree — the Fly client
-	// registers gradle under its maven repo name, and the agent hooks map the maven
-	// package type to [maven, gradle]. Anything resolving a gradle repository from
-	// the "maven" type is contradicting this mapping, and `jf setup gradle` will not
-	// offer a maven-type repository when it prompts.
+	// Gradle is its own Artifactory package type, NOT part of "maven" — Artifactory
+	// has real Gradle repositories. Pinned because downstream copies of this table
+	// fold gradle into maven: the Fly client registers it under its maven repo name
+	// (it had no Gradle repositories to point at), and the agent hooks map the maven
+	// package type to [maven, gradle]. Since this map drives
+	// promptUserToSelectRepository, `jf setup gradle` will not offer a maven-type
+	// repository, so those copies have to change rather than this mapping.
 	assert.Equal(t, []string{"maven"}, byRepoType["maven"])
 	assert.Equal(t, []string{"gradle"}, byRepoType["gradle"])
 }

--- a/artifactory/commands/setup/capabilities_test.go
+++ b/artifactory/commands/setup/capabilities_test.go
@@ -1,0 +1,207 @@
+package setup
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/common/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The point of publishing the table: adding a package manager to `jf setup`
+// without describing it here would ship an incomplete contract to the consumers
+// that replaced their own copies with it.
+func TestGetCapabilities_CoversEverySupportedPackageManager(t *testing.T) {
+	capabilities := GetCapabilities()
+	supported := GetSupportedPackageManagersList()
+
+	require.Len(t, capabilities, len(supported),
+		"every package manager `jf setup` supports needs exactly one Capability")
+
+	byName := make(map[string]Capability, len(capabilities))
+	for _, capability := range capabilities {
+		byName[capability.PackageManager] = capability
+	}
+	for _, packageManager := range supported {
+		require.Contains(t, byName, packageManager,
+			"`jf setup %s` is supported but has no Capability entry", packageManager)
+	}
+
+	// Order has to match, so callers can zip the two lists.
+	for i, packageManager := range supported {
+		assert.Equal(t, packageManager, capabilities[i].PackageManager,
+			"GetCapabilities must use the same order as GetSupportedPackageManagersList")
+	}
+}
+
+// Every field a consumer is told it can rely on must actually be populated —
+// an entry added with only a location would otherwise pass the coverage test
+// above while publishing empty binaries and version arguments.
+func TestGetCapabilities_EveryEntryIsFullyPopulated(t *testing.T) {
+	for _, capability := range GetCapabilities() {
+		t.Run(capability.PackageManager, func(t *testing.T) {
+			assert.NotEmpty(t, capability.RepoPackageType, "repoPackageType must be set")
+			assert.NotEmpty(t, capability.ConfigLocation, "configLocation must be set")
+			assert.NotEmpty(t, capability.ClientBinaries, "clientBinaries must never be empty")
+			assert.NotEmpty(t, capability.VersionCmd, "versionCmd must never be empty")
+			assert.Contains(t, []string{RoleInstall, RolePublish}, capability.Role)
+			for _, binary := range capability.ClientBinaries {
+				assert.NotEmpty(t, binary, "clientBinaries must not contain empty strings")
+			}
+		})
+	}
+}
+
+// Defaults exist so entries only spell out what differs. Assert the defaults are
+// applied rather than silently left empty.
+func TestGetCapabilities_Defaults(t *testing.T) {
+	npm, err := GetCapability(project.Npm)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"npm"}, npm.ClientBinaries, "clientBinaries defaults to the package manager's own name")
+	assert.Equal(t, []string{"--version"}, npm.VersionCmd, "versionCmd defaults to --version")
+	assert.Empty(t, npm.Aliases)
+	assert.Equal(t, RoleInstall, npm.Role)
+	assert.True(t, npm.RequiresClient)
+}
+
+// The three facts downstream copies got wrong, pinned here.
+func TestGetCapabilities_KnownSpecialCases(t *testing.T) {
+	t.Run("maven and gradle need no client on PATH", func(t *testing.T) {
+		// configureMaven goes through NewSettingsXmlManager and configureGradle through
+		// WriteInitScript, so a wrapper-only project must not be gated on a PATH lookup.
+		for _, packageManager := range []project.ProjectType{project.Maven, project.Gradle} {
+			capability, err := GetCapability(packageManager)
+			require.NoError(t, err)
+			assert.False(t, capability.RequiresClient,
+				"%s setup writes its configuration directly", capability.PackageManager)
+		}
+	})
+
+	t.Run("maven is reachable as mvn", func(t *testing.T) {
+		maven, err := GetCapability(project.Maven)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"mvn"}, maven.Aliases)
+		assert.Equal(t, []string{"mvn"}, maven.ClientBinaries)
+	})
+
+	t.Run("pip prefers pip over pip3", func(t *testing.T) {
+		// Matches getExecutable, which tries pip first and falls back to pip3.
+		pip, err := GetCapability(project.Pip)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"pip", "pip3"}, pip.ClientBinaries)
+	})
+
+	t.Run("twine is publish-only", func(t *testing.T) {
+		twine, err := GetCapability(project.Twine)
+		require.NoError(t, err)
+		assert.Equal(t, RolePublish, twine.Role)
+		assert.Equal(t, "pypi", twine.RepoPackageType, "publish-only does not mean a different repo type")
+	})
+
+	t.Run("clients that reject --version", func(t *testing.T) {
+		for packageManager, expected := range map[project.ProjectType][]string{
+			project.Nuget:  {"help"},
+			project.Dotnet: {"help"},
+			project.Go:     {"version"},
+			project.Helm:   {"version", "--short"},
+		} {
+			capability, err := GetCapability(packageManager)
+			require.NoError(t, err)
+			assert.Equal(t, expected, capability.VersionCmd, capability.PackageManager)
+		}
+	})
+
+	t.Run("helm requires OCI support", func(t *testing.T) {
+		// configureHelm runs `helm registry login`; OCI reached GA in Helm 3.8.0.
+		helm, err := GetCapability(project.Helm)
+		require.NoError(t, err)
+		assert.Equal(t, "3.8.0", helm.MinVersion)
+	})
+}
+
+// A shared config file is a concurrency constraint, so the grouping has to be
+// exactly the set of package managers that write the same file — no more.
+func TestGetCapabilities_ConfigGroupsMatchSharedFiles(t *testing.T) {
+	grouped := make(map[string][]string)
+	for _, capability := range GetCapabilities() {
+		if capability.ConfigGroup != "" {
+			grouped[capability.ConfigGroup] = append(grouped[capability.ConfigGroup], capability.PackageManager)
+		}
+	}
+
+	assert.Equal(t, map[string][]string{
+		ConfigGroupPipConf:     {"pip", "pipenv"},
+		ConfigGroupNugetConfig: {"nuget", "dotnet"},
+	}, grouped)
+
+	// npm, pnpm and Yarn each write their own file, so grouping them would
+	// needlessly serialize three independent setups.
+	for _, packageManager := range []project.ProjectType{project.Npm, project.Pnpm, project.Yarn} {
+		capability, err := GetCapability(packageManager)
+		require.NoError(t, err)
+		assert.Empty(t, capability.ConfigGroup, "%s writes its own file", capability.PackageManager)
+	}
+	// Docker and Podman keep separate credential stores.
+	for _, packageManager := range []project.ProjectType{project.Docker, project.Podman} {
+		capability, err := GetCapability(packageManager)
+		require.NoError(t, err)
+		assert.Empty(t, capability.ConfigGroup, "%s has its own credential store", capability.PackageManager)
+	}
+
+	// Every group must have more than one member, or it is not a constraint.
+	for group, packageManagers := range grouped {
+		assert.Greater(t, len(packageManagers), 1, "config group %q has a single member", group)
+	}
+}
+
+func TestGetCapability_UnsupportedPackageManager(t *testing.T) {
+	_, err := GetCapability(project.Cocoapods)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported package manager")
+}
+
+func TestMarshalCapabilities(t *testing.T) {
+	encoded, err := MarshalCapabilities()
+	require.NoError(t, err)
+
+	var decoded []Capability
+	require.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
+	assert.Equal(t, GetCapabilities(), decoded, "the JSON form must round-trip")
+
+	// Optional fields must stay absent rather than emitting empty values that a
+	// consumer would have to distinguish from a real one.
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(encoded), &raw))
+	for _, entry := range raw {
+		if entry["packageManager"] == "npm" {
+			assert.NotContains(t, entry, "aliases")
+			assert.NotContains(t, entry, "minVersion")
+			assert.NotContains(t, entry, "configGroup")
+			assert.Contains(t, entry, "requiresClient", "non-optional fields must always be present")
+		}
+	}
+}
+
+// Callers group by repo type to decide which package managers a governed
+// repository covers, so the mapping has to survive being inverted.
+func TestGetCapabilities_GroupByRepoPackageType(t *testing.T) {
+	byRepoType := make(map[string][]string)
+	for _, capability := range GetCapabilities() {
+		byRepoType[capability.RepoPackageType] = append(byRepoType[capability.RepoPackageType], capability.PackageManager)
+	}
+
+	assert.ElementsMatch(t, []string{"pip", "pipenv", "poetry", "twine", "uv"}, byRepoType["pypi"])
+	assert.ElementsMatch(t, []string{"npm", "pnpm", "yarn"}, byRepoType["npm"])
+	assert.ElementsMatch(t, []string{"docker", "podman"}, byRepoType["docker"])
+	assert.ElementsMatch(t, []string{"nuget", "dotnet"}, byRepoType["nuget"])
+
+	// Gradle is its own Artifactory package type here, NOT part of "maven".
+	// Pinned deliberately: downstream copies of this table disagree — the Fly client
+	// registers gradle under its maven repo name, and the agent hooks map the maven
+	// package type to [maven, gradle]. Anything resolving a gradle repository from
+	// the "maven" type is contradicting this mapping, and `jf setup gradle` will not
+	// offer a maven-type repository when it prompts.
+	assert.Equal(t, []string{"maven"}, byRepoType["maven"])
+	assert.Equal(t, []string{"gradle"}, byRepoType["gradle"])
+}

--- a/artifactory/commands/setup/setup.go
+++ b/artifactory/commands/setup/setup.go
@@ -55,12 +55,41 @@ type packageManagerConfig struct {
 	// function or the tool it drives really honors the variable — the per-entry
 	// comments record what was verified.
 	overrideEnv string
+	// aliases are the other names a caller may use for this package manager, so
+	// downstream tools do not each keep their own alias table.
+	aliases []string
+	// clientBinaries are the executables to look for on PATH, in preference order.
+	// Defaults to the package manager's own name, so only set it where they differ.
+	clientBinaries []string
+	// versionCmd is the argument list that makes the client print its version.
+	// Defaults to --version; several clients do not accept that flag at all.
+	versionCmd []string
+	// minVersion is the oldest client release `jf setup` can actually configure.
+	// Only set where a specific release introduced the mechanism setup depends on,
+	// and record which one in the entry's comment — this is published to callers
+	// that will refuse to run below it.
+	minVersion string
+	// configOnly marks the package managers whose configure function writes the
+	// configuration file itself and never runs the client. Their setup succeeds on a
+	// machine that has no client installed, which matters for wrapper-only projects
+	// (`./mvnw`, `./gradlew`), so callers must not gate them on a PATH lookup.
+	configOnly bool
+	// publishOnly marks the package managers configured for uploading rather than
+	// resolving. They are not part of install-time routing.
+	publishOnly bool
+	// configGroup names the configuration file this package manager shares with
+	// others. Everything in one group writes the SAME file, so concurrent `jf setup`
+	// runs across a group race each other and callers have to serialize them.
+	configGroup string
 }
 
-// One entry per package manager in packageManagerToRepositoryPackageType; a test
-// asserts the two stay in step.
+// One entry per package manager in packageManagerToRepositoryPackageType.
+// TestGetCapabilities_EveryEntryIsFullyPopulated keeps the two maps in step: a
+// package manager added there without an entry here publishes an empty location
+// and empty client binaries through GetCapabilities, and fails that test.
 var packageManagerConfigs = map[project.ProjectType]packageManagerConfig{
 	// npm resolves the file `npm config set` writes through NPM_CONFIG_USERCONFIG.
+	// npm, pnpm and Yarn are NOT one config group: each writes its own file.
 	project.Npm: {location: "your user-level npm configuration (.npmrc)", overrideEnv: "NPM_CONFIG_USERCONFIG"},
 	// pnpm is deliberately left without an override: `pnpm config set` writes to
 	// pnpm's own config directory (auth.ini) and ignores NPM_CONFIG_USERCONFIG, which
@@ -69,26 +98,45 @@ var packageManagerConfigs = map[project.ProjectType]packageManagerConfig{
 	// Yarn Classic writes ~/.yarnrc, and YARN_RC_FILENAME does not redirect it.
 	project.Yarn: {location: "your user-level Yarn configuration (.yarnrc)"},
 	// configurePip writes the file itself when PIP_CONFIG_FILE is set, because
-	// `pip config set` does not support that variable.
-	project.Pip:    {location: "your user-level pip configuration (pip.conf)", overrideEnv: "PIP_CONFIG_FILE"},
-	project.Pipenv: {location: "your user-level pip configuration (pip.conf)", overrideEnv: "PIP_CONFIG_FILE"},
+	// `pip config set` does not support that variable. requiresClient stays true:
+	// the default path does shell out, and only the override path does not.
+	// pip and pipenv share pip.conf, so their setups must not run concurrently.
+	project.Pip: {location: "your user-level pip configuration (pip.conf)", overrideEnv: "PIP_CONFIG_FILE",
+		clientBinaries: []string{"pip", "pip3"}, configGroup: ConfigGroupPipConf},
+	project.Pipenv: {location: "your user-level pip configuration (pip.conf)", overrideEnv: "PIP_CONFIG_FILE",
+		configGroup: ConfigGroupPipConf},
 	// `poetry config` writes config.toml into POETRY_CONFIG_DIR when it is set.
 	project.Poetry: {location: "your user-level Poetry configuration (config.toml)", overrideEnv: "POETRY_CONFIG_DIR"},
 	// Twine's .pypirc path is chosen per invocation (--config-file), not by the environment.
-	project.Twine: {location: "your user-level Twine configuration (.pypirc)"},
+	project.Twine: {location: "your user-level Twine configuration (.pypirc)", publishOnly: true},
 	// ConfigureUVIndex writes to UV_CONFIG_FILE when it is set.
-	project.UV:     {location: "your user-level uv configuration (uv.toml)", overrideEnv: "UV_CONFIG_FILE"},
-	project.Nuget:  {location: "your user-level NuGet configuration (NuGet.Config)"},
-	project.Dotnet: {location: "your user-level NuGet configuration (NuGet.Config)"},
+	// minVersion is deliberately unset: configureUV needs `uv auth login`, and the
+	// release that introduced it has not been confirmed. Fly Desktop asserts 0.8.15.
+	project.UV: {location: "your user-level uv configuration (uv.toml)", overrideEnv: "UV_CONFIG_FILE"},
+	// nuget and dotnet both write NuGet.Config, so their setups must not run concurrently.
+	// Neither client accepts --version; both print it through `help`.
+	project.Nuget: {location: "your user-level NuGet configuration (NuGet.Config)",
+		versionCmd: []string{"help"}, configGroup: ConfigGroupNugetConfig},
+	project.Dotnet: {location: "your user-level NuGet configuration (NuGet.Config)",
+		versionCmd: []string{"help"}, configGroup: ConfigGroupNugetConfig},
 	// `go env -w` writes to the file GOENV points at, defaulting to the per-user Go env file.
-	project.Go: {location: "your user-level Go environment (GOPROXY in your Go env file)", overrideEnv: "GOENV"},
+	project.Go: {location: "your user-level Go environment (GOPROXY in your Go env file)", overrideEnv: "GOENV",
+		versionCmd: []string{"version"}},
 	// gradle.WriteInitScript drops the script under GRADLE_USER_HOME when it is set.
-	project.Gradle: {location: "your user-level Gradle configuration (an init script in your Gradle user home)", overrideEnv: gradle.UserHomeEnv},
+	// configOnly: WriteInitScript writes the file directly, so `gradle` need not exist.
+	project.Gradle: {location: "your user-level Gradle configuration (an init script in your Gradle user home)",
+		overrideEnv: gradle.UserHomeEnv, configOnly: true},
 	// Maven picks the settings file per invocation (-s), not from the environment.
-	project.Maven:  {location: "your user-level Maven settings (settings.xml)"},
+	// configOnly: configureMaven goes through NewSettingsXmlManager, so `mvn` need not exist.
+	project.Maven: {location: "your user-level Maven settings (settings.xml)", configOnly: true,
+		aliases: []string{"mvn"}, clientBinaries: []string{"mvn"}},
+	// Docker and Podman keep separate credential stores, so they are not one group.
 	project.Docker: {location: "your Docker credential store", credentialsOnly: true},
 	project.Podman: {location: "your Podman credential store", credentialsOnly: true},
-	project.Helm:   {location: "your Helm registry credential store", credentialsOnly: true},
+	// configureHelm runs `helm registry login` against an OCI registry. OCI support
+	// reached general availability in Helm 3.8.0, so older clients cannot be configured.
+	project.Helm: {location: "your Helm registry credential store", credentialsOnly: true,
+		versionCmd: []string{"version", "--short"}, minVersion: "3.8.0"},
 }
 
 // configScopeNote describes what the command changed and how widely it applies, or


### PR DESCRIPTION
## Overview

Publishes the package-manager table `jf setup` already owns, so the four downstream copies of it can be deleted.

> **Stacked on #520** (base is that branch, not `main`, to avoid duplicating `packageManagerConfigs`). GitHub will retarget to `main` when #520 merges.

## The problem

Four consumers each hand-maintain their own approximation of this table, and none can be checked against this package:

| Consumer | Its copy | Drift guard |
|---|---|---|
| Fly Desktop (TS) | `SUPPORTED_PACKAGE_MANAGERS` — binaries, aliases, version commands, min versions | none |
| Fly client (Go) | `handlers/register.go` — names, aliases, binaries, repo types, config groups | none |
| JFrog agent hooks | `TYPE_TO_PMS` + `PM_BINARIES` + `PMS_SETUP_WITHOUT_CLIENT` | none |
| JFrog skills | the manifest table in `SKILL.md` | none |

Each drifts silently the day a package manager is added here. Two live examples:

- The agent hooks gated **maven and gradle on a PATH lookup**, even though `configureMaven` goes through `NewSettingsXmlManager` and `configureGradle` through `WriteInitScript` — neither needs a client. That broke wrapper-only projects (`./mvnw`, `./gradlew`) until it was patched there.
- Their pip probe tries **`pip3` before `pip`**, while `getExecutable` tries `pip` first — so the two can resolve different interpreters' pip.

Both are the same root cause: the knowledge lives here and is re-derived elsewhere.

## What this adds

`GetCapabilities()` / `GetCapability(pm)` / `MarshalCapabilities()`, built **from the existing maps** — no second table to keep in step.

Entries now carry, beyond `location` / `overrideEnv` / `credentialsOnly`:

| Field | Why |
|---|---|
| `clientBinaries` | Defaults to the package manager's own name. `maven` → `mvn`; `pip` → `pip`, `pip3`, matching `getExecutable`'s order. |
| `versionCmd` | **`nuget` and `dotnet` reject `--version`** and print it via `help`; `go` uses `version`; `helm` uses `version --short`. |
| `minVersion` | Only where a release introduced the mechanism setup depends on. `helm` **3.8.0** — `configureHelm` runs `helm registry login` against an OCI registry, and OCI reached GA in 3.8.0. |
| `requiresClient` (from `configOnly`) | False for maven and gradle, so callers stop gating them on a client that wrapper-only projects never install. |
| `role` (from `publishOnly`) | `twine` is upload configuration, not install-time routing — it is `publish`, and still `pypi`. |
| `configGroup` | Package managers writing the **same file**: `pip`+`pipenv` (`pip.conf`), `nuget`+`dotnet` (`NuGet.Config`). Callers must serialize those setups. npm/pnpm/Yarn each write their own file and are deliberately **not** grouped, as are Docker and Podman. |

`configGroup` is the field none of the copies had except the Fly client, and it is a correctness constraint, not metadata: two concurrent `jf setup` runs in one group race on the same file.

## Sample output

```json
{
  "packageManager": "pip",
  "repoPackageType": "pypi",
  "clientBinaries": ["pip", "pip3"],
  "versionCmd": ["--version"],
  "requiresClient": true,
  "role": "install",
  "credentialsOnly": false,
  "configGroup": "pip-conf",
  "configLocation": "your user-level pip configuration (pip.conf)",
  "overrideEnv": "PIP_CONFIG_FILE"
}
```

## A divergence found while writing the tests

**`gradle` maps to the `gradle` repository package type here, not `maven`.** The Fly client registers gradle under its maven repo name, and the agent hooks map the `maven` package type to `[maven, gradle]`. Since `packageManagerToRepositoryPackageType` drives `promptUserToSelectRepository`, `jf setup gradle` will **not** offer a maven-type repository — so both copies contradict this mapping, and a caller passing a maven repo key to `jf setup gradle` is relying on Artifactory's Maven layout rather than on the type model.

I pinned the current behaviour in a test rather than changing it, because which one is correct is your call. Flagging it because it is exactly the kind of disagreement this table exists to prevent, and it went unnoticed in three repos.

## Tests

`TestGetCapabilities_EveryEntryIsFullyPopulated` is now what actually keeps `packageManagerConfigs` in step with `packageManagerToRepositoryPackageType`. The existing comment claimed a test did that, but the only one (`TestPackageManagerConfigs_OverridesAreExactlyTheVerifiedSet`) covers the override-env subset — I corrected the comment.

Mutation-checked, not just green:

| Mutation | Caught by |
|---|---|
| Add `project.Cocoapods` to the repo-type map with no config entry | `EveryEntryIsFullyPopulated/cocoapods` → *"configLocation must be set"* |
| Flip maven's `configOnly` to false | `KnownSpecialCases/maven_and_gradle_need_no_client_on_PATH` |

Also covered: default application, every special case above, group membership and that no group has a single member, JSON round-trip, and that optional fields stay **absent** rather than emitting empty values a consumer would have to disambiguate.

Full `artifactory/commands/setup` suite passes locally (15s, includes the real per-PM setup tests).

## Not in this PR

- **The `jf setup --list` flag** lives in `jfrog-cli`; `MarshalCapabilities` is the whole implementation, so that side is a thin flag. Happy to open it as a companion once the shape here is agreed — the flag name and JSON keys become a versioned contract, so they are worth settling first.
- **`uv`'s `minVersion` is unset.** `configureUV` needs `uv auth login` and I could not confirm which release introduced it. Fly Desktop asserts `0.8.15`; worth confirming before publishing it as a CLI-level claim.
- Deleting the downstream copies — follow-ups in those repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
