### PR TITLE
XRAY-145659 - Add generic Zero Touch Remediation service

### DIFF
--- a/artifactory/zerotouchremediation/buildtool.go
+++ b/artifactory/zerotouchremediation/buildtool.go
@@ -16,8 +16,10 @@ type BuildTool interface {
 	ProjectRoot(workingDir string) (string, error)
 	// EnsureLockfiles materializes expected lock artifacts when absent and the command allows it.
 	// Returns paths (relative to project root) that were bootstrapped and did not exist before.
+	// Tools without lockfiles (for example Maven) return a nil/empty slice.
 	EnsureLockfiles(ctx context.Context, projectRoot, command string, runner CommandRunner, bootstrapArgs ...string) (bootstrapped []string, err error)
-	// DiscoverLockfiles returns all lockfiles (paths relative to project root).
+	// DiscoverLockfiles returns lock artifacts relative to project root.
+	// Tools without lockfiles return a nil/empty slice; the generic flow then skips apply.
 	DiscoverLockfiles(workingDir string) ([]Lockfile, error)
 }
 

--- a/artifactory/zerotouchremediation/buildtool.go
+++ b/artifactory/zerotouchremediation/buildtool.go
@@ -1,0 +1,26 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"slices"
+)
+
+// CommandRunner runs a build-tool subprocess (injected for tests).
+type CommandRunner func(ctx context.Context, projectRoot string, args ...string) error
+
+// BuildTool describes a package manager for the generic resolution flow.
+type BuildTool interface {
+	ToolName() string
+	RelevantCommands() []string
+	// ProjectRoot resolves monorepo/reactor/solution root from workingDir.
+	ProjectRoot(workingDir string) (string, error)
+	// EnsureLockfiles materializes expected lock artifacts when absent and the command allows it.
+	// Returns paths (relative to project root) that were bootstrapped and did not exist before.
+	EnsureLockfiles(ctx context.Context, projectRoot, command string, runner CommandRunner, bootstrapArgs ...string) (bootstrapped []string, err error)
+	// DiscoverLockfiles returns all lockfiles (paths relative to project root).
+	DiscoverLockfiles(workingDir string) ([]Lockfile, error)
+}
+
+func IsRelevantCommand(tool BuildTool, command string) bool {
+	return slices.Contains(tool.RelevantCommands(), command)
+}

--- a/artifactory/zerotouchremediation/buildtool_test.go
+++ b/artifactory/zerotouchremediation/buildtool_test.go
@@ -1,0 +1,30 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeTool struct {
+	name     string
+	commands []string
+}
+
+func (f fakeTool) ToolName() string                       { return f.name }
+func (f fakeTool) RelevantCommands() []string             { return f.commands }
+func (f fakeTool) ProjectRoot(dir string) (string, error) { return dir, nil }
+func (f fakeTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunner, _ ...string) ([]string, error) {
+	return nil, nil
+}
+func (f fakeTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
+	return []Lockfile{{Path: "lock.json", Content: []byte(`{}`)}}, nil
+}
+
+func TestIsRelevantCommand(t *testing.T) {
+	tool := fakeTool{name: "fake", commands: []string{"install", "ci"}}
+	assert.True(t, IsRelevantCommand(tool, "install"))
+	assert.True(t, IsRelevantCommand(tool, "ci"))
+	assert.False(t, IsRelevantCommand(tool, "publish"))
+}

--- a/artifactory/zerotouchremediation/service.go
+++ b/artifactory/zerotouchremediation/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
@@ -13,11 +14,13 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
 
-// ZtrComponentsEnabledEnvVar enables Zero Touch Remediation when set to "true".
-// Feature is disabled by default.
+// ZtrComponentsEnabledEnvVar enables Zero Touch Remediation when set to a
+// truthy value per strconv.ParseBool ("true", "TRUE", "1", "t", …). Disabled by default.
 const ZtrComponentsEnabledEnvVar = "JFROG_CLI_ZTR_COMPONENTS_ENABLED"
 
-const ZeroTouchRemediationMinVersion = "3.154.0"
+// ZeroTouchRemediationMinXrayVersion is the minimum JFrog Xray version that
+// supports the component-resolution / Zero Touch Remediation API.
+const ZeroTouchRemediationMinXrayVersion = "3.154.0"
 
 var noopRestore = func() error { return nil }
 
@@ -34,10 +37,6 @@ func SkipRemediation(message string, cause error) (func() error, bool, error) {
 	return noopRestore, false, nil
 }
 
-func skipRemediationWarn(message string, cause error) (func() error, bool, error) {
-	return skipWithRestore(noopRestore, message, cause)
-}
-
 func skipWithRestore(restore func() error, message string, cause error) (func() error, bool, error) {
 	if cause != nil {
 		log.Warn(message + cause.Error())
@@ -51,7 +50,8 @@ func skipWithRestore(restore func() error, message string, cause error) (func() 
 }
 
 func IsComponentResolutionEnabled() bool {
-	return os.Getenv(ZtrComponentsEnabledEnvVar) == "true"
+	value, err := strconv.ParseBool(os.Getenv(ZtrComponentsEnabledEnvVar))
+	return err == nil && value
 }
 
 // Lockfile is a CLI-side lock artifact. Path is relative to project root (read/write only — not sent to Xray).
@@ -81,21 +81,21 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 	}
 	version, err := client.GetVersion()
 	if err != nil {
-		return skipRemediationWarn("Zero Touch Remediation skipped: could not get Xray version: ", err)
+		return SkipRemediation("Zero Touch Remediation skipped: could not get Xray version: ", err)
 	}
 	log.Debug("Xray version: ", version)
-	if versionErr := clientutils.ValidateMinimumVersion(clientutils.Xray, version, ZeroTouchRemediationMinVersion); versionErr != nil {
-		return skipRemediationWarn("Zero Touch Remediation is not supported on the current Xray version. ", versionErr)
+	if versionErr := clientutils.ValidateMinimumVersion(clientutils.Xray, version, ZeroTouchRemediationMinXrayVersion); versionErr != nil {
+		return SkipRemediation("Zero Touch Remediation is not supported on the current Xray version. ", versionErr)
 	}
 	log.Debug("Running Zero Touch Remediation at '"+repo+"' RT repository for tool:", tool.ToolName())
 	projectRoot, err := tool.ProjectRoot(workingDir)
 	if err != nil {
-		return skipRemediationWarn("Zero Touch Remediation skipped: could not resolve project root: ", err)
+		return skipWithRestore(noopRestore, "Zero Touch Remediation skipped: could not resolve project root: ", err)
 	}
 	log.Debug("Ensuring lockfiles in project root: ", projectRoot)
 	bootstrapped, err := tool.EnsureLockfiles(ctx, projectRoot, command, runner, bootstrapArgs...)
 	if err != nil {
-		return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+		return skipWithRestore(noopRestore, "Zero Touch Remediation skipped: ", err)
 	}
 	skipAfterBootstrap := func(message string, cause error) (func() error, bool, error) {
 		return skipWithRestore(restoreAbsentLockfiles(projectRoot, bootstrapped), message, cause)
@@ -287,9 +287,10 @@ func containedLockfilePath(projectRoot, rel string) (string, error) {
 	return full, nil
 }
 
-// rejectSymlinksUnderRoot Lstats each path component from projectRoot to fullPath,
-// not including projectRoot itself. Walking above the root would reject macOS
-// TempDirs whose prefix is /var → /private/var.
+// rejectSymlinksUnderRoot Lstats each component from projectRoot to fullPath so a
+// symlink parent cannot redirect writes outside the tree. It does not inspect
+// projectRoot or its ancestors (macOS TempDir is often under /var → /private/var).
+// Empty and "." parts from Rel are skipped. Missing components are allowed.
 func rejectSymlinksUnderRoot(projectRoot, fullPath string) error {
 	root, err := filepath.Abs(projectRoot)
 	if err != nil {
@@ -312,6 +313,8 @@ func rejectSymlinksUnderRoot(projectRoot, fullPath string) error {
 	return nil
 }
 
+// rejectSymlink uses Lstat (does not follow) and allows a missing path so a
+// lockfile can be created. Stat would follow a dangling or redirected link.
 func rejectSymlink(path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {

--- a/artifactory/zerotouchremediation/service.go
+++ b/artifactory/zerotouchremediation/service.go
@@ -35,12 +35,19 @@ func SkipRemediation(message string, cause error) (func() error, bool, error) {
 }
 
 func skipRemediationWarn(message string, cause error) (func() error, bool, error) {
+	return skipWithRestore(noopRestore, message, cause)
+}
+
+func skipWithRestore(restore func() error, message string, cause error) (func() error, bool, error) {
 	if cause != nil {
 		log.Warn(message + cause.Error())
 	} else {
 		log.Warn(message)
 	}
-	return noopRestore, false, nil
+	if restore == nil {
+		restore = noopRestore
+	}
+	return restore, false, nil
 }
 
 func IsComponentResolutionEnabled() bool {
@@ -90,9 +97,12 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 	if err != nil {
 		return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
 	}
+	skipAfterBootstrap := func(message string, cause error) (func() error, bool, error) {
+		return skipWithRestore(restoreAbsentLockfiles(projectRoot, bootstrapped), message, cause)
+	}
 	lockfiles, err := tool.DiscoverLockfiles(workingDir)
 	if err != nil {
-		return skipRemediationWarn("Zero Touch Remediation skipped: could not discover lockfiles: ", err)
+		return skipAfterBootstrap("Zero Touch Remediation skipped: could not discover lockfiles: ", err)
 	}
 	log.Debug("Discovered lockfiles: ", getLockfilePaths(lockfiles))
 	var toWrite []Lockfile
@@ -104,7 +114,7 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 			Lockfile:  string(lf.Content),
 		})
 		if err != nil {
-			return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+			return skipAfterBootstrap("Zero Touch Remediation skipped: ", err)
 		}
 		if disabled {
 			log.Debug("Zero Touch Remediation skipped: the service is disabled on the server")
@@ -127,7 +137,7 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 	log.Debug("Applying", len(toWrite), "remediated lockfile(s)...")
 	restore, err = ApplyLockfiles(projectRoot, toWrite, bootstrapped)
 	if err != nil {
-		return skipRemediationWarn("Zero Touch Remediation skipped: failed to apply remediated lockfiles: ", err)
+		return skipAfterBootstrap("Zero Touch Remediation skipped: failed to apply remediated lockfiles: ", err)
 	}
 	restore = composeRestore(restore, restoreAbsentLockfiles(projectRoot, bootstrappedNotWritten(bootstrapped, toWrite)))
 	log.Info("Zero Touch Remediation applied", totalChanges, "package change(s) across", len(toWrite), "lockfile(s)")

--- a/artifactory/zerotouchremediation/service.go
+++ b/artifactory/zerotouchremediation/service.go
@@ -108,7 +108,7 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 		}
 		if disabled {
 			log.Debug("Zero Touch Remediation skipped: the service is disabled on the server")
-			return noopRestore, false, nil
+			return restoreAbsentLockfiles(projectRoot, bootstrapped), false, nil
 		}
 		if len(resp.Changes) == 0 {
 			log.Debug("No changes for ", lf.Path)
@@ -122,15 +122,63 @@ func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo st
 		}
 	}
 	if len(toWrite) == 0 {
-		return noopRestore, false, nil
+		return restoreAbsentLockfiles(projectRoot, bootstrapped), false, nil
 	}
 	log.Debug("Applying", len(toWrite), "remediated lockfile(s)...")
 	restore, err = ApplyLockfiles(projectRoot, toWrite, bootstrapped)
 	if err != nil {
 		return skipRemediationWarn("Zero Touch Remediation skipped: failed to apply remediated lockfiles: ", err)
 	}
+	restore = composeRestore(restore, restoreAbsentLockfiles(projectRoot, bootstrappedNotWritten(bootstrapped, toWrite)))
 	log.Info("Zero Touch Remediation applied", totalChanges, "package change(s) across", len(toWrite), "lockfile(s)")
 	return restore, true, nil
+}
+
+func bootstrappedNotWritten(bootstrapped []string, written []Lockfile) []string {
+	inWritten := make(map[string]bool, len(written))
+	for _, lf := range written {
+		inWritten[lf.Path] = true
+	}
+	var leftover []string
+	for _, path := range bootstrapped {
+		if !inWritten[path] {
+			leftover = append(leftover, path)
+		}
+	}
+	return leftover
+}
+
+func restoreAbsentLockfiles(projectRoot string, relPaths []string) func() error {
+	if len(relPaths) == 0 {
+		return noopRestore
+	}
+	return func() error {
+		var restoreErr error
+		for _, rel := range relPaths {
+			fullPath, pathErr := containedLockfilePath(projectRoot, rel)
+			if pathErr != nil {
+				restoreErr = errors.Join(restoreErr, pathErr)
+				continue
+			}
+			if rbErr := restoreLockfileBackup(lockfileBackup{path: fullPath}); rbErr != nil {
+				restoreErr = errors.Join(restoreErr, rbErr)
+			}
+		}
+		return restoreErr
+	}
+}
+
+func composeRestore(fns ...func() error) func() error {
+	return func() error {
+		var restoreErr error
+		for _, fn := range fns {
+			if fn == nil {
+				continue
+			}
+			restoreErr = errors.Join(restoreErr, fn())
+		}
+		return restoreErr
+	}
 }
 
 func getLockfilePaths(lockfiles []Lockfile) []string {
@@ -175,7 +223,7 @@ func ApplyLockfiles(projectRoot string, lockfiles []Lockfile, treatAsAbsent []st
 		if pathErr != nil {
 			return fail(pathErr)
 		}
-		if linkErr := rejectSymlink(fullPath); linkErr != nil {
+		if linkErr := rejectSymlinksUnderRoot(projectRoot, fullPath); linkErr != nil {
 			return fail(linkErr)
 		}
 		backup := lockfileBackup{path: fullPath}
@@ -227,6 +275,31 @@ func containedLockfilePath(projectRoot, rel string) (string, error) {
 		return "", errorutils.CheckErrorf("lockfile path %q escapes project root", rel)
 	}
 	return full, nil
+}
+
+// rejectSymlinksUnderRoot Lstats each path component from projectRoot to fullPath,
+// not including projectRoot itself. Walking above the root would reject macOS
+// TempDirs whose prefix is /var → /private/var.
+func rejectSymlinksUnderRoot(projectRoot, fullPath string) error {
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	rel, err := filepath.Rel(root, fullPath)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		if linkErr := rejectSymlink(current); linkErr != nil {
+			return linkErr
+		}
+	}
+	return nil
 }
 
 func rejectSymlink(path string) error {

--- a/artifactory/zerotouchremediation/service.go
+++ b/artifactory/zerotouchremediation/service.go
@@ -1,0 +1,244 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+// ZtrComponentsEnabledEnvVar enables Zero Touch Remediation when set to "true".
+// Feature is disabled by default.
+const ZtrComponentsEnabledEnvVar = "JFROG_CLI_ZTR_COMPONENTS_ENABLED"
+
+const ZeroTouchRemediationMinVersion = "3.154.0"
+
+var noopRestore = func() error { return nil }
+
+// writeFile is os.WriteFile; tests replace it to simulate truncate-then-fail.
+var writeFile = os.WriteFile
+
+// SkipRemediation logs and returns without error. Zero Touch Remediation is best-effort and must not fail the caller's build.
+func SkipRemediation(message string, cause error) (func() error, bool, error) {
+	if cause != nil {
+		log.Debug(message + cause.Error())
+	} else {
+		log.Debug(message)
+	}
+	return noopRestore, false, nil
+}
+
+func skipRemediationWarn(message string, cause error) (func() error, bool, error) {
+	if cause != nil {
+		log.Warn(message + cause.Error())
+	} else {
+		log.Warn(message)
+	}
+	return noopRestore, false, nil
+}
+
+func IsComponentResolutionEnabled() bool {
+	return os.Getenv(ZtrComponentsEnabledEnvVar) == "true"
+}
+
+// Lockfile is a CLI-side lock artifact. Path is relative to project root (read/write only — not sent to Xray).
+type Lockfile struct {
+	Path    string
+	Content []byte
+}
+
+type lockfileBackup struct {
+	path    string
+	content []byte // nil means the file did not exist before apply
+}
+
+// ComponentResolutionClient resolves a single lockfile via Xray.
+type ComponentResolutionClient interface {
+	GetVersion() (string, error)
+	ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error)
+}
+
+// RunIfEnabled ensures lockfiles exist, discovers them, calls Xray once per file, writes remediated lockfiles when changes returned.
+// Operational failures are skipped (warn + continue) so remediation never fails the caller's build.
+// Returns a restore function to revert lockfile writes if the subsequent build-tool command fails, and remediated=true when at least one lockfile was updated.
+func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo string, tool BuildTool, command, workingDir string, runner CommandRunner, bootstrapArgs ...string) (restore func() error, remediated bool, err error) {
+	if !IsComponentResolutionEnabled() || !IsRelevantCommand(tool, command) {
+		log.Debug("Zero Touch Remediation disabled or not relevant command: ", command)
+		return noopRestore, false, nil
+	}
+	version, err := client.GetVersion()
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not get Xray version: ", err)
+	}
+	log.Debug("Xray version: ", version)
+	if versionErr := clientutils.ValidateMinimumVersion(clientutils.Xray, version, ZeroTouchRemediationMinVersion); versionErr != nil {
+		return skipRemediationWarn("Zero Touch Remediation is not supported on the current Xray version. ", versionErr)
+	}
+	log.Debug("Running Zero Touch Remediation at '"+repo+"' RT repository for tool:", tool.ToolName())
+	projectRoot, err := tool.ProjectRoot(workingDir)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not resolve project root: ", err)
+	}
+	log.Debug("Ensuring lockfiles in project root: ", projectRoot)
+	bootstrapped, err := tool.EnsureLockfiles(ctx, projectRoot, command, runner, bootstrapArgs...)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+	}
+	lockfiles, err := tool.DiscoverLockfiles(workingDir)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not discover lockfiles: ", err)
+	}
+	log.Debug("Discovered lockfiles: ", getLockfilePaths(lockfiles))
+	var toWrite []Lockfile
+	var totalChanges int
+	for _, lf := range lockfiles {
+		resp, disabled, err := client.ZeroTouchRemediation(services.ComponentResolutionRequest{
+			BuildTool: tool.ToolName(),
+			Repo:      repo,
+			Lockfile:  string(lf.Content),
+		})
+		if err != nil {
+			return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+		}
+		if disabled {
+			log.Debug("Zero Touch Remediation skipped: the service is disabled on the server")
+			return noopRestore, false, nil
+		}
+		if len(resp.Changes) == 0 {
+			log.Debug("No changes for ", lf.Path)
+			continue
+		}
+		toWrite = append(toWrite, Lockfile{Path: lf.Path, Content: []byte(resp.Lockfile)})
+		totalChanges += len(resp.Changes)
+		log.Debug("Remediated", lf.Path, "with", len(resp.Changes), "package change(s)")
+		for _, ch := range resp.Changes {
+			log.Debug("  ", ch.Package, ":", ch.BeforeIntegrity, "→", ch.AfterIntegrity)
+		}
+	}
+	if len(toWrite) == 0 {
+		return noopRestore, false, nil
+	}
+	log.Debug("Applying", len(toWrite), "remediated lockfile(s)...")
+	restore, err = ApplyLockfiles(projectRoot, toWrite, bootstrapped)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: failed to apply remediated lockfiles: ", err)
+	}
+	log.Info("Zero Touch Remediation applied", totalChanges, "package change(s) across", len(toWrite), "lockfile(s)")
+	return restore, true, nil
+}
+
+func getLockfilePaths(lockfiles []Lockfile) []string {
+	paths := make([]string, 0, len(lockfiles))
+	for _, lf := range lockfiles {
+		paths = append(paths, lf.Path)
+	}
+	return paths
+}
+
+// ApplyLockfiles backs up existing lockfiles under projectRoot, writes updates, returns restore func.
+// Paths listed in treatAsAbsent are restored by deletion even if they exist on disk (bootstrapped locks).
+func ApplyLockfiles(projectRoot string, lockfiles []Lockfile, treatAsAbsent []string) (restore func() error, err error) {
+	if len(lockfiles) == 0 {
+		return func() error { return nil }, nil
+	}
+
+	absent := make(map[string]bool, len(treatAsAbsent))
+	for _, path := range treatAsAbsent {
+		absent[path] = true
+	}
+
+	var backups []lockfileBackup
+	restoreWritten := func() error {
+		var restoreErr error
+		for _, backup := range backups {
+			if rbErr := restoreLockfileBackup(backup); rbErr != nil {
+				restoreErr = errors.Join(restoreErr, rbErr)
+			}
+		}
+		return restoreErr
+	}
+	fail := func(cause error) (func() error, error) {
+		if rbErr := restoreWritten(); rbErr != nil {
+			return nil, errors.Join(errorutils.CheckError(cause), rbErr)
+		}
+		return nil, errorutils.CheckError(cause)
+	}
+
+	for _, lf := range lockfiles {
+		fullPath, pathErr := containedLockfilePath(projectRoot, lf.Path)
+		if pathErr != nil {
+			return fail(pathErr)
+		}
+		if linkErr := rejectSymlink(fullPath); linkErr != nil {
+			return fail(linkErr)
+		}
+		backup := lockfileBackup{path: fullPath}
+		if !absent[lf.Path] {
+			data, readErr := os.ReadFile(fullPath)
+			if readErr == nil {
+				backup.content = data
+			} else if !os.IsNotExist(readErr) {
+				return fail(readErr)
+			}
+		}
+
+		backups = append(backups, backup)
+		if err = os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return fail(err)
+		}
+		if err = writeFile(fullPath, lf.Content, 0644); err != nil {
+			return fail(err)
+		}
+	}
+
+	return restoreWritten, nil
+}
+
+func restoreLockfileBackup(backup lockfileBackup) error {
+	if backup.content == nil {
+		if err := os.Remove(backup.path); err != nil && !os.IsNotExist(err) {
+			return errorutils.CheckError(err)
+		}
+		return nil
+	}
+	return errorutils.CheckError(os.WriteFile(backup.path, backup.content, 0644))
+}
+
+func containedLockfilePath(projectRoot, rel string) (string, error) {
+	if rel == "" || filepath.IsAbs(rel) {
+		return "", errorutils.CheckErrorf("lockfile path %q is not relative to the project root", rel)
+	}
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	full := filepath.Clean(filepath.Join(root, rel))
+	relToRoot, err := filepath.Rel(root, full)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(os.PathSeparator)) {
+		return "", errorutils.CheckErrorf("lockfile path %q escapes project root", rel)
+	}
+	return full, nil
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errorutils.CheckError(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errorutils.CheckErrorf("refusing to write lockfile through symlink %s", path)
+	}
+	return nil
+}

--- a/artifactory/zerotouchremediation/service_test.go
+++ b/artifactory/zerotouchremediation/service_test.go
@@ -31,7 +31,7 @@ func (m *mockClient) GetVersion() (string, error) {
 	if m.version != "" {
 		return m.version, nil
 	}
-	return ZeroTouchRemediationMinVersion, nil
+	return ZeroTouchRemediationMinXrayVersion, nil
 }
 
 func (m *mockClient) ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {
@@ -95,8 +95,16 @@ func TestIsComponentResolutionEnabled(t *testing.T) {
 		t.Setenv(ZtrComponentsEnabledEnvVar, "true")
 		assert.True(t, IsComponentResolutionEnabled())
 	})
+	t.Run("enabled for ParseBool truthy values", func(t *testing.T) {
+		for _, v := range []string{"TRUE", "True", "1", "t", "T"} {
+			t.Setenv(ZtrComponentsEnabledEnvVar, v)
+			assert.True(t, IsComponentResolutionEnabled(), v)
+		}
+	})
 	t.Run("not enabled for other values", func(t *testing.T) {
 		t.Setenv(ZtrComponentsEnabledEnvVar, "false")
+		assert.False(t, IsComponentResolutionEnabled())
+		t.Setenv(ZtrComponentsEnabledEnvVar, "yes")
 		assert.False(t, IsComponentResolutionEnabled())
 	})
 }
@@ -526,7 +534,7 @@ type selectingClient struct {
 }
 
 func (s *selectingClient) GetVersion() (string, error) {
-	return ZeroTouchRemediationMinVersion, nil
+	return ZeroTouchRemediationMinXrayVersion, nil
 }
 
 func (s *selectingClient) ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {

--- a/artifactory/zerotouchremediation/service_test.go
+++ b/artifactory/zerotouchremediation/service_test.go
@@ -1,0 +1,406 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+type mockClient struct {
+	callCount    int
+	lastReq      services.ComponentResolutionRequest
+	resp         services.ComponentResolutionResponse
+	disabled     bool
+	version      string
+	versionErr   error
+	remediateErr error
+}
+
+func (m *mockClient) GetVersion() (string, error) {
+	if m.versionErr != nil {
+		return "", m.versionErr
+	}
+	if m.version != "" {
+		return m.version, nil
+	}
+	return ZeroTouchRemediationMinVersion, nil
+}
+
+func (m *mockClient) ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {
+	m.callCount++
+	m.lastReq = req
+	if m.remediateErr != nil {
+		return nil, false, m.remediateErr
+	}
+	return &m.resp, m.disabled, nil
+}
+
+type mockTool struct {
+	name      string
+	commands  []string
+	root      string
+	lockfiles []Lockfile
+	ensureErr error
+}
+
+func (m mockTool) ToolName() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "npm"
+}
+func (m mockTool) RelevantCommands() []string {
+	if len(m.commands) > 0 {
+		return m.commands
+	}
+	return []string{"install", "ci"}
+}
+func (m mockTool) ProjectRoot(_ string) (string, error) {
+	return m.root, nil
+}
+func (m mockTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunner, _ ...string) ([]string, error) {
+	if m.ensureErr != nil {
+		return nil, m.ensureErr
+	}
+	return nil, nil
+}
+func (m mockTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
+	return m.lockfiles, nil
+}
+
+func enableZTR(t *testing.T) {
+	t.Helper()
+	t.Setenv(ZtrComponentsEnabledEnvVar, "true")
+}
+
+func TestIsComponentResolutionEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "")
+		assert.False(t, IsComponentResolutionEnabled())
+	})
+	t.Run("enabled when env true", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "true")
+		assert.True(t, IsComponentResolutionEnabled())
+	})
+	t.Run("not enabled for other values", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "false")
+		assert.False(t, IsComponentResolutionEnabled())
+	})
+}
+
+func TestRunIfEnabled_WritesRemediatedLockfiles(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: "remediated",
+		Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+	assert.Equal(t, "npm", client.lastReq.BuildTool)
+	assert.Equal(t, "npm-virtual", client.lastReq.Repo)
+	assert.Equal(t, "orig", client.lastReq.Lockfile)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "remediated", string(data))
+}
+
+func TestRunIfEnabled_WritesRemediatedNpmLockAsString(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	orig := `{"lockfileVersion":3,"name":"app"}`
+	require.NoError(t, os.WriteFile(lockPath, []byte(orig), 0644))
+
+	remediated := `{"lockfileVersion":3,"name":"app","remediated":true}`
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: remediated,
+		Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte(orig)}}}
+
+	_, remediatedFlag, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediatedFlag)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, remediated, string(data))
+	assert.Equal(t, orig, client.lastReq.Lockfile)
+}
+
+func TestRunIfEnabled_SkipsWhenServiceDisabled(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{disabled: true}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_SkipsWhenNotEnabled(t *testing.T) {
+	t.Setenv(ZtrComponentsEnabledEnvVar, "")
+	client := &mockClient{}
+	tool := mockTool{}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsWhenNoChanges(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: "orig",
+		Changes:  nil,
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_LoopsPerDiscoveredFile(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lock"), []byte("a"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lock"), []byte("b"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{Lockfile: "x", Changes: nil}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{
+		{Path: "a.lock", Content: []byte("a")},
+		{Path: "b.lock", Content: []byte("b")},
+	}}
+	_, _, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsIrrelevantCommand(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{}
+	tool := mockTool{}
+	_, _, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "version", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsEnsureLockfilesError(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{}
+	tool := mockTool{ensureErr: errors.New("package-lock.json is required for npm ci")}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "ci", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsGetVersionError(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{versionErr: errors.New("xray unavailable")}
+	tool := mockTool{root: t.TempDir(), lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsRemediateError(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{remediateErr: errors.New("connection refused")}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_SkipsWhenXrayVersionTooLow(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{
+		version: "3.100.0",
+		resp: services.ComponentResolutionResponse{
+			Lockfile: "remediated",
+			Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+		},
+	}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_AllowsXrayDevVersion(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{
+		version: "3.x-dev",
+		resp: services.ComponentResolutionResponse{
+			Lockfile: "remediated",
+			Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+		},
+	}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "remediated", string(data))
+}
+
+func TestApplyLockfiles_WritesMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("a"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "app"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app/gradle.lockfile"), []byte("b"), 0644))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("a-remediated")},
+		{Path: "app/gradle.lockfile", Content: []byte("b-remediated")},
+	}, nil)
+	require.NoError(t, err)
+	defer testsutils.RemoveAllAndAssert(t, dir)
+
+	a, _ := os.ReadFile(filepath.Join(dir, "package-lock.json"))
+	b, _ := os.ReadFile(filepath.Join(dir, "app/gradle.lockfile"))
+	assert.Equal(t, "a-remediated", string(a))
+	assert.Equal(t, "b-remediated", string(b))
+
+	require.NoError(t, restore())
+}
+
+func TestApplyLockfiles_RestoresWhenWriteTruncatesThenFails(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("original-lock"), 0644))
+
+	origWrite := writeFile
+	t.Cleanup(func() { writeFile = origWrite })
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if err := origWrite(name, nil, perm); err != nil {
+			return err
+		}
+		return errors.New("disk full")
+	}
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+	assert.Contains(t, err.Error(), "disk full")
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "original-lock", string(data))
+}
+
+func TestApplyLockfiles_RollsBackOnLaterWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(firstPath, []byte("original-first"), 0644))
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not-a-dir"), 0644))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated-first")},
+		{Path: "blocker/nested.lock", Content: []byte("remediated-second")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+
+	data, readErr := os.ReadFile(firstPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "original-first", string(data))
+}
+
+func TestApplyLockfiles_RejectsPathEscapingProjectRoot(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(filepath.Dir(dir), "escaped.lock")
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "../escaped.lock", Content: []byte("pwned")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+	assert.NoFileExists(t, outside)
+}
+
+func TestApplyLockfiles_RejectsSymlinkLockfile(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "target.lock")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0644))
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.Symlink(outside, lockPath))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+
+	data, readErr := os.ReadFile(outside)
+	require.NoError(t, readErr)
+	assert.Equal(t, "secret", string(data))
+}

--- a/artifactory/zerotouchremediation/service_test.go
+++ b/artifactory/zerotouchremediation/service_test.go
@@ -49,6 +49,7 @@ type mockTool struct {
 	root         string
 	lockfiles    []Lockfile
 	ensureErr    error
+	discoverErr  error
 	bootstrapped []string
 }
 
@@ -74,6 +75,9 @@ func (m mockTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunne
 	return m.bootstrapped, nil
 }
 func (m mockTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
+	if m.discoverErr != nil {
+		return nil, m.discoverErr
+	}
 	return m.lockfiles, nil
 }
 
@@ -257,6 +261,81 @@ func TestRunIfEnabled_SkipsRemediateError(t *testing.T) {
 	data, readErr := os.ReadFile(lockPath)
 	require.NoError(t, readErr)
 	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_DiscoverErrorRestoresBootstrapped(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("generated"), 0644))
+
+	client := &mockClient{}
+	tool := mockTool{
+		root:         dir,
+		discoverErr:  errors.New("discover failed"),
+		bootstrapped: []string{"package-lock.json"},
+	}
+	restore, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+	assert.FileExists(t, lockPath)
+	require.NoError(t, restore())
+	assert.NoFileExists(t, lockPath)
+}
+
+func TestRunIfEnabled_RemediateErrorRestoresBootstrapped(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("generated"), 0644))
+
+	client := &mockClient{remediateErr: errors.New("connection refused")}
+	tool := mockTool{
+		root:         dir,
+		lockfiles:    []Lockfile{{Path: "package-lock.json", Content: []byte("generated")}},
+		bootstrapped: []string{"package-lock.json"},
+	}
+	restore, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.FileExists(t, lockPath)
+	require.NoError(t, restore())
+	assert.NoFileExists(t, lockPath)
+}
+
+func TestRunIfEnabled_ApplyErrorRestoresLeftoverBootstrapped(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	changedPath := filepath.Join(dir, "package-lock.json")
+	leftoverPath := filepath.Join(dir, "npm-shrinkwrap.json")
+	require.NoError(t, os.WriteFile(changedPath, []byte("generated-a"), 0644))
+	require.NoError(t, os.WriteFile(leftoverPath, []byte("generated-b"), 0644))
+
+	origWrite := writeFile
+	t.Cleanup(func() { writeFile = origWrite })
+	writeFile = func(string, []byte, os.FileMode) error {
+		return errors.New("disk full")
+	}
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: "remediated-a",
+		Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+	}}
+	tool := mockTool{
+		root: dir,
+		lockfiles: []Lockfile{
+			{Path: "package-lock.json", Content: []byte("generated-a")},
+		},
+		bootstrapped: []string{"package-lock.json", "npm-shrinkwrap.json"},
+	}
+	restore, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.FileExists(t, leftoverPath)
+	require.NoError(t, restore())
+	assert.NoFileExists(t, leftoverPath)
+	assert.NoFileExists(t, changedPath)
 }
 
 func TestRunIfEnabled_SkipsWhenXrayVersionTooLow(t *testing.T) {

--- a/artifactory/zerotouchremediation/service_test.go
+++ b/artifactory/zerotouchremediation/service_test.go
@@ -44,11 +44,12 @@ func (m *mockClient) ZeroTouchRemediation(req services.ComponentResolutionReques
 }
 
 type mockTool struct {
-	name      string
-	commands  []string
-	root      string
-	lockfiles []Lockfile
-	ensureErr error
+	name         string
+	commands     []string
+	root         string
+	lockfiles    []Lockfile
+	ensureErr    error
+	bootstrapped []string
 }
 
 func (m mockTool) ToolName() string {
@@ -70,7 +71,7 @@ func (m mockTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunne
 	if m.ensureErr != nil {
 		return nil, m.ensureErr
 	}
-	return nil, nil
+	return m.bootstrapped, nil
 }
 func (m mockTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
 	return m.lockfiles, nil
@@ -385,6 +386,97 @@ func TestApplyLockfiles_RejectsPathEscapingProjectRoot(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, restore)
 	assert.NoFileExists(t, outside)
+}
+
+func TestRunIfEnabled_RestoresBootstrappedLockfileWhenNoChanges(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("generated"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{Lockfile: "generated", Changes: nil}}
+	tool := mockTool{
+		root:         dir,
+		lockfiles:    []Lockfile{{Path: "package-lock.json", Content: []byte("generated")}},
+		bootstrapped: []string{"package-lock.json"},
+	}
+
+	restore, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.FileExists(t, lockPath)
+	require.NoError(t, restore())
+	assert.NoFileExists(t, lockPath)
+}
+
+func TestRunIfEnabled_RestoresUnchangedBootstrappedLockfile(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	changedPath := filepath.Join(dir, "package-lock.json")
+	unchangedPath := filepath.Join(dir, "npm-shrinkwrap.json")
+	require.NoError(t, os.WriteFile(changedPath, []byte("generated-a"), 0644))
+	require.NoError(t, os.WriteFile(unchangedPath, []byte("generated-b"), 0644))
+
+	client := &selectingClient{
+		resps: map[string]services.ComponentResolutionResponse{
+			"generated-a": {Lockfile: "remediated-a", Changes: []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}}},
+			"generated-b": {Lockfile: "generated-b"},
+		},
+	}
+	tool := mockTool{
+		root: dir,
+		lockfiles: []Lockfile{
+			{Path: "package-lock.json", Content: []byte("generated-a")},
+			{Path: "npm-shrinkwrap.json", Content: []byte("generated-b")},
+		},
+		bootstrapped: []string{"package-lock.json", "npm-shrinkwrap.json"},
+	}
+
+	restore, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediated)
+	assert.Equal(t, []byte("remediated-a"), mustRead(t, changedPath))
+	assert.Equal(t, []byte("generated-b"), mustRead(t, unchangedPath))
+	require.NoError(t, restore())
+	assert.NoFileExists(t, changedPath)
+	assert.NoFileExists(t, unchangedPath)
+}
+
+type selectingClient struct {
+	resps map[string]services.ComponentResolutionResponse
+}
+
+func (s *selectingClient) GetVersion() (string, error) {
+	return ZeroTouchRemediationMinVersion, nil
+}
+
+func (s *selectingClient) ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {
+	resp := s.resps[req.Lockfile]
+	return &resp, false, nil
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+func TestApplyLockfiles_RejectsSymlinkParentDir(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "package-lock.json"), []byte("secret"), 0644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "module")))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: filepath.Join("module", "package-lock.json"), Content: []byte("remediated")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+
+	data, readErr := os.ReadFile(filepath.Join(outside, "package-lock.json"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "secret", string(data))
 }
 
 func TestApplyLockfiles_RejectsSymlinkLockfile(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260827111619-bee4d60fbdc7
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJ
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049 h1:eogwWAzZFir1suYEgZ4ZrYrch8fhWs7ma2dxv06p/z8=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e h1:jAvx6jwQ/faEyKMfwbcIiTGxwEZfp1w5iWPpXBhulGA=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=


### PR DESCRIPTION
## Summary

Adds a build-tool-neutral **Zero Touch Remediation (ZTR)** package under `artifactory/zerotouchremediation`. Callers opt in with `JFROG_CLI_ZTR_COMPONENTS_ENABLED` (`strconv.ParseBool`: `true`, `TRUE`, `1`, `t`, …). Disabled by default.

When enabled, `RunIfEnabled`:

1. Skips if the command is not in the tool’s `RelevantCommands`.
2. Checks JFrog Xray ≥ `3.154.0` (`ZeroTouchRemediationMinXrayVersion`) for the component-resolution API.
3. Resolves the project root, bootstraps missing lockfiles via the tool, and discovers lock artifacts.
4. Sends each lockfile to Xray and writes returned changes.
5. Returns a restore callback so the **caller** can revert lockfiles if the subsequent build command fails. On success the remediating lockfiles stay on disk.

Operational failures are best-effort: warn/debug and continue. Remediation must not fail the user’s build.

Lockfile writes stay under the project root: relative paths only, refuse `..`, and `Lstat` every path component so a symlink parent cannot redirect the write. Missing leaf files are allowed (bootstrap). Apply failures restore immediately.

This PR is the generic contract and implementation only. It does **not** wire any CLI command.

### Follow-up

- **#544** — opt-in ZTR for `jf npm install` / `jf npm ci` (the path that actually installs from the lockfile).
- **npm publish is out of scope.** `jf npm publish` packs and deploys; it does not resolve or install from the lockfile. `package-lock.json` is omitted from the npm tarball, so lockfile remediation would not change the published artifact. We are not taking that work forward.

### Files

- `artifactory/zerotouchremediation/buildtool.go` — `BuildTool` / `CommandRunner` contracts (per-tool; a manager without a lock artifact returns empty slices and the generic flow skips apply)
- `artifactory/zerotouchremediation/service.go` — gating, Xray call, apply, rollback, symlink checks
- `go.mod` / `go.sum` — `jfrog-client-go` bump for the component-resolution API

## Test plan

- [x] `go test ./artifactory/zerotouchremediation`
- [x] `go vet ./artifactory/zerotouchremediation`