### PR TITLE
jf-ide-setup-support-user-auth-tokens-for-curated-ai-editor-extensions

### DIFF
--- a/ide/commands/aieditorextensions/base.go
+++ b/ide/commands/aieditorextensions/base.go
@@ -88,7 +88,15 @@ func parsePositionalURLConfig(ctx *components.Context) (*BaseSetupConfig, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain reference token for repository '%s': %w", repoKey, err)
 	}
-	cfg.ServiceURL = AppendReferenceToken(rawURL, token)
+
+	// Rebuild the ServiceURL from a canonical shape rather than appending to whatever
+	// the user typed. This gives us a deterministic output regardless of whether the
+	// input URL:
+	//   - lacks the gallery suffix (e.g. .../aieditorextensions/<repo>)
+	//   - already carries an old token (e.g. .../gallery/OLD_TOKEN) — the old token
+	//     is discarded rather than being stacked with the new one
+	//   - contains a query string or fragment — those are dropped by SplitApiURL
+	cfg.ServiceURL = common.BuildURL(baseURL, ApiType, repoKey, DefaultURLSuffix) + "/" + token
 	return cfg, nil
 }
 
@@ -135,15 +143,28 @@ func parseFlagConfig(ctx *components.Context) (*BaseSetupConfig, error) {
 }
 
 // resolveServerDetails picks the server credentials to use when only a
-// positional URL was supplied. It honors --server-id / --access-token /
-// --user+--password / default `jf config` — in that order — via
-// common.GetServerDetails, and falls back to constructing details from the
-// URL's base host if no configured server matches.
+// positional URL was supplied.
+//   - --access-token / --user+--password on the CLI take precedence and are
+//     paired with the URL's own base — no host mismatch possible.
+//   - Otherwise we fall back to the default `jf config` server, but we require
+//     its host to match the positional URL's host. Otherwise we would fetch a
+//     token from Artifactory A and write it into a URL for Artifactory B, and
+//     downloads from that URL would fail with a 401.
 func resolveServerDetails(ctx *components.Context, urlBaseURL string) (*config.ServerDetails, error) {
 	if ctx.IsFlagSet("access-token") || (ctx.IsFlagSet("user") && ctx.IsFlagSet("password")) {
-		// Explicit creds on the CLI take precedence; pair them with the URL's base.
 		return common.BuildServerDetailsFromBaseURL(ctx, urlBaseURL)
 	}
-	// Otherwise defer to --server-id / default jf config resolution.
-	return common.GetServerDetails(ctx)
+	details, err := common.GetServerDetails(ctx)
+	if err != nil {
+		return nil, err
+	}
+	configuredBaseURL := common.GetBaseUrl(details)
+	if !common.URLsHaveSameHost(urlBaseURL, configuredBaseURL) {
+		return nil, fmt.Errorf(
+			"the default 'jf config' server ('%s') does not match the positional URL's host - "+
+				"either pass --access-token or --user + --password to authenticate against the URL directly, "+
+				"or run 'jf config use' to switch to a server that matches",
+			configuredBaseURL)
+	}
+	return details, nil
 }

--- a/ide/commands/aieditorextensions/base.go
+++ b/ide/commands/aieditorextensions/base.go
@@ -46,26 +46,35 @@ func ParseBaseSetupConfig(ctx *components.Context) (*BaseSetupConfig, error) {
 }
 
 // parsePositionalURLConfig handles `jf ide setup <ide> <URL>`.
-// If <URL> already embeds a token, we pass it through untouched. Otherwise we
-// derive base URL + repo key from the URL, resolve server credentials from
-// standard flags/config, fetch a token, and append it.
+// The URL must contain /api/<ApiType>/<repo-key>/. We derive base URL + repo
+// key from the URL, resolve server credentials from standard flags/config,
+// call AIEditorExtensionGenerateToken, and append the returned referenceToken.
 func parsePositionalURLConfig(ctx *components.Context) (*BaseSetupConfig, error) {
 	rawURL := ctx.GetArgumentAt(1)
+
+	// A positional URL already identifies the Artifactory host, so combining
+	// it with --server-id (which brings its own host + saved credentials) is
+	// ambiguous. Reject the combination up front rather than silently picking
+	// one or the other.
+	if ctx.IsFlagSet("server-id") {
+		return nil, fmt.Errorf(
+			"positional URL and --server-id cannot be combined; the URL already identifies the Artifactory host. " +
+				"Drop --server-id and let the CLI use the default 'jf config' server " +
+				"(or supply --access-token or --user + --password), " +
+				"or drop the positional URL and use --repo-key with --server-id.")
+	}
+
 	cfg := &BaseSetupConfig{
 		ServiceURL:  rawURL,
 		IsDirectURL: true,
-	}
-
-	if urlHasReferenceToken(rawURL) {
-		cfg.RepoKey = common.ExtractRepoKeyFromURL(rawURL, ApiType)
-		return cfg, nil
 	}
 
 	baseURL, repoKey, ok := common.SplitApiURL(rawURL, ApiType)
 	if !ok {
 		return nil, fmt.Errorf(
 			"positional URL does not contain '/api/%s/<repo-key>/' — cannot resolve repo key to fetch a reference token. "+
-				"Use --repo-key with server credentials, or pass a fully-formed Set Me Up URL that already ends with '/gallery/<token>'", ApiType)
+				"Use --repo-key with server credentials, or pass a URL of the form "+
+				"https://<host>/artifactory/api/%s/<repo>/_apis/public/gallery", ApiType, ApiType)
 	}
 	cfg.RepoKey = repoKey
 
@@ -95,6 +104,12 @@ func parseFlagConfig(ctx *components.Context) (*BaseSetupConfig, error) {
 	}
 
 	if cfg.RepoKey == "" {
+		if ctx.GetNumberOfArgs() > 1 {
+			return nil, fmt.Errorf(
+				"positional argument '%s' is not a valid URL (a scheme and host are required, e.g. https://<host>/artifactory/api/%s/<repo>/_apis/public/gallery); "+
+					"and --repo-key was not supplied. Provide either a fully-qualified URL positionally or set --repo-key",
+				ctx.GetArgumentAt(1), ApiType)
+		}
 		return nil, errors.New("--repo-key flag is required. Please specify the repository key for your AI Editor Extensions repository")
 	}
 

--- a/ide/commands/aieditorextensions/base.go
+++ b/ide/commands/aieditorextensions/base.go
@@ -58,10 +58,10 @@ func parsePositionalURLConfig(ctx *components.Context) (*BaseSetupConfig, error)
 	// one or the other.
 	if ctx.IsFlagSet("server-id") {
 		return nil, fmt.Errorf(
-			"positional URL and --server-id cannot be combined; the URL already identifies the Artifactory host. " +
-				"Drop --server-id and let the CLI use the default 'jf config' server " +
+			"positional URL and --server-id cannot be combined; the URL already identifies the Artifactory host - " +
+				"drop --server-id and let the CLI use the default 'jf config' server " +
 				"(or supply --access-token or --user + --password), " +
-				"or drop the positional URL and use --repo-key with --server-id.")
+				"or drop the positional URL and use --repo-key with --server-id")
 	}
 
 	cfg := &BaseSetupConfig{

--- a/ide/commands/aieditorextensions/base.go
+++ b/ide/commands/aieditorextensions/base.go
@@ -26,18 +26,68 @@ type BaseSetupConfig struct {
 	IsDirectURL   bool
 }
 
+// ParseBaseSetupConfig resolves the AI Editor Extensions gallery configuration.
+//
+// The positional URL flow fetches a per-user reference token via
+// AIEditorExtensionGenerateToken and appends it to the ServiceURL, so that
+// curated downloads are attributable to the individual user. The flag flow
+// (--repo-key with --url/--server-id/default config) is intentionally
+// unchanged and does not tokenize the URL.
+//
+// Supported input surfaces:
+//   - Positional URL:  jf ide setup <ide> https://<host>/artifactory/api/aieditorextensions/<repo>[/...]
+//   - --url flag (base) + --repo-key
+//   - --repo-key only (uses default server / --server-id)
 func ParseBaseSetupConfig(ctx *components.Context) (*BaseSetupConfig, error) {
-	cfg := &BaseSetupConfig{}
-
-	// Check for direct URL first (argument position 1, position 0 is IDE name)
 	if ctx.GetNumberOfArgs() > 1 && common.IsValidUrl(ctx.GetArgumentAt(1)) {
-		cfg.ServiceURL = ctx.GetArgumentAt(1)
-		cfg.RepoKey = common.ExtractRepoKeyFromURL(cfg.ServiceURL, ApiType)
-		cfg.IsDirectURL = true
+		return parsePositionalURLConfig(ctx)
+	}
+	return parseFlagConfig(ctx)
+}
+
+// parsePositionalURLConfig handles `jf ide setup <ide> <URL>`.
+// If <URL> already embeds a token, we pass it through untouched. Otherwise we
+// derive base URL + repo key from the URL, resolve server credentials from
+// standard flags/config, fetch a token, and append it.
+func parsePositionalURLConfig(ctx *components.Context) (*BaseSetupConfig, error) {
+	rawURL := ctx.GetArgumentAt(1)
+	cfg := &BaseSetupConfig{
+		ServiceURL:  rawURL,
+		IsDirectURL: true,
+	}
+
+	if urlHasReferenceToken(rawURL) {
+		cfg.RepoKey = common.ExtractRepoKeyFromURL(rawURL, ApiType)
 		return cfg, nil
 	}
 
-	// Parse flags
+	baseURL, repoKey, ok := common.SplitApiURL(rawURL, ApiType)
+	if !ok {
+		return nil, fmt.Errorf(
+			"positional URL does not contain '/api/%s/<repo-key>/' — cannot resolve repo key to fetch a reference token. "+
+				"Use --repo-key with server credentials, or pass a fully-formed Set Me Up URL that already ends with '/gallery/<token>'", ApiType)
+	}
+	cfg.RepoKey = repoKey
+
+	rtDetails, err := resolveServerDetails(ctx, baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve server credentials to fetch reference token for repository '%s': %w", repoKey, err)
+	}
+	cfg.ServerDetails = rtDetails
+
+	token, err := FetchReferenceToken(rtDetails, repoKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain reference token for repository '%s': %w", repoKey, err)
+	}
+	cfg.ServiceURL = AppendReferenceToken(rawURL, token)
+	return cfg, nil
+}
+
+// parseFlagConfig handles the flag-driven input surfaces. This flow is
+// intentionally unchanged by RTECO-1568: it does not fetch a per-user
+// reference token. Only the positional URL flow tokenizes the ServiceURL.
+func parseFlagConfig(ctx *components.Context) (*BaseSetupConfig, error) {
+	cfg := &BaseSetupConfig{}
 	cfg.RepoKey = ctx.GetStringFlagValue(RepoKeyFlag)
 	cfg.URLSuffix = ctx.GetStringFlagValue(URLSuffixFlag)
 	if cfg.URLSuffix == "" {
@@ -52,22 +102,33 @@ func ParseBaseSetupConfig(ctx *components.Context) (*BaseSetupConfig, error) {
 		return nil, err
 	}
 
-	// Get server details
 	rtDetails, err := common.GetServerDetails(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server configuration: %w. Please run 'jf config add' first", err)
 	}
 	cfg.ServerDetails = rtDetails
 
-	// Validate repository
 	if err := common.ValidateRepository(cfg.RepoKey, rtDetails, ApiType); err != nil {
 		return nil, err
 	}
 
-	// Build service URL
 	baseUrl := common.GetBaseUrl(rtDetails)
 	cfg.ServiceURL = common.BuildURL(baseUrl, ApiType, cfg.RepoKey, cfg.URLSuffix)
 	cfg.IsDirectURL = false
 
 	return cfg, nil
+}
+
+// resolveServerDetails picks the server credentials to use when only a
+// positional URL was supplied. It honors --server-id / --access-token /
+// --user+--password / default `jf config` — in that order — via
+// common.GetServerDetails, and falls back to constructing details from the
+// URL's base host if no configured server matches.
+func resolveServerDetails(ctx *components.Context, urlBaseURL string) (*config.ServerDetails, error) {
+	if ctx.IsFlagSet("access-token") || (ctx.IsFlagSet("user") && ctx.IsFlagSet("password")) {
+		// Explicit creds on the CLI take precedence; pair them with the URL's base.
+		return common.BuildServerDetailsFromBaseURL(ctx, urlBaseURL)
+	}
+	// Otherwise defer to --server-id / default jf config resolution.
+	return common.GetServerDetails(ctx)
 }

--- a/ide/commands/aieditorextensions/token.go
+++ b/ide/commands/aieditorextensions/token.go
@@ -17,6 +17,7 @@ import (
 const (
 	// aiEditorExtensionTokenAPI is the Artifactory REST path that issues a
 	// per-user reference token used by curated AI editor extension downloads.
+	// #nosec G101 -- REST endpoint path, not a credential.
 	aiEditorExtensionTokenAPI = "api/setMeUp/AIEditorExtensionGenerateToken"
 
 	tokenHTTPRetries            = 3

--- a/ide/commands/aieditorextensions/token.go
+++ b/ide/commands/aieditorextensions/token.go
@@ -75,17 +75,3 @@ func FetchReferenceToken(serverDetails *config.ServerDetails, repoKey string) (s
 func AppendReferenceToken(serviceURL, token string) string {
 	return strings.TrimRight(serviceURL, "/") + "/" + token
 }
-
-// urlHasReferenceToken reports whether a gallery service URL already embeds
-// a reference token, i.e. whether it looks like ".../_apis/public/gallery/<something>".
-// Used to decide whether to skip token fetch on a direct URL that already has one.
-func urlHasReferenceToken(serviceURL string) bool {
-	const marker = "/" + DefaultURLSuffix + "/"
-	idx := strings.Index(serviceURL, marker)
-	if idx < 0 {
-		return false
-	}
-	tail := strings.TrimSpace(serviceURL[idx+len(marker):])
-	tail = strings.TrimRight(tail, "/")
-	return tail != ""
-}

--- a/ide/commands/aieditorextensions/token.go
+++ b/ide/commands/aieditorextensions/token.go
@@ -1,0 +1,91 @@
+package aieditorextensions
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	// aiEditorExtensionTokenAPI is the Artifactory REST path that issues a
+	// per-user reference token used by curated AI editor extension downloads.
+	aiEditorExtensionTokenAPI = "api/setMeUp/AIEditorExtensionGenerateToken"
+
+	tokenHTTPRetries            = 3
+	tokenHTTPRetryWaitMilliSecs = 0
+)
+
+// generateTokenResponse mirrors the JSON returned by AIEditorExtensionGenerateToken.
+type generateTokenResponse struct {
+	ReferenceToken string `json:"referenceToken"`
+	RepoKey        string `json:"repoKey"`
+}
+
+// FetchReferenceToken calls GET api/setMeUp/AIEditorExtensionGenerateToken?repoKey=<repoKey>
+// against the configured Artifactory and returns the per-user referenceToken.
+// The token is what makes curated extension downloads attributable to the
+// individual user rather than an anonymous gallery consumer.
+func FetchReferenceToken(serverDetails *config.ServerDetails, repoKey string) (string, error) {
+	if serverDetails == nil {
+		return "", fmt.Errorf("server details are required to obtain a reference token")
+	}
+	if strings.TrimSpace(repoKey) == "" {
+		return "", fmt.Errorf("repository key is required to obtain a reference token")
+	}
+
+	serviceManager, err := utils.CreateServiceManager(serverDetails, tokenHTTPRetries, tokenHTTPRetryWaitMilliSecs, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to create service manager: %w", err)
+	}
+
+	artURL := clientutils.AddTrailingSlashIfNeeded(serviceManager.GetConfig().GetServiceDetails().GetUrl())
+	requestURL := fmt.Sprintf("%s%s?repoKey=%s", artURL, aiEditorExtensionTokenAPI, url.QueryEscape(repoKey))
+	log.Debug("Fetching AI editor extension reference token:", requestURL)
+
+	httpDetails := serviceManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	resp, body, _, err := serviceManager.Client().SendGet(requestURL, true, &httpDetails)
+	if err != nil {
+		return "", fmt.Errorf("failed to call reference token endpoint: %w", err)
+	}
+	if err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
+		return "", err
+	}
+
+	var parsed generateTokenResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse reference token response: %w", err)
+	}
+	if strings.TrimSpace(parsed.ReferenceToken) == "" {
+		return "", fmt.Errorf("reference token endpoint returned an empty referenceToken for repository '%s'", repoKey)
+	}
+	return parsed.ReferenceToken, nil
+}
+
+// AppendReferenceToken appends "/<token>" to a gallery service URL, taking care
+// not to double up on slashes. The output is the URL that gets written to
+// product.json's extensionsGallery.serviceUrl.
+func AppendReferenceToken(serviceURL, token string) string {
+	return strings.TrimRight(serviceURL, "/") + "/" + token
+}
+
+// urlHasReferenceToken reports whether a gallery service URL already embeds
+// a reference token, i.e. whether it looks like ".../_apis/public/gallery/<something>".
+// Used to decide whether to skip token fetch on a direct URL that already has one.
+func urlHasReferenceToken(serviceURL string) bool {
+	const marker = "/" + DefaultURLSuffix + "/"
+	idx := strings.Index(serviceURL, marker)
+	if idx < 0 {
+		return false
+	}
+	tail := strings.TrimSpace(serviceURL[idx+len(marker):])
+	tail = strings.TrimRight(tail, "/")
+	return tail != ""
+}

--- a/ide/commands/aieditorextensions/token.go
+++ b/ide/commands/aieditorextensions/token.go
@@ -21,7 +21,7 @@ const (
 	aiEditorExtensionTokenAPI = "api/setMeUp/AIEditorExtensionGenerateToken"
 
 	tokenHTTPRetries            = 3
-	tokenHTTPRetryWaitMilliSecs = 0
+	tokenHTTPRetryWaitMilliSecs = 1000
 )
 
 // generateTokenResponse mirrors the JSON returned by AIEditorExtensionGenerateToken.
@@ -70,9 +70,3 @@ func FetchReferenceToken(serverDetails *config.ServerDetails, repoKey string) (s
 	return parsed.ReferenceToken, nil
 }
 
-// AppendReferenceToken appends "/<token>" to a gallery service URL, taking care
-// not to double up on slashes. The output is the URL that gets written to
-// product.json's extensionsGallery.serviceUrl.
-func AppendReferenceToken(serviceURL, token string) string {
-	return strings.TrimRight(serviceURL, "/") + "/" + token
-}

--- a/ide/commands/aieditorextensions/token_test.go
+++ b/ide/commands/aieditorextensions/token_test.go
@@ -91,21 +91,3 @@ func TestAppendReferenceToken(t *testing.T) {
 	}
 }
 
-func TestUrlHasReferenceToken(t *testing.T) {
-	tests := []struct {
-		name string
-		url  string
-		want bool
-	}{
-		{"tokenless", "https://acme/api/aieditorextensions/repo/_apis/public/gallery", false},
-		{"tokenless with trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/", false},
-		{"with token", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/TOKEN", true},
-		{"with token and slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/TOKEN/", true},
-		{"unrelated url", "https://acme/artifactory/api/repositories/foo", false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, urlHasReferenceToken(tc.url))
-		})
-	}
-}

--- a/ide/commands/aieditorextensions/token_test.go
+++ b/ide/commands/aieditorextensions/token_test.go
@@ -31,6 +31,16 @@ func newTokenServer(t *testing.T, wantRepoKey string, respondWith generateTokenR
 	}))
 }
 
+// newRawTokenServer lets a test control the exact response body bytes,
+// so we can exercise malformed JSON and missing-field cases.
+func newRawTokenServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
 func TestFetchReferenceToken_Success(t *testing.T) {
 	srv := newTokenServer(t, "adam-aiee-remote",
 		generateTokenResponse{ReferenceToken: "abc123", RepoKey: "adam-aiee-remote"},
@@ -77,17 +87,29 @@ func TestFetchReferenceToken_EmptyToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty referenceToken")
 }
 
-func TestAppendReferenceToken(t *testing.T) {
-	tests := []struct {
-		name, url, token, want string
-	}{
-		{"no trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery", "T", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/T"},
-		{"trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/", "T", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/T"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, AppendReferenceToken(tc.url, tc.token))
-		})
-	}
+// TestFetchReferenceToken_MalformedJSON exercises the case where Artifactory
+// (or a misconfigured intermediary) responds 200 OK with a body that isn't
+// valid JSON at all. The CLI must fail loudly rather than silently writing
+// an empty or garbage token into product.json.
+func TestFetchReferenceToken_MalformedJSON(t *testing.T) {
+	srv := newRawTokenServer(t, http.StatusOK, "<html>not json</html>")
+	defer srv.Close()
+
+	details := &config.ServerDetails{Url: srv.URL + "/", ArtifactoryUrl: srv.URL + "/"}
+	_, err := FetchReferenceToken(details, "repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse reference token response")
 }
 
+// TestFetchReferenceToken_MissingReferenceTokenField mirrors an Artifactory
+// response that returns JSON but omits the referenceToken field entirely
+// (only repoKey present). Treated as an empty token, so we error out.
+func TestFetchReferenceToken_MissingReferenceTokenField(t *testing.T) {
+	srv := newRawTokenServer(t, http.StatusOK, `{"repoKey":"repo"}`)
+	defer srv.Close()
+
+	details := &config.ServerDetails{Url: srv.URL + "/", ArtifactoryUrl: srv.URL + "/"}
+	_, err := FetchReferenceToken(details, "repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty referenceToken")
+}

--- a/ide/commands/aieditorextensions/token_test.go
+++ b/ide/commands/aieditorextensions/token_test.go
@@ -1,0 +1,111 @@
+package aieditorextensions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTokenServer(t *testing.T, wantRepoKey string, respondWith generateTokenResponse, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/"+aiEditorExtensionTokenAPI) {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("repoKey"); got != wantRepoKey {
+			t.Errorf("repoKey mismatch: got %q want %q", got, wantRepoKey)
+		}
+		w.WriteHeader(status)
+		if respondWith.ReferenceToken != "" || respondWith.RepoKey != "" {
+			_ = json.NewEncoder(w).Encode(respondWith)
+		}
+	}))
+}
+
+func TestFetchReferenceToken_Success(t *testing.T) {
+	srv := newTokenServer(t, "adam-aiee-remote",
+		generateTokenResponse{ReferenceToken: "abc123", RepoKey: "adam-aiee-remote"},
+		http.StatusOK)
+	defer srv.Close()
+
+	details := &config.ServerDetails{Url: srv.URL + "/", ArtifactoryUrl: srv.URL + "/"}
+	token, err := FetchReferenceToken(details, "adam-aiee-remote")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", token)
+}
+
+func TestFetchReferenceToken_EmptyRepoKey(t *testing.T) {
+	details := &config.ServerDetails{Url: "http://example.invalid/", ArtifactoryUrl: "http://example.invalid/"}
+	_, err := FetchReferenceToken(details, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository key is required")
+}
+
+func TestFetchReferenceToken_NilServerDetails(t *testing.T) {
+	_, err := FetchReferenceToken(nil, "some-repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server details are required")
+}
+
+func TestFetchReferenceToken_ServerError(t *testing.T) {
+	srv := newTokenServer(t, "repo", generateTokenResponse{}, http.StatusInternalServerError)
+	defer srv.Close()
+
+	details := &config.ServerDetails{Url: srv.URL + "/", ArtifactoryUrl: srv.URL + "/"}
+	_, err := FetchReferenceToken(details, "repo")
+	require.Error(t, err)
+}
+
+func TestFetchReferenceToken_EmptyToken(t *testing.T) {
+	srv := newTokenServer(t, "repo",
+		generateTokenResponse{ReferenceToken: "", RepoKey: "repo"},
+		http.StatusOK)
+	defer srv.Close()
+
+	details := &config.ServerDetails{Url: srv.URL + "/", ArtifactoryUrl: srv.URL + "/"}
+	_, err := FetchReferenceToken(details, "repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty referenceToken")
+}
+
+func TestAppendReferenceToken(t *testing.T) {
+	tests := []struct {
+		name, url, token, want string
+	}{
+		{"no trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery", "T", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/T"},
+		{"trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/", "T", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/T"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, AppendReferenceToken(tc.url, tc.token))
+		})
+	}
+}
+
+func TestUrlHasReferenceToken(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"tokenless", "https://acme/api/aieditorextensions/repo/_apis/public/gallery", false},
+		{"tokenless with trailing slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/", false},
+		{"with token", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/TOKEN", true},
+		{"with token and slash", "https://acme/api/aieditorextensions/repo/_apis/public/gallery/TOKEN/", true},
+		{"unrelated url", "https://acme/artifactory/api/repositories/foo", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, urlHasReferenceToken(tc.url))
+		})
+	}
+}

--- a/ide/common/base.go
+++ b/ide/common/base.go
@@ -30,6 +30,31 @@ func GetServerDetails(c *components.Context) (*config.ServerDetails, error) {
 	return rtDetails, nil
 }
 
+// BuildServerDetailsFromBaseURL constructs a ServerDetails from an explicit
+// Artifactory base URL and the auth flags on ctx (--access-token, or
+// --user + --password). Used when the caller has already resolved a base URL
+// from a full API URL (e.g. --url with /api/<apiType>/<key>/... embedded) and
+// therefore should not consult saved configs.
+func BuildServerDetailsFromBaseURL(c *components.Context, baseURL string) (*config.ServerDetails, error) {
+	baseURL = strings.TrimRight(baseURL, "/") + "/"
+	details := &config.ServerDetails{
+		ArtifactoryUrl: baseURL,
+		Url:            baseURL,
+	}
+	if tok := c.GetStringFlagValue("access-token"); tok != "" {
+		details.AccessToken = tok
+		return details, nil
+	}
+	user := c.GetStringFlagValue("user")
+	password := c.GetStringFlagValue("password")
+	if user != "" && password != "" {
+		details.User = user
+		details.Password = password
+		return details, nil
+	}
+	return nil, fmt.Errorf("credentials required: pass --access-token, or --user and --password")
+}
+
 // HasServerConfigFlags checks if any server configuration flags are provided
 func HasServerConfigFlags(c *components.Context) bool {
 	return c.IsFlagSet("url") ||
@@ -112,6 +137,29 @@ func ExtractRepoKeyFromURL(urlStr, apiType string) string {
 		}
 	}
 	return ""
+}
+
+// SplitApiURL takes a URL like https://host/artifactory/api/<apiType>/<repoKey>[/rest]
+// and returns baseURL="https://host/artifactory", repoKey="<repoKey>", ok=true.
+// Returns ok=false when the URL does not embed /api/<apiType>/<key>.
+func SplitApiURL(rawURL, apiType string) (baseURL, repoKey string, ok bool) {
+	marker := "/api/" + apiType + "/"
+	idx := strings.Index(rawURL, marker)
+	if idx < 0 {
+		return "", "", false
+	}
+	base := strings.TrimRight(rawURL[:idx], "/")
+	rest := rawURL[idx+len(marker):]
+	// Repo key is the first path segment after /api/<apiType>/
+	if slash := strings.Index(rest, "/"); slash >= 0 {
+		repoKey = rest[:slash]
+	} else {
+		repoKey = rest
+	}
+	if base == "" || repoKey == "" {
+		return "", "", false
+	}
+	return base, repoKey, true
 }
 
 // IsValidUrl checks if a string is a valid URL with scheme and host

--- a/ide/common/base.go
+++ b/ide/common/base.go
@@ -142,24 +142,44 @@ func ExtractRepoKeyFromURL(urlStr, apiType string) string {
 // SplitApiURL takes a URL like https://host/artifactory/api/<apiType>/<repoKey>[/rest]
 // and returns baseURL="https://host/artifactory", repoKey="<repoKey>", ok=true.
 // Returns ok=false when the URL does not embed /api/<apiType>/<key>.
+//
+// Only the URL path is inspected; any query string or fragment is dropped.
+// This prevents a URL like ".../<repo>?source=setup" from being interpreted as
+// a repo key of "<repo>?source=setup".
 func SplitApiURL(rawURL, apiType string) (baseURL, repoKey string, ok bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", "", false
+	}
 	marker := "/api/" + apiType + "/"
-	idx := strings.Index(rawURL, marker)
+	idx := strings.Index(u.Path, marker)
 	if idx < 0 {
 		return "", "", false
 	}
-	base := strings.TrimRight(rawURL[:idx], "/")
-	rest := rawURL[idx+len(marker):]
-	// Repo key is the first path segment after /api/<apiType>/
+	basePath := strings.TrimRight(u.Path[:idx], "/")
+	rest := u.Path[idx+len(marker):]
 	if slash := strings.Index(rest, "/"); slash >= 0 {
 		repoKey = rest[:slash]
 	} else {
 		repoKey = rest
 	}
-	if base == "" || repoKey == "" {
+	if repoKey == "" {
 		return "", "", false
 	}
-	return base, repoKey, true
+	baseURL = u.Scheme + "://" + u.Host + basePath
+	return baseURL, repoKey, true
+}
+
+// URLsHaveSameHost reports whether two URLs point at the same host.
+// Used to guard against fetching a per-user token from one Artifactory
+// instance and then writing it into a URL for a different one.
+func URLsHaveSameHost(a, b string) bool {
+	ua, err1 := url.Parse(a)
+	ub, err2 := url.Parse(b)
+	if err1 != nil || err2 != nil || ua.Host == "" || ub.Host == "" {
+		return false
+	}
+	return strings.EqualFold(ua.Host, ub.Host)
 }
 
 // IsValidUrl checks if a string is a valid URL with scheme and host

--- a/ide/common/base_test.go
+++ b/ide/common/base_test.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitApiURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawURL      string
+		apiType     string
+		wantBase    string
+		wantRepoKey string
+		wantOk      bool
+	}{
+		{
+			name:        "with repo only",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:        "with trailing slash",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo/",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:        "with gallery suffix",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:        "with token suffix",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery/TOKEN",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:    "wrong apiType",
+			rawURL:  "https://acme.jfrog.io/artifactory/api/vscode/repo",
+			apiType: "aieditorextensions",
+			wantOk:  false,
+		},
+		{
+			name:    "base only",
+			rawURL:  "https://acme.jfrog.io/artifactory",
+			apiType: "aieditorextensions",
+			wantOk:  false,
+		},
+		{
+			name:    "no api segment",
+			rawURL:  "https://acme.jfrog.io/artifactory/aieditorextensions/repo",
+			apiType: "aieditorextensions",
+			wantOk:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base, key, ok := SplitApiURL(tc.rawURL, tc.apiType)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.wantBase, base)
+				assert.Equal(t, tc.wantRepoKey, key)
+			}
+		})
+	}
+}

--- a/ide/common/base_test.go
+++ b/ide/common/base_test.go
@@ -65,6 +65,36 @@ func TestSplitApiURL(t *testing.T) {
 			apiType: "aieditorextensions",
 			wantOk:  false,
 		},
+		{
+			name:        "with query string is stripped from repo key",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo?source=setup",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:        "with fragment is stripped from repo key",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo#anchor",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:        "with query string after gallery",
+			rawURL:      "https://acme.jfrog.io/artifactory/api/aieditorextensions/repo/_apis/public/gallery?x=1",
+			apiType:     "aieditorextensions",
+			wantBase:    "https://acme.jfrog.io/artifactory",
+			wantRepoKey: "repo",
+			wantOk:      true,
+		},
+		{
+			name:    "not a URL (no scheme)",
+			rawURL:  "acme.jfrog.io/artifactory/api/aieditorextensions/repo",
+			apiType: "aieditorextensions",
+			wantOk:  false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -74,6 +104,27 @@ func TestSplitApiURL(t *testing.T) {
 				assert.Equal(t, tc.wantBase, base)
 				assert.Equal(t, tc.wantRepoKey, key)
 			}
+		})
+	}
+}
+
+func TestURLsHaveSameHost(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "https://acme.jfrog.io/artifactory", "https://acme.jfrog.io/artifactory", true},
+		{"same host different path", "https://acme.jfrog.io/artifactory", "https://acme.jfrog.io/other", true},
+		{"case-insensitive host", "https://ACME.jfrog.io/artifactory", "https://acme.jfrog.io/artifactory", true},
+		{"different host", "https://staging.jfrog.io/artifactory", "https://production.jfrog.io/artifactory", false},
+		{"empty a", "", "https://acme.jfrog.io/artifactory", false},
+		{"empty b", "https://acme.jfrog.io/artifactory", "", false},
+		{"invalid a", "not a url", "https://acme.jfrog.io/artifactory", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, URLsHaveSameHost(tc.a, tc.b))
 		})
 	}
 }

--- a/ide/docs/setup.go
+++ b/ide/docs/setup.go
@@ -26,6 +26,12 @@ Prerequisites:
     * --url paired with --user + --password.
 - --repo-key identifies the Artifactory repository.
 - For VS Code-based IDEs you may need write access to product.json (sudo on some installs).
+- When the AI Editor Extensions gallery URL is passed as the positional argument
+  (not via --repo-key), the CLI calls Artifactory's AIEditorExtensionGenerateToken
+  endpoint using the resolved server credentials and appends the returned per-user
+  referenceToken to the gallery URL written into product.json. This makes curated
+  downloads attributable to the authenticated user. The flag flow (--repo-key
+  with --url / --server-id / default server) does not tokenize the URL.
 
 Common patterns:
   $ jf ide setup vscode --repo-key=vscode-remote
@@ -40,7 +46,11 @@ Gotchas:
   ignored when --url is present. To use a saved server, drop --url and pass --server-id alone.
 - --update-mode only applies to VS Code-based IDEs: "default", "manual", or "none".
 - product.json may require elevated privileges to edit on macOS/Linux system installs.
-- If a service URL is passed as the second positional arg, --repo-key and server config become optional.
+- If a positional service URL is passed and it already ends with /_apis/public/gallery/<token>, the CLI
+  writes it verbatim (no token round-trip). If it does not, the CLI calls
+  AIEditorExtensionGenerateToken to append a per-user token, using --server-id, --access-token,
+  --user + --password, or the default 'jf config' server to authenticate. The URL must contain
+  /api/aieditorextensions/<repo-key>/ so the CLI can identify the repo to request a token for.
 
 Related: jf c add, jf rt repo-create`
 }

--- a/ide/docs/setup.go
+++ b/ide/docs/setup.go
@@ -47,9 +47,12 @@ Gotchas:
 - --update-mode only applies to VS Code-based IDEs: "default", "manual", or "none".
 - product.json may require elevated privileges to edit on macOS/Linux system installs.
 - When a positional service URL is passed, the CLI calls AIEditorExtensionGenerateToken to append a
-  per-user token, using --server-id, --access-token, --user + --password, or the default
-  'jf config' server to authenticate. The URL must contain /api/aieditorextensions/<repo-key>/ so the
-  CLI can identify the repo to request a token for.
+  per-user token, using --access-token, --user + --password, or the default 'jf config' server to
+  authenticate. --server-id is not accepted alongside a positional URL, since the URL already
+  identifies the Artifactory host and combining the two would be ambiguous. The URL must contain
+  /api/aieditorextensions/<repo-key>/ so the CLI can identify the repo to request a token for.
+  If the default 'jf config' server points at a different Artifactory host than the URL, the
+  command fails with a clear message rather than mixing credentials across hosts.
 
 Related: jf c add, jf rt repo-create`
 }

--- a/ide/docs/setup.go
+++ b/ide/docs/setup.go
@@ -46,11 +46,10 @@ Gotchas:
   ignored when --url is present. To use a saved server, drop --url and pass --server-id alone.
 - --update-mode only applies to VS Code-based IDEs: "default", "manual", or "none".
 - product.json may require elevated privileges to edit on macOS/Linux system installs.
-- If a positional service URL is passed and it already ends with /_apis/public/gallery/<token>, the CLI
-  writes it verbatim (no token round-trip). If it does not, the CLI calls
-  AIEditorExtensionGenerateToken to append a per-user token, using --server-id, --access-token,
-  --user + --password, or the default 'jf config' server to authenticate. The URL must contain
-  /api/aieditorextensions/<repo-key>/ so the CLI can identify the repo to request a token for.
+- When a positional service URL is passed, the CLI calls AIEditorExtensionGenerateToken to append a
+  per-user token, using --server-id, --access-token, --user + --password, or the default
+  'jf config' server to authenticate. The URL must contain /api/aieditorextensions/<repo-key>/ so the
+  CLI can identify the repo to request a token for.
 
 Related: jf c add, jf rt repo-create`
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI editor extension gallery URLs are automatically configured with a per-user reference token during `jf ide setup`.
  - Supports credentials supplied through command-line options or the configured default server.
  - Validates gallery URLs and repository paths before completing setup.

- **Bug Fixes**
  - Improved handling and error messages for invalid URLs, mismatched servers, missing credentials, unavailable services, and invalid token responses.

- **Documentation**
  - Updated setup guidance with gallery token requirements and supported authentication options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->