### PR TITLE
Add QA section to AI descriptions for repository, build-info, and generic transfer commands

### DIFF
--- a/artifactory/docs/buildadddependencies/help.go
+++ b/artifactory/docs/buildadddependencies/help.go
@@ -33,7 +33,18 @@ Gotchas:
 - Local mode does not upload anything; it only records checksums in the in-progress build-info.
 - Files are recorded with build-info-relative paths; renaming sources between this command and build-publish breaks tooling.
 
-Related: jf rt build-publish, jf rt build-add-git, jf rt build-collect-env, jf rt upload`
+Related: jf rt build-publish, jf rt build-add-git, jf rt build-collect-env, jf rt upload
+
+QA:
+Q: How do I add dependencies to my build 'my-build' with number '1'?
+A: jf rt bad my-build 1 "path/to/dependencies/*"
+
+Q: Could you tell me the command to incorporate dependencies for the build 'appBuild' with the number '100'?
+A: jf rt bad appBuild 100 "path/to/dependencies/*"
+
+Q: How do I include dependencies for 'simpleBuild' with build number '10'?
+A: jf rt bad simpleBuild 10 "path/to/dependencies/*"
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/buildaddgit/help.go
+++ b/artifactory/docs/buildaddgit/help.go
@@ -32,7 +32,18 @@ Gotchas:
 - A shallow clone (depth=1) may have no usable git log, causing empty issue extraction.
 - Issues are extracted by regex; misconfigured patterns silently produce no matches.
 
-Related: jf rt build-publish, jf rt build-collect-env, jf rt build-add-dependencies`
+Related: jf rt build-publish, jf rt build-collect-env, jf rt build-add-dependencies
+
+QA:
+Q: How do I add Git details to my build 'my-build' with number '1'?
+A: jf rt bag my-build 1
+
+Q: Could you tell me the command to incorporate Git info for the build 'appBuild' with the number '100'?
+A: jf rt bag appBuild 100
+
+Q: How do I include Git information for 'simpleBuild' with number '10'?
+A: jf rt bag simpleBuild 10
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/buildappend/help.go
+++ b/artifactory/docs/buildappend/help.go
@@ -30,7 +30,18 @@ Gotchas:
 - Both builds must live on the same Artifactory instance.
 - The appended build's artifacts are not duplicated; only the reference is added.
 
-Related: jf rt build-publish, jf rt build-promote`
+Related: jf rt build-publish, jf rt build-promote
+
+QA:
+Q: How do I append build 'build1' with number '1' to 'master-build' with number '10'?
+A: jf rt ba master-build 10 build1 1
+
+Q: Could you tell me the command to incorporate 'build3' with the number '3' into 'appBuild' with the number '30'?
+A: jf rt ba appBuild 30 build3 3
+
+Q: How do I add 'build5' build number '5' to my 'simpleBuild' with number '50'?
+A: jf rt ba simpleBuild 50 build5 5
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/buildcollectenv/help.go
+++ b/artifactory/docs/buildcollectenv/help.go
@@ -29,7 +29,18 @@ Gotchas:
 - Default exclusion in build-publish drops *password*, *secret*, *token*, *key*, *auth*; widening that mask can leak credentials.
 - Calling again for the same build overwrites the previous snapshot.
 
-Related: jf rt build-publish, jf rt build-add-git, jf rt build-add-dependencies`
+Related: jf rt build-publish, jf rt build-add-git, jf rt build-add-dependencies
+
+QA:
+Q: How do I collect environment variables for my build 'my-build' with number '1'?
+A: jf rt bce my-build 1
+
+Q: Could you provide the command to collect environment variables for the build 'appBuild' with the number '100'?
+A: jf rt bce appBuild 100
+
+Q: How do I collect environment variables for 'simpleBuild' with build number '10'?
+A: jf rt bce simpleBuild 10
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/builddiscard/help.go
+++ b/artifactory/docs/builddiscard/help.go
@@ -31,7 +31,18 @@ Gotchas:
 - --max-builds and --max-days can be combined; either condition triggers discard.
 - --async=true returns immediately; check Artifactory logs for completion.
 
-Related: jf rt build-publish, jf rt build-clean, jf rt delete`
+Related: jf rt build-publish, jf rt build-clean, jf rt delete
+
+QA:
+Q: How do I discard old builds of 'my-build' while keeping the 10 most recent?
+A: jf rt bdi my-build --max-builds=10
+
+Q: Could you tell me the command to discard old builds of 'appBuild' but keep the last 5?
+A: jf rt bdi appBuild --max-builds=5
+
+Q: What's the command to discard old builds of 'imageBuild' but keep the last 15?
+A: jf rt bdi imageBuild --max-builds=15
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/buildpublish/help.go
+++ b/artifactory/docs/buildpublish/help.go
@@ -30,7 +30,12 @@ Gotchas:
 - Default --env-exclude masks common secret patterns; widening it can leak credentials into the build-info.
 - After publish, subsequent rt commands using the same build/number will create a separate revision.
 
-Related: jf rt build-collect-env, jf rt build-add-git, jf rt build-promote, jf rt build-discard`
+Related: jf rt build-collect-env, jf rt build-add-git, jf rt build-promote, jf rt build-discard
+
+QA:
+Q: How can I publish a build named 'my-build' with number '1' using JFrog CLI?
+A: jf rt bp my-build 1
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/copy/help.go
+++ b/artifactory/docs/copy/help.go
@@ -37,7 +37,27 @@ Gotchas:
 - Always smoke-test with --dry-run before bulk copies; there is no undo.
 - Cross-repo-type copy may fail (e.g. Maven layout to a generic repo retains paths but loses metadata).
 
-Related: jf rt move, jf rt upload, jf rt search, jf rt build-promote`
+Related: jf rt move, jf rt upload, jf rt search, jf rt build-promote
+
+QA:
+Q: How do I copy a file named 'project.jar' from one repository to another?
+A: jf rt cp SourceRepo/project.jar DestinationRepo/
+
+Q: What is the syntax to copy 'myapp.war' from dockrepo to 'webapps-local/' with a 5 seconds interval between retries?
+A: jf rt cp dockrepo/myapp.war webapps-local/ --retry-wait-time=5s
+
+Q: What's the command to copy all .png files from 'ImageStorage' to 'BackupImages'?
+A: jf rt cp "ImageStorage/*.png" BackupImages/
+
+Q: Could you provide the command to copy 'report.pdf' from the repository 'DocsStorage' to the repository 'BackupDocs'?
+A: jf rt cp DocsStorage/report.pdf BackupDocs/
+
+Q: What is the precise command to copy files that start with 'DEV' from the repository 'DevFiles' to the repository 'BackupDev'?
+A: jf rt cp "DevFiles/DEV*" BackupDev/
+
+Q: How do I copy .log files from 'LogsArchive' to 'BackupLogs'?
+A: jf rt cp "LogsArchive/*.log" BackupLogs/
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/curl/help.go
+++ b/artifactory/docs/curl/help.go
@@ -29,7 +29,18 @@ Gotchas:
 - Use --server-id to pick a specific server when several are configured.
 - The base URL is the Artifactory one; for platform or lifecycle APIs, prefer their dedicated paths.
 
-Related: jf rt ping, jf c show, jf rt repo-create`
+Related: jf rt ping, jf c show, jf rt repo-create
+
+QA:
+Q: How do I use the curl command to send a GET request to the /api/build endpoint in Artifactory?
+A: jf rt curl -XGET /api/build
+
+Q: Could you tell me the command to use curl to send a POST request to the /api/build endpoint in Artifactory with data from a file named data.json?
+A: jf rt curl -XPOST /api/build -d @data.json
+
+Q: How do I use the curl command to send a GET request to the /api/system/version endpoint in Artifactory?
+A: jf rt curl -XGET "/api/system/version"
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/delete/help.go
+++ b/artifactory/docs/delete/help.go
@@ -31,7 +31,18 @@ Gotchas:
 - Deletes are immediate and irreversible unless the repo has trash-can/retention enabled.
 - --recursive defaults to true; combine with precise patterns.
 
-Related: jf rt search, jf rt delete-props, jf rt build-discard`
+Related: jf rt search, jf rt delete-props, jf rt build-discard
+
+QA:
+Q: How to delete .jar files from "MavenCentral"?
+A: jf rt del "MavenCentral/*.jar"
+
+Q: What's the command to delete .png files from "ImageStorage"?
+A: jf rt del "ImageStorage/*.png"
+
+Q: How to delete files starting with "DEV" from "DevFiles"?
+A: jf rt del "DevFiles/DEV*"
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/deleteprops/help.go
+++ b/artifactory/docs/deleteprops/help.go
@@ -29,7 +29,27 @@ Gotchas:
 - Only the listed keys are removed; other properties on the artifact remain.
 - --repo-only narrows to repo-descriptor properties.
 
-Related: jf rt set-props, jf rt search, jf rt delete`
+Related: jf rt set-props, jf rt search, jf rt delete
+
+QA:
+Q: How to delete properties from .jar files in "MavenCentral"?
+A: jf rt delp "MavenCentral/*.jar" key
+
+Q: What's the command to delete properties from .png files in "ImageStorage"?
+A: jf rt delp "ImageStorage/*.png" key
+
+Q: Can I delete properties from "report.pdf" in "DocsStorage"?
+A: jf rt delp DocsStorage/report.pdf key
+
+Q: How to delete properties from files starting with "DEV" in "DevFiles"?
+A: jf rt delp "DevFiles/DEV*" key
+
+Q: What command deletes properties from .log files in "LogsArchive"?
+A: jf rt delp "LogsArchive/*.log" key
+
+Q: How can I remove the 'version' property from all the jar files in the maven-central repository?
+A: jf rt delp 'maven-central/*.jar' 'version'
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/download/help.go
+++ b/artifactory/docs/download/help.go
@@ -39,7 +39,18 @@ Gotchas:
 - Transitive download (across remote-repo virtuals) requires JFROG_CLI_TRANSITIVE_DOWNLOAD=true.
 - Default --recursive=true; set --recursive=false for shallow matches only.
 
-Related: jf rt upload, jf rt direct-download, jf rt search, jf rt copy`
+Related: jf rt upload, jf rt direct-download, jf rt search, jf rt copy
+
+QA:
+Q: How to download "project.jar" from "MavenRepo" to my local directory?
+A: jf rt dl "MavenRepo/project.jar" "/Users/john/Documents/project.jar"
+
+Q: How to Download the latest file uploaded to the all-my-frogs folder in the my-local-repo repository.
+A: jf rt dl 'my-local-repo/all-my-frogs/*' --sort-by=created --sort-order=desc --limit=1
+
+Q: Can I download "report.pdf" from "DocsRepo" to my local directory?
+A: jf rt dl "DocsRepo/report.pdf" "/var/www/html/report.pdf"
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/gitlfsclean/help.go
+++ b/artifactory/docs/gitlfsclean/help.go
@@ -31,7 +31,18 @@ Gotchas:
 - Interactive confirmation by default; use --quiet in scripts.
 - Always run --dry-run first; deletes are permanent.
 
-Related: jf rt delete, jf rt build-discard`
+Related: jf rt delete, jf rt build-discard
+
+QA:
+Q: Could you guide me through the process of tidying up Git LFS files in JFrog Artifactory considering that the conf for the .git dir resides in the present dir?
+A: jf rt glc
+
+Q: Could you elucidate the approach for removing Git LFS files in JFrog Artifactory provided the .git dir conf exists within 'my-other-project'?
+A: jf rt glc my-other-project
+
+Q: Could you outline the procedure for purging Git LFS files from JFrog Artifactory with the .git dir conf situated within a folder labeled 'my-fourth-project'?
+A: jf rt glc my-fourth-project
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/move/help.go
+++ b/artifactory/docs/move/help.go
@@ -39,7 +39,7 @@ Related: jf rt copy, jf rt delete, jf rt upload, jf rt build-promote
 
 QA:
 Q: What is the command to move 'myapp.war' from local-j to 'webapps-local/' with a 4000 milliseconds delay between retry attempts?
-A: jf rt mv myapp.war webapps-local/ --retry-wait-time=4000ms
+A: jf rt mv "local-j/myapp.war" webapps-local/ --retry-wait-time=4000ms
 
 Q: How can I move 'mylib.jar' to 'libs-local/' with a retry wait time of 6 seconds?
 A: jf rt mv 'local-j/mylib.jar' libs-local/ --retry-wait-time=6s

--- a/artifactory/docs/move/help.go
+++ b/artifactory/docs/move/help.go
@@ -35,7 +35,15 @@ Gotchas:
 - Same trailing-slash rule as copy/upload: slash = folder, no slash = rename target.
 - Failures partway through can leave artifacts in a mixed state; check the summary.
 
-Related: jf rt copy, jf rt delete, jf rt upload, jf rt build-promote`
+Related: jf rt copy, jf rt delete, jf rt upload, jf rt build-promote
+
+QA:
+Q: What is the command to move 'myapp.war' from local-j to 'webapps-local/' with a 4000 milliseconds delay between retry attempts?
+A: jf rt mv myapp.war webapps-local/ --retry-wait-time=4000ms
+
+Q: How can I move 'mylib.jar' to 'libs-local/' with a retry wait time of 6 seconds?
+A: jf rt mv 'local-j/mylib.jar' libs-local/ --retry-wait-time=6s
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/ping/help.go
+++ b/artifactory/docs/ping/help.go
@@ -26,7 +26,18 @@ Gotchas:
 - Anonymous ping works against an unauthenticated server; a successful ping does not imply repo access.
 - Output is indented JSON on stdout; "OK" status means the API is reachable.
 
-Related: jf c show, jf rt curl /api/system/health`
+Related: jf c show, jf rt curl /api/system/health
+
+QA:
+Q: How can I verify the accessibility of my default Artifactory server?
+A: jf rt ping
+
+Q: How can I ping the Artifactory server through the specified URL 'https://my-rt-server.com/artifactory'?
+A: jf rt ping --url=https://my-rt-server.com/artifactory
+
+Q: How can I check connection to Artifactory server with ID 'rt-server-2' without verifying TLS certificates?
+A: jf rt ping --server-id=rt-server-2 --insecure-tls
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/ping/help.go
+++ b/artifactory/docs/ping/help.go
@@ -37,6 +37,7 @@ A: jf rt ping --url=https://my-rt-server.com/artifactory
 
 Q: How can I check connection to Artifactory server with ID 'rt-server-2' without verifying TLS certificates?
 A: jf rt ping --server-id=rt-server-2 --insecure-tls
+Warning: Use --insecure-tls only for controlled troubleshooting; it disables TLS certificate validation.
 `
 }
 

--- a/artifactory/docs/replicationcreate/help.go
+++ b/artifactory/docs/replicationcreate/help.go
@@ -25,7 +25,18 @@ Gotchas:
 - Push replication needs network reachability from this Artifactory to the target.
 - Only one replication per repo+URL combination; calling again with the same target errors.
 
-Related: jf rt replication-template, jf rt replication-delete, jf rt repo-create`
+Related: jf rt replication-template, jf rt replication-delete, jf rt repo-create
+
+QA:
+Q: Could you guide me through the process of creating a replication job in JFrog Artifactory considering that the template path is 'template1.json'?
+A: jf rt rplc template1.json
+
+Q: Could you elucidate the approach for forming a replication job in JFrog Artifactory provided the template path is 'template3.json'?
+A: jf rt rplc template3.json
+
+Q: Could you outline the procedure for constructing a replication job in JFrog Artifactory with the template path being 'template5.json'?
+A: jf rt rplc template5.json
+`
 }
 
 func GetDescription() string {

--- a/artifactory/docs/replicationdelete/help.go
+++ b/artifactory/docs/replicationdelete/help.go
@@ -26,7 +26,18 @@ Gotchas:
 - Interactive confirmation by default; pass --quiet in CI.
 - Removes ALL replication configs on the repo (push and pull), not just one.
 
-Related: jf rt replication-create, jf rt replication-template, jf rt repo-delete`
+Related: jf rt replication-create, jf rt replication-template, jf rt repo-delete
+
+QA:
+Q: Could you guide me through the process of deleting a replication job in Artifactory considering that the repo name is 'repo1'?
+A: jf rt rpldel repo1
+
+Q: Could you elucidate the approach for eradicating a replication job in Artifactory provided the repo name is 'repo3'?
+A: jf rt rpldel repo3
+
+Q: Could you outline the procedure for discarding a replication job in Artifactory with the repo name being 'repo5'?
+A: jf rt rpldel repo5
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/replicationtemplate/help.go
+++ b/artifactory/docs/replicationtemplate/help.go
@@ -26,7 +26,18 @@ Gotchas:
 - Interactive only; cannot be scripted unattended.
 - Output is a literal template; add ${var} placeholders manually for reuse.
 
-Related: jf rt replication-create, jf rt replication-delete, jf rt repo-template`
+Related: jf rt replication-create, jf rt replication-delete, jf rt repo-template
+
+QA:
+Q: Could you guide me through the process of creating a replication template in Artifactory considering that the template path is 'template1.json'?
+A: jf rt rplt template1.json
+
+Q: Could you elucidate the approach for establishing a replication template in Artifactory provided the template path is 'template3.json'?
+A: jf rt rplt template3.json
+
+Q: Could you outline the procedure for forming a replication template in Artifactory with the template path being 'template5.json'?
+A: jf rt rplt template5.json
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/repocreate/help.go
+++ b/artifactory/docs/repocreate/help.go
@@ -33,7 +33,18 @@ Gotchas:
 - Template variables ${var} are substituted via --vars "k=v;k2=v2".
 - Federated repos require Artifactory Enterprise+; remote-host URLs must be reachable.
 
-Related: jf rt repo-update, jf rt repo-delete, jf rt repo-template`
+Related: jf rt repo-update, jf rt repo-delete, jf rt repo-template
+
+QA:
+Q: Could you guide me through the process of creating a repo in Artifactory considering that the repo name is 'repo1'?
+A: jf rt rc repo1
+
+Q: Could you elucidate the approach for forming a repo in Artifactory provided the repository name is 'repo3'?
+A: jf rt rc repo3
+
+Q: Could you outline the procedure for constructing a repo in Artifactory with the repository name being 'repo5'?
+A: jf rt rc repo5
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/repocreate/help.go
+++ b/artifactory/docs/repocreate/help.go
@@ -37,13 +37,13 @@ Related: jf rt repo-update, jf rt repo-delete, jf rt repo-template
 
 QA:
 Q: Could you guide me through the process of creating a repo in Artifactory considering that the repo name is 'repo1'?
-A: jf rt rc repo1
+A: jf rt rc repo1-template.json
 
 Q: Could you elucidate the approach for forming a repo in Artifactory provided the repository name is 'repo3'?
-A: jf rt rc repo3
+A: jf rt rc repo3-template.json
 
 Q: Could you outline the procedure for constructing a repo in Artifactory with the repository name being 'repo5'?
-A: jf rt rc repo5
+A: jf rt rc repo5-template.json
 `
 }
 

--- a/artifactory/docs/repodelete/help.go
+++ b/artifactory/docs/repodelete/help.go
@@ -28,7 +28,18 @@ Gotchas:
 - All artifacts in matched repos are deleted, not just the repo definition.
 - No grace period; rely on backups for recovery.
 
-Related: jf rt repo-create, jf rt repo-update, jf rt delete`
+Related: jf rt repo-create, jf rt repo-update, jf rt delete
+
+QA:
+Q: Could you guide me through the process of deleting a repository in Artifactory considering that the repo name is 'repo1'?
+A: jf rt rdel repo1
+
+Q: Could you elucidate the approach for eradicating a repository in Artifactory provided the repo name is 'repo3'?
+A: jf rt rdel repo3
+
+Q: Could you outline the procedure for discarding a repository in Artifactory with the repo name being 'repo5'?
+A: jf rt rdel repo5
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/repotemplate/help.go
+++ b/artifactory/docs/repotemplate/help.go
@@ -28,7 +28,18 @@ Gotchas:
 - Interactive only; cannot be scripted unattended.
 - Output is a literal template; you usually want to add ${var} placeholders by hand for reusability.
 
-Related: jf rt repo-create, jf rt repo-update, jf rt replication-template`
+Related: jf rt repo-create, jf rt repo-update, jf rt replication-template
+
+QA:
+Q: Could you guide me through the process of creating a configuration template in JFrog Artifactory considering that the template path is 'template1.json'?
+A: jf rt rpt template1.json
+
+Q: Could you elucidate the approach for establishing a configuration template in JFrog Artifactory provided the template path is 'template3.json'?
+A: jf rt rpt template3.json
+
+Q: Could you outline the procedure for forming a configuration template in JFrog Artifactory with the template path being 'template5.json'?
+A: jf rt rpt template5.json
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/repoupdate/help.go
+++ b/artifactory/docs/repoupdate/help.go
@@ -36,13 +36,13 @@ Related: jf rt repo-create, jf rt repo-delete, jf rt repo-template
 
 QA:
 Q: Could you guide me through the process of updating a repository in JFrog Artifactory considering that the repo name is 'repo1'?
-A: jf rt ru repo1
+A: jf rt ru repo1-template.json
 
 Q: Could you elucidate the approach for altering a repository in JFrog Artifactory provided the repo name is 'repo3'?
-A: jf rt ru repo3
+A: jf rt ru repo3-template.json
 
 Q: Could you outline the procedure for adjusting a repository in JFrog Artifactory with the repo name being 'repo5'?
-A: jf rt ru repo5
+A: jf rt ru repo5-template.json
 `
 }
 

--- a/artifactory/docs/repoupdate/help.go
+++ b/artifactory/docs/repoupdate/help.go
@@ -32,7 +32,18 @@ Gotchas:
 - Template substitutes ${var} via --vars "k=v;k2=v2".
 - Update is whole-document; omitted fields may be reset to defaults.
 
-Related: jf rt repo-create, jf rt repo-delete, jf rt repo-template`
+Related: jf rt repo-create, jf rt repo-delete, jf rt repo-template
+
+QA:
+Q: Could you guide me through the process of updating a repository in JFrog Artifactory considering that the repo name is 'repo1'?
+A: jf rt ru repo1
+
+Q: Could you elucidate the approach for altering a repository in JFrog Artifactory provided the repo name is 'repo3'?
+A: jf rt ru repo3
+
+Q: Could you outline the procedure for adjusting a repository in JFrog Artifactory with the repo name being 'repo5'?
+A: jf rt ru repo5
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/search/help.go
+++ b/artifactory/docs/search/help.go
@@ -38,7 +38,27 @@ Gotchas:
 - Output is JSON to stdout; large result sets benefit from --limit and --sort-by.
 - --transitive only works against virtual repos pointing at remote repos.
 
-Related: jf rt download, jf rt delete, jf rt set-props`
+Related: jf rt download, jf rt delete, jf rt set-props
+
+QA:
+Q: How to search for .jar files in "MavenCentral"?
+A: jf rt s "MavenCentral/*.jar"
+
+Q: What is the command to search 'myapp.war' in 'webapps-local/' with a retry wait time of 2 seconds?
+A: jf rt s webapps-local/myapp.war --retry-wait-time=2s
+
+Q: How can I search for artifacts in 'my-repo' using a spec file 'artifactSpec.json' with variable 'ARTIFACT_TYPE=jar' using JFrog CLI?
+A: jf rt s --spec=artifactSpec.json --spec-vars='ARTIFACT_TYPE=jar'
+
+Q: What's the command to search for .png files in "ImageStorage"?
+A: jf rt s "ImageStorage/*.png"
+
+Q: Can I find "report.pdf" in "DocsStorage"?
+A: jf rt s DocsStorage/report.pdf
+
+Q: How to search for files starting with "DEV" in "DevFiles"?
+A: jf rt s "DevFiles/DEV*"
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/setprops/help.go
+++ b/artifactory/docs/setprops/help.go
@@ -38,7 +38,27 @@ Gotchas:
 - --repo-only restricts the operation to the repo descriptor, not artifacts inside it.
 - Existing same-key values are overwritten; use delete-props first if you want a clean state.
 
-Related: jf rt delete-props, jf rt search, jf rt upload (--target-props)`
+Related: jf rt delete-props, jf rt search, jf rt upload (--target-props)
+
+QA:
+Q: How to set properties on .jar files in "MavenCentral"?
+A: jf rt sp "MavenCentral/*.jar" "key=value"
+
+Q: How can I set properties on files in a specific Artifactory server ID for files matching the pattern 'my-repo/my-path/*' and properties 'key1=value1;key2=value2'?
+A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --server-id=myServerID
+
+Q: How can I set properties on files using a file spec named 'myFileSpec.json' for properties 'key1=value1;key2=value2'?
+A: jf rt sp 'key1=value1;key2=value2' --spec=myFileSpec.json
+
+Q: How can I set properties on files using variables in the file spec named 'myFileSpec.json' for properties 'key1=value1;key2=value2' and spec variables 'key1=value1;key2=value2'?
+A: jf rt sp 'key1=value1;key2=value2' --spec=myFileSpec.json --spec-vars='key1=value1;key2=value2'
+
+Q: How can I set properties 'key1=value1;key2=value2' on files that have specific properties 'key1=value1;key2=value2' for files matching the pattern 'my-repo/my-path/*'?
+A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --props=key1=value1;key2=value2
+
+Q: How can I set properties 'key1=value1;key2=value2' on files that do not have specific properties 'key1=value1;key2=value2' for files matching the pattern 'my-repo/my-path/*'?
+A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --exclude-props=key1=value1;key2=value2
+`
 }
 
 func GetArguments() []components.Argument {

--- a/artifactory/docs/setprops/help.go
+++ b/artifactory/docs/setprops/help.go
@@ -54,10 +54,10 @@ Q: How can I set properties on files using variables in the file spec named 'myF
 A: jf rt sp 'key1=value1;key2=value2' --spec=myFileSpec.json --spec-vars='key1=value1;key2=value2'
 
 Q: How can I set properties 'key1=value1;key2=value2' on files that have specific properties 'key1=value1;key2=value2' for files matching the pattern 'my-repo/my-path/*'?
-A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --props=key1=value1;key2=value2
+A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --props='key1=value1;key2=value2'
 
 Q: How can I set properties 'key1=value1;key2=value2' on files that do not have specific properties 'key1=value1;key2=value2' for files matching the pattern 'my-repo/my-path/*'?
-A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --exclude-props=key1=value1;key2=value2
+A: jf rt sp 'my-repo/my-path/*' 'key1=value1;key2=value2' --exclude-props='key1=value1;key2=value2'
 `
 }
 

--- a/artifactory/docs/upload/help.go
+++ b/artifactory/docs/upload/help.go
@@ -38,7 +38,27 @@ Gotchas:
 - Wildcards behave differently than --regexp; mixing them is invalid. Pick one mode.
 - --flat=true (default for some patterns) flattens directory structure; set --flat=false to preserve hierarchy.
 
-Related: jf rt download, jf rt copy, jf rt search, jf rt set-props`
+Related: jf rt download, jf rt copy, jf rt search, jf rt set-props
+
+QA:
+Q: How to upload "project.jar" to "MavenCentral"?
+A: jf rt u "/local/path/to/project.jar" "MavenCentral/"
+
+Q: What's the JFrog CLI command to upload all .tgz files from my local directory to a corresponding directory in my Artifactory repo?
+A: jf rt u "(*.tgz)" "my-local-repo/{1}/" --recursive=false
+
+Q: How can I upload 'myapp.war' to 'webapps-local/' with properties 'version=1.0' and 'release=stable'?
+A: jf rt u myapp.war webapps-local/ --target-props='version=1.0;release=stable'
+
+Q: How can I upload 'myapp.war' to 'webapps-local/' and pack it into a ZIP archive?
+A: jf rt u myapp.war webapps-local/ --archive=zip
+
+Q: What is the command to upload 'myapp.war' to 'webapps-local/' with a retry wait time of 6000 milliseconds?
+A: jf rt u myapp.war webapps-local/ --retry-wait-time=6000ms
+
+Q: How can I upload a Debian package 'mypackage.deb' to 'debian-local/' with distribution 'buster' and component 'main' using JFrog CLI?
+A: jf rt u --deb=buster/main/amd64 mypackage.deb debian-local/
+`
 }
 
 func GetArguments() []components.Argument {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----

Adds a `QA:` section to the AI-agent help text (`GetAIDescription`) of the upload/download/move/copy/delete/search/set-props, build-*, repo-*, replication-*, ping, and curl commands: a handful of curated, deduplicated real-world question → command examples per command, sourced from the JFrog CLI qna dataset. Purely additive text change appended after the existing `Related:` line — no behavior, schema, or struct changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AI-assisted command help with related-command references and practical Q&A examples.
  * Added usage guidance for build management, repository administration, replication, file operations, searches, properties, uploads, downloads, and server connectivity.
  * Included examples covering common options such as wildcards, retries, server IDs, file specifications, filters, and deployment targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->