### PR TITLE
Add Zero Touch Remediation to npm publish

### DIFF
--- a/artifactory/commands/npm/common.go
+++ b/artifactory/commands/npm/common.go
@@ -14,6 +14,8 @@ type CommonArgs struct {
 	npmArgs            []string
 	serverDetails      *config.ServerDetails
 	useNative          bool
+	configFilePath     string
+	executablePath     string
 }
 
 func (ca *CommonArgs) SetServerDetails(serverDetails *config.ServerDetails) *CommonArgs {
@@ -42,6 +44,16 @@ func (ca *CommonArgs) UseNative() bool {
 
 func (ca *CommonArgs) SetUseNative(useNpmRc bool) *CommonArgs {
 	ca.useNative = useNpmRc
+	return ca
+}
+
+func (ca *CommonArgs) SetConfigFilePath(configFilePath string) *CommonArgs {
+	ca.configFilePath = configFilePath
+	return ca
+}
+
+func (ca *CommonArgs) SetExecutablePath(executablePath string) *CommonArgs {
+	ca.executablePath = executablePath
 	return ca
 }
 

--- a/artifactory/commands/npm/npmcommand.go
+++ b/artifactory/commands/npm/npmcommand.go
@@ -2,6 +2,7 @@ package npm
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -56,9 +57,8 @@ var (
 
 type NpmCommand struct {
 	CommonArgs
-	cmdName        string
-	jsonOutput     bool
-	executablePath string
+	cmdName    string
+	jsonOutput bool
 	// Function to be called to restore the user's old npmrc and delete the one we created.
 	restoreNpmrcFunc func() error
 	workingDirectory string
@@ -73,6 +73,8 @@ type NpmCommand struct {
 	collectBuildInfo    bool
 	buildInfoModule     *build.NpmModule
 	installHandler      *NpmInstallStrategy
+	// When true, the subsequent install uses npm ci to honor remediated lockfile integrity.
+	remediatedLockfile bool
 	// When true, skips the 404 error handling that checks if packages are blocked by curation
 	disableCVSCheck bool
 }
@@ -351,7 +353,24 @@ func (nc *NpmCommand) Run() (err error) {
 	defer func() {
 		err = errors.Join(err, nc.installHandler.RestoreNpmrc())
 	}()
-	err = nc.installHandler.Install()
+	if !nc.UseNative() {
+		if err = nc.CreateTempNpmrc(); err != nil {
+			return
+		}
+	}
+	var restoreResolution func() error
+	restoreResolution, nc.remediatedLockfile, err = nc.runZeroTouchRemediation(context.Background(), nc.cmdName, nc.workingDirectory, nc.npmArgs)
+	if err != nil {
+		return err
+	}
+	var installErr error
+	defer func() {
+		if installErr != nil && restoreResolution != nil {
+			err = errors.Join(err, restoreResolution())
+		}
+	}()
+	installErr = nc.installHandler.Install()
+	err = installErr
 	if err != nil {
 		if !nc.disableCVSCheck && (nc.cmdName == "install" || nc.cmdName == "ci") {
 			if blockedErr := nc.handle404Errors(err); blockedErr != nil {
@@ -508,8 +527,19 @@ func (nc *NpmCommand) prepareBuildInfoModule() error {
 	return nil
 }
 
+func (nc *NpmCommand) effectiveNpmCommand() string {
+	if nc.remediatedLockfile && nc.cmdName == "install" {
+		return "ci"
+	}
+	return nc.cmdName
+}
+
 func (nc *NpmCommand) collectDependencies() error {
-	nc.buildInfoModule.SetNpmArgs(append([]string{nc.cmdName}, nc.npmArgs...))
+	npmCommand := nc.effectiveNpmCommand()
+	if npmCommand != nc.cmdName {
+		log.Info("Using npm ci after Zero Touch Remediation to install from the remediated lockfile")
+	}
+	nc.buildInfoModule.SetNpmArgs(append([]string{npmCommand}, nc.npmArgs...))
 	return errorutils.CheckError(nc.buildInfoModule.Build())
 }
 

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -3,6 +3,7 @@ package npm
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,7 +38,6 @@ const (
 
 type NpmPublishCommandArgs struct {
 	CommonArgs
-	executablePath         string
 	workingDirectory       string
 	collectBuildInfo       bool
 	packedFilePaths        []string
@@ -79,6 +79,7 @@ func (npc *NpmPublishCommand) ServerDetails() (*config.ServerDetails, error) {
 
 func (npc *NpmPublishCommand) SetConfigFilePath(configFilePath string) *NpmPublishCommand {
 	npc.configFilePath = configFilePath
+	npc.CommonArgs.SetConfigFilePath(configFilePath)
 	return npc
 }
 
@@ -171,6 +172,18 @@ func (npc *NpmPublishCommand) Run() (err error) {
 	err = npc.preparePrerequisites()
 	if err != nil {
 		return err
+	}
+	var restoreResolution func() error
+	if !npc.tarballProvided {
+		restoreResolution, _, err = npc.runZeroTouchRemediationForPublish(context.Background(), "publish", npc.workingDirectory, npc.publishPath, npc.npmArgs)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil && restoreResolution != nil {
+				err = errors.Join(err, restoreResolution())
+			}
+		}()
 	}
 
 	var npmBuild *build.Build

--- a/artifactory/commands/npm/zerotouchremediation.go
+++ b/artifactory/commands/npm/zerotouchremediation.go
@@ -1,0 +1,106 @@
+package npm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gofrogcmd "github.com/jfrog/gofrog/io"
+
+	"github.com/jfrog/jfrog-cli-core/v2/common/project"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/xray"
+
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/zerotouchremediation"
+)
+
+func (ca *CommonArgs) runZeroTouchRemediation(ctx context.Context, command, workingDir string, npmArgs []string) (restore func() error, remediated bool, err error) {
+	if command == "install" && isSinglePackageInstall(npmArgs) {
+		return func() error { return nil }, false, nil
+	}
+	return ca.runZeroTouchRemediationWithTool(ctx, command, workingDir, NewBuildToolWithArgs(npmArgs), BootstrapArgsFrom(npmArgs)...)
+}
+
+func (ca *CommonArgs) runZeroTouchRemediationForPublish(ctx context.Context, command, workingDir, publishPath string, npmArgs []string) (restore func() error, remediated bool, err error) {
+	return ca.runZeroTouchRemediationWithTool(ctx, command, workingDir, NewBuildToolForPublish(workingDir, publishPath, npmArgs), BootstrapArgsFrom(npmArgs)...)
+}
+
+func (ca *CommonArgs) runZeroTouchRemediationWithTool(ctx context.Context, command, workingDir string, tool zerotouchremediation.BuildTool, bootstrapArgs ...string) (restore func() error, remediated bool, err error) {
+	if !zerotouchremediation.IsComponentResolutionEnabled() {
+		return zerotouchremediation.SkipRemediation("Zero Touch Remediation is not enabled", nil)
+	}
+	resolverRepo, resolverErr := ca.resolverRepoForResolution(command)
+	if resolverErr != nil {
+		return zerotouchremediation.SkipRemediation("Zero Touch Remediation skipped: could not determine resolver repo: ", resolverErr)
+	}
+	if resolverRepo == "" {
+		return zerotouchremediation.SkipRemediation("Zero Touch Remediation skipped: resolver repo is empty", nil)
+	}
+	var projectKey string
+	if ca.buildConfiguration != nil {
+		projectKey = ca.buildConfiguration.GetProject()
+	}
+	xrayManager, xrayErr := xray.CreateXrayServiceManager(ca.serverDetails, xray.WithScopedProjectKey(projectKey))
+	if xrayErr != nil {
+		return zerotouchremediation.SkipRemediation("Zero Touch Remediation skipped: could not create Xray service manager: ", xrayErr)
+	}
+	return zerotouchremediation.RunIfEnabled(ctx, xrayManager, resolverRepo, tool, command, workingDir, ca.npmBootstrapRunner(), bootstrapArgs...)
+}
+
+// resolverRepoForResolution returns the Artifactory virtual repo for dependency policy scope.
+func (ca *CommonArgs) resolverRepoForResolution(command string) (string, error) {
+	if command != "publish" && ca.repo != "" {
+		return ca.repo, nil
+	}
+	if ca.configFilePath != "" {
+		vConfig, err := project.ReadConfigFile(ca.configFilePath, project.YAML)
+		if err != nil {
+			return "", fmt.Errorf("failed to read config file: %w", err)
+		}
+		resolverConfig, err := project.GetRepoConfigByPrefix(ca.configFilePath, project.ProjectConfigResolverPrefix, vConfig)
+		if err != nil {
+			return "", fmt.Errorf("failed to get resolver config: %w", err)
+		}
+		return resolverConfig.TargetRepo(), nil
+	}
+	if ca.executablePath != "" {
+		registryURL, err := ca.getNpmRegistryURL()
+		if err != nil {
+			return "", fmt.Errorf("failed to get registry URL: %w", err)
+		}
+		return extractRepoName(registryURL)
+	}
+	return ca.repo, nil
+}
+
+func (ca *CommonArgs) getNpmRegistryURL() (string, error) {
+	configCommand := gofrogcmd.Command{
+		Executable: ca.executablePath,
+		CmdName:    "config",
+		CmdArgs:    []string{"get", "registry"},
+	}
+	data, err := configCommand.RunWithOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (ca *CommonArgs) npmBootstrapRunner() zerotouchremediation.CommandRunner {
+	return func(ctx context.Context, projectRoot string, args ...string) error {
+		return runNpmAt(ctx, ca.executablePath, projectRoot, args...)
+	}
+}
+
+func runNpmAt(_ context.Context, executablePath, projectRoot string, args ...string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	cmd := gofrogcmd.NewCommand(executablePath, args[0], args[1:])
+	cmd.Dir = projectRoot
+	_, err := cmd.RunWithOutput()
+	return err
+}
+
+func isSinglePackageInstall(npmArgs []string) bool {
+	return HasPackageOperands(npmArgs)
+}

--- a/artifactory/commands/npm/zerotouchremediation_test.go
+++ b/artifactory/commands/npm/zerotouchremediation_test.go
@@ -1,0 +1,79 @@
+package npm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jfrog/jfrog-client-go/xray/services"
+
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/zerotouchremediation"
+)
+
+type countingZTRClient struct {
+	calls int
+}
+
+func (c *countingZTRClient) GetVersion() (string, error) {
+	return zerotouchremediation.ZeroTouchRemediationMinVersion, nil
+}
+
+func (c *countingZTRClient) ZeroTouchRemediation(_ services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {
+	c.calls++
+	return &services.ComponentResolutionResponse{
+		Changes: []services.Change{{Package: "lodash"}},
+	}, false, nil
+}
+
+func TestRunZeroTouchRemediation_DisabledByDefault(t *testing.T) {
+	t.Setenv(zerotouchremediation.ZtrComponentsEnabledEnvVar, "")
+	ca := &CommonArgs{}
+	ca.SetRepo("npm-virtual").SetServerDetails(nil)
+	_, remediated, err := ca.runZeroTouchRemediation(t.Context(), "install", t.TempDir(), nil)
+	assert.NoError(t, err)
+	assert.False(t, remediated)
+}
+
+func TestEffectiveNpmCommandAfterRemediation(t *testing.T) {
+	nc := &NpmCommand{cmdName: "install", remediatedLockfile: true}
+	assert.Equal(t, "ci", nc.effectiveNpmCommand())
+
+	nc.remediatedLockfile = false
+	assert.Equal(t, "install", nc.effectiveNpmCommand())
+
+	nc.cmdName = "ci"
+	nc.remediatedLockfile = true
+	assert.Equal(t, "ci", nc.effectiveNpmCommand())
+}
+
+func TestIsSinglePackageInstall(t *testing.T) {
+	assert.True(t, isSinglePackageInstall([]string{"lodash"}))
+	assert.True(t, isSinglePackageInstall([]string{"--save", "lodash"}))
+	assert.False(t, isSinglePackageInstall([]string{"--verbose"}))
+	assert.False(t, isSinglePackageInstall([]string{"-w", "app"}))
+	assert.False(t, isSinglePackageInstall([]string{"--workspace", "@scope/pkg"}))
+	assert.False(t, isSinglePackageInstall([]string{"--prefix", "packages/app"}))
+	assert.False(t, isSinglePackageInstall([]string{"--registry", "https://registry.example"}))
+	assert.False(t, isSinglePackageInstall([]string{"--tag", "next"}))
+	assert.False(t, isSinglePackageInstall([]string{"--omit", "dev"}))
+	assert.False(t, isSinglePackageInstall(nil))
+}
+
+func TestRunIfEnabled_SkipsSymlinkedLockfile(t *testing.T) {
+	t.Setenv(zerotouchremediation.ZtrComponentsEnabledEnvVar, "true")
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.lock")
+	require.NoError(t, os.WriteFile(outside, []byte("secret-from-outside"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "package-lock.json")))
+
+	client := &countingZTRClient{}
+	_, remediated, err := zerotouchremediation.RunIfEnabled(context.Background(), client, "npm-virtual", NewBuildTool(), "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.calls)
+}

--- a/artifactory/commands/npm/ztr_args_parse.go
+++ b/artifactory/commands/npm/ztr_args_parse.go
@@ -1,0 +1,99 @@
+package npm
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+type discoveryOptions struct {
+	prefixDir   string
+	publishPath string
+}
+
+type npmCLIArgs struct {
+	prefixDir       string
+	bootstrapArgs   []string
+	packageOperands []string
+}
+
+func parseNpmCLIArgs(args []string) npmCLIArgs {
+	var out npmCLIArgs
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--prefix" || arg == "--cwd" || arg == "-C":
+			if i+1 < len(args) {
+				i++
+				out.prefixDir = args[i]
+			}
+		case strings.HasPrefix(arg, "--prefix="):
+			out.prefixDir = strings.TrimPrefix(arg, "--prefix=")
+		case strings.HasPrefix(arg, "--cwd="):
+			out.prefixDir = strings.TrimPrefix(arg, "--cwd=")
+		case strings.HasPrefix(arg, "-C") && arg != "-C":
+			out.prefixDir = strings.TrimPrefix(arg, "-C")
+		case arg == "--workspaces":
+			out.bootstrapArgs = append(out.bootstrapArgs, arg)
+		case arg == "--workspace" || arg == "-w":
+			if i+1 < len(args) {
+				i++
+				out.bootstrapArgs = append(out.bootstrapArgs, arg, args[i])
+			}
+		case strings.HasPrefix(arg, "--workspace="):
+			out.bootstrapArgs = append(out.bootstrapArgs, arg)
+		case strings.HasPrefix(arg, "-w=") && len(arg) > 3:
+			out.bootstrapArgs = append(out.bootstrapArgs, arg)
+		case arg == "--registry" || arg == "--tag" || arg == "--omit":
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+		case strings.HasPrefix(arg, "-"):
+			continue
+		default:
+			out.packageOperands = append(out.packageOperands, arg)
+		}
+	}
+	return out
+}
+
+// HasPackageOperands reports whether npmArgs include a package name (not an option value).
+func HasPackageOperands(npmArgs []string) bool {
+	return len(parseNpmCLIArgs(npmArgs).packageOperands) > 0
+}
+
+// BootstrapArgsFrom extracts workspace flags to pass to npm install --package-lock-only.
+func BootstrapArgsFrom(npmArgs []string) []string {
+	return parseNpmCLIArgs(npmArgs).bootstrapArgs
+}
+
+func effectiveStartDir(workingDir string, opts discoveryOptions) (string, error) {
+	abs, err := filepath.Abs(workingDir)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if opts.publishPath != "" {
+		return resolveDiscoveryPath(abs, opts.publishPath)
+	}
+	if opts.prefixDir != "" {
+		return resolveDiscoveryPath(abs, opts.prefixDir)
+	}
+	return abs, nil
+}
+
+// resolveDiscoveryPath joins base and p unless p is already absolute.
+// On Windows, Unix-style paths (e.g. /repo/pkg) are not filepath.IsAbs but must not be joined with base.
+func resolveDiscoveryPath(base, p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p), nil
+	}
+	if strings.HasPrefix(filepath.ToSlash(p), "/") {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return "", errorutils.CheckError(err)
+		}
+		return filepath.Clean(abs), nil
+	}
+	return filepath.Clean(filepath.Join(base, p)), nil
+}

--- a/artifactory/commands/npm/ztr_args_parse_test.go
+++ b/artifactory/commands/npm/ztr_args_parse_test.go
@@ -1,0 +1,109 @@
+package npm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNpmCLIArgs_Prefix(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"install", "--prefix", "sub/pkg"})
+	assert.Equal(t, "sub/pkg", opts.prefixDir)
+}
+
+func TestParseNpmCLIArgs_CShort(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"-C", "services/api", "ci"})
+	assert.Equal(t, "services/api", opts.prefixDir)
+}
+
+func TestParseNpmCLIArgs_PrefixEquals(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"install", "--prefix=frontend"})
+	assert.Equal(t, "frontend", opts.prefixDir)
+}
+
+func TestParseNpmCLIArgs_WorkspaceBootstrap(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"install", "--workspace", "@scope/pkg", "-w", "app"})
+	assert.Equal(t, []string{"--workspace", "@scope/pkg", "-w", "app"}, opts.bootstrapArgs)
+}
+
+func TestParseNpmCLIArgs_ShortWorkspaceConsumesValue(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"-w", "app"})
+	assert.Equal(t, []string{"-w", "app"}, opts.bootstrapArgs)
+	assert.Empty(t, opts.packageOperands)
+}
+
+func TestParseNpmCLIArgs_ShortWorkspaceEquals(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"install", "-w=app"})
+	assert.Equal(t, []string{"-w=app"}, opts.bootstrapArgs)
+}
+
+func TestParseNpmCLIArgs_WorkspacesBooleanUnchanged(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"install", "--workspaces"})
+	assert.Equal(t, []string{"--workspaces"}, opts.bootstrapArgs)
+}
+
+func TestParseNpmCLIArgs_PackageOperandsSkipOptionValues(t *testing.T) {
+	opts := parseNpmCLIArgs([]string{"--save", "lodash"})
+	assert.Equal(t, []string{"lodash"}, opts.packageOperands)
+
+	opts = parseNpmCLIArgs([]string{"--prefix", "packages/app", "lodash"})
+	assert.Equal(t, []string{"lodash"}, opts.packageOperands)
+	assert.Equal(t, "packages/app", opts.prefixDir)
+
+	opts = parseNpmCLIArgs([]string{"--verbose"})
+	assert.Empty(t, opts.packageOperands)
+}
+
+func TestEffectiveStartDir_PublishPathOverridesCwd(t *testing.T) {
+	root := t.TempDir()
+	publishPath := filepath.Join(root, "packages", "foo")
+	got, err := effectiveStartDir(root, discoveryOptions{publishPath: publishPath})
+	assert.NoError(t, err)
+	assert.Equal(t, publishPath, got)
+}
+
+func TestEffectiveStartDir_PublishPathUnixAbsolute(t *testing.T) {
+	got, err := effectiveStartDir("/repo", discoveryOptions{publishPath: "/repo/packages/foo"})
+	assert.NoError(t, err)
+	want, err := filepath.Abs("/repo/packages/foo")
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestEffectiveStartDir_PrefixFromArgs(t *testing.T) {
+	root := t.TempDir()
+	got, err := effectiveStartDir(root, discoveryOptions{prefixDir: "sub"})
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "sub"), got)
+}
+
+func TestEffectiveStartDir_PrefixFromArgsUnixRoot(t *testing.T) {
+	got, err := effectiveStartDir("/repo", discoveryOptions{prefixDir: "sub"})
+	assert.NoError(t, err)
+	root, err := filepath.Abs("/repo")
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "sub"), got)
+}
+
+func TestBootstrapArgsFrom(t *testing.T) {
+	assert.Equal(t, []string{"-w", "app"}, BootstrapArgsFrom([]string{"install", "-w", "app"}))
+	assert.Empty(t, BootstrapArgsFrom([]string{"install", "-w"}))
+}
+
+func TestHasPackageOperands(t *testing.T) {
+	assert.True(t, HasPackageOperands([]string{"lodash"}))
+	assert.True(t, HasPackageOperands([]string{"--save", "lodash"}))
+	assert.False(t, HasPackageOperands([]string{"--verbose"}))
+	assert.False(t, HasPackageOperands([]string{"-w", "app"}))
+	assert.False(t, HasPackageOperands([]string{"--workspace", "@scope/pkg"}))
+	assert.False(t, HasPackageOperands(nil))
+	assert.False(t, HasPackageOperands([]string{"--registry", "https://registry.example"}))
+	assert.False(t, HasPackageOperands([]string{"--registry=https://registry.example"}))
+	assert.False(t, HasPackageOperands([]string{"--tag", "next"}))
+	assert.False(t, HasPackageOperands([]string{"--tag=next"}))
+	assert.False(t, HasPackageOperands([]string{"--omit", "dev"}))
+	assert.False(t, HasPackageOperands([]string{"--omit=dev"}))
+	assert.True(t, HasPackageOperands([]string{"--registry", "https://registry.example", "lodash"}))
+	assert.True(t, HasPackageOperands([]string{"--omit", "dev", "lodash"}))
+}

--- a/artifactory/commands/npm/ztr_buildtool.go
+++ b/artifactory/commands/npm/ztr_buildtool.go
@@ -1,0 +1,91 @@
+package npm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/zerotouchremediation"
+)
+
+const toolName = "npm"
+
+type BuildTool struct {
+	opts discoveryOptions
+}
+
+func NewBuildTool() BuildTool {
+	return BuildTool{}
+}
+
+func NewBuildToolWithArgs(npmArgs []string) BuildTool {
+	parsed := parseNpmCLIArgs(npmArgs)
+	return BuildTool{opts: discoveryOptions{prefixDir: parsed.prefixDir}}
+}
+
+func NewBuildToolForPublish(workingDir, publishPath string, npmArgs []string) BuildTool {
+	parsed := parseNpmCLIArgs(npmArgs)
+	return BuildTool{opts: discoveryOptions{
+		prefixDir:   parsed.prefixDir,
+		publishPath: publishPath,
+	}}
+}
+
+func (BuildTool) ToolName() string { return toolName }
+
+func (BuildTool) RelevantCommands() []string {
+	return []string{"install", "ci", "publish"}
+}
+
+func (t BuildTool) ProjectRoot(workingDir string) (string, error) {
+	return discoverProjectRootWithOptions(workingDir, t.opts)
+}
+
+func (t BuildTool) EnsureLockfiles(ctx context.Context, projectRoot, command string, runner zerotouchremediation.CommandRunner, bootstrapArgs ...string) ([]string, error) {
+	if _, err := os.Stat(filepath.Join(projectRoot, shrinkwrapFileName)); err == nil {
+		return nil, nil
+	} else if !os.IsNotExist(err) {
+		return nil, errorutils.CheckError(err)
+	}
+	lockPath := filepath.Join(projectRoot, lockfileName)
+	if _, err := os.Stat(lockPath); err == nil {
+		return nil, nil
+	} else if !os.IsNotExist(err) {
+		return nil, errorutils.CheckError(err)
+	}
+	switch command {
+	case "ci":
+		return nil, errorutils.CheckErrorf("Zero Touch Remediation requires %s or %s for npm ci (generate with npm install first)", lockfileName, shrinkwrapFileName)
+	case "install", "publish":
+		if runner == nil {
+			return nil, errorutils.CheckErrorf("npm runner required to bootstrap %s", lockfileName)
+		}
+		log.Info("Zero Touch Remediation: generating ", lockfileName, " (lockfile was missing)")
+		args := append([]string{"install", "--package-lock-only"}, bootstrapArgs...)
+		if err := runner(ctx, projectRoot, args...); err != nil {
+			return nil, errorutils.CheckError(err)
+		}
+		return []string{lockfileName}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (t BuildTool) DiscoverLockfiles(workingDir string) ([]zerotouchremediation.Lockfile, error) {
+	root, err := discoverProjectRootWithOptions(workingDir, t.opts)
+	if err != nil {
+		return nil, err
+	}
+	name, err := lockfileNameInDir(root)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	return []zerotouchremediation.Lockfile{{Path: name, Content: data}}, nil
+}

--- a/artifactory/commands/npm/ztr_buildtool_test.go
+++ b/artifactory/commands/npm/ztr_buildtool_test.go
@@ -1,0 +1,137 @@
+package npm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNpmBuildTool_DiscoverLockfiles_SingleRootLock(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"lock":true}`), 0644))
+
+	tool := NewBuildTool()
+	files, err := tool.DiscoverLockfiles(dir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "package-lock.json", files[0].Path)
+	assert.JSONEq(t, `{"lock":true}`, string(files[0].Content))
+}
+
+func TestNpmBuildTool_DiscoverLockfiles_Shrinkwrap(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"a"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "npm-shrinkwrap.json"), []byte(`{"s":1}`), 0644))
+
+	tool := NewBuildTool()
+	files, err := tool.DiscoverLockfiles(dir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "npm-shrinkwrap.json", files[0].Path)
+}
+
+func TestNpmBuildTool_DiscoverLockfiles_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.lock")
+	require.NoError(t, os.WriteFile(outside, []byte("secret-from-outside"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "package-lock.json")))
+
+	files, err := NewBuildTool().DiscoverLockfiles(dir)
+	require.Error(t, err)
+	assert.Empty(t, files)
+}
+
+func TestNpmBuildTool_EnsureLockfiles_SkipsWhenShrinkwrapExists(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"a"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "npm-shrinkwrap.json"), []byte(`{}`), 0644))
+
+	called := false
+	runner := func(context.Context, string, ...string) error { called = true; return nil }
+
+	tool := NewBuildTool()
+	_, err := tool.EnsureLockfiles(context.Background(), dir, "install", runner)
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func TestNpmBuildTool_EnsureLockfiles_CiRequiresExistingLock(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+
+	tool := NewBuildTool()
+	_, err := tool.EnsureLockfiles(context.Background(), dir, "ci", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package-lock.json")
+}
+
+func TestNpmBuildTool_EnsureLockfiles_InstallBootstrapsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+
+	var ran []string
+	runner := func(_ context.Context, root string, args ...string) error {
+		ran = append(ran, root+":"+strings.Join(args, " "))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "package-lock.json"), []byte(`{"bootstrapped":true}`), 0644))
+		return nil
+	}
+
+	tool := NewBuildTool()
+	bootstrapped, err := tool.EnsureLockfiles(context.Background(), dir, "install", runner)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"package-lock.json"}, bootstrapped)
+	assert.Contains(t, ran[0], "install --package-lock-only")
+}
+
+func TestNpmBuildTool_EnsureLockfiles_SkipsBootstrapWhenLockExists(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{}`), 0644))
+
+	called := false
+	runner := func(context.Context, string, ...string) error {
+		called = true
+		return nil
+	}
+
+	tool := NewBuildTool()
+	_, err := tool.EnsureLockfiles(context.Background(), dir, "install", runner)
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func TestNpmBuildTool_EnsureLockfiles_PassesWorkspaceFlags(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+
+	var ran []string
+	runner := func(_ context.Context, root string, args ...string) error {
+		ran = append(ran, strings.Join(args, " "))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "package-lock.json"), []byte(`{}`), 0644))
+		return nil
+	}
+
+	tool := NewBuildTool()
+	_, err := tool.EnsureLockfiles(context.Background(), dir, "publish", runner, "--workspaces")
+	require.NoError(t, err)
+	assert.Contains(t, ran[0], "--workspaces")
+}
+
+func TestNewBuildToolWithArgs_Prefix(t *testing.T) {
+	tool := NewBuildToolWithArgs([]string{"install", "--prefix", "frontend"})
+	root := t.TempDir()
+	sub := filepath.Join(root, "frontend")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "package.json"), []byte(`{"name":"fe"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "package-lock.json"), []byte(`{}`), 0644))
+
+	got, err := tool.ProjectRoot(root)
+	require.NoError(t, err)
+	assert.Equal(t, sub, got)
+}

--- a/artifactory/commands/npm/ztr_discover.go
+++ b/artifactory/commands/npm/ztr_discover.go
@@ -1,0 +1,108 @@
+package npm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+const (
+	lockfileName       = "package-lock.json"
+	shrinkwrapFileName = "npm-shrinkwrap.json"
+)
+
+func discoverProjectRoot(workingDir string) (string, error) {
+	return discoverProjectRootWithOptions(workingDir, discoveryOptions{})
+}
+
+func discoverProjectRootWithOptions(workingDir string, opts discoveryOptions) (string, error) {
+	startDir, err := effectiveStartDir(workingDir, opts)
+	if err != nil {
+		return "", err
+	}
+	dir := startDir
+	var firstPackageJSON string
+	var topWorkspaceRoot string
+	for {
+		pkgPath := filepath.Join(dir, "package.json")
+		if _, statErr := os.Stat(pkgPath); statErr == nil {
+			if firstPackageJSON == "" {
+				firstPackageJSON = dir
+			}
+			if data, readErr := os.ReadFile(pkgPath); readErr == nil {
+				if pkg, parseErr := parsePackageJSON(data); parseErr == nil && pkg.hasWorkspaces() {
+					topWorkspaceRoot = dir
+				}
+			}
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, shrinkwrapFileName)); statErr == nil {
+			return dir, nil
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, lockfileName)); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	if topWorkspaceRoot != "" {
+		return topWorkspaceRoot, nil
+	}
+	if firstPackageJSON != "" {
+		return firstPackageJSON, nil
+	}
+	return "", errorutils.CheckErrorf("no %s or lockfile found from %s", "package.json", startDir)
+}
+
+func lockfileNameInDir(dir string) (string, error) {
+	for _, name := range []string{shrinkwrapFileName, lockfileName} {
+		info, err := os.Lstat(filepath.Join(dir, name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", errorutils.CheckError(err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		return name, nil
+	}
+	return "", errorutils.CheckErrorf("no %s or %s under %s", shrinkwrapFileName, lockfileName, dir)
+}
+
+type packageJSON struct {
+	Workspaces json.RawMessage `json:"workspaces"`
+}
+
+func parsePackageJSON(data []byte) (packageJSON, error) {
+	var p packageJSON
+	if err := json.Unmarshal(data, &p); err != nil {
+		return packageJSON{}, err
+	}
+	return p, nil
+}
+
+func (p packageJSON) hasWorkspaces() bool {
+	if len(p.Workspaces) == 0 || string(p.Workspaces) == "null" {
+		return false
+	}
+	if string(p.Workspaces) == "[]" {
+		return false
+	}
+	var arr []any
+	if json.Unmarshal(p.Workspaces, &arr) == nil {
+		return len(arr) > 0
+	}
+	var obj struct {
+		Packages []any `json:"packages"`
+	}
+	if json.Unmarshal(p.Workspaces, &obj) == nil {
+		return len(obj.Packages) > 0
+	}
+	return true
+}

--- a/artifactory/commands/npm/ztr_discover_test.go
+++ b/artifactory/commands/npm/ztr_discover_test.go
@@ -1,0 +1,116 @@
+package npm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverProjectRoot_FromWorkspacePackage(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "packages", "app")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"workspaces":["packages/*"]}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package-lock.json"), []byte(`{}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"name":"app"}`), 0644))
+
+	got, err := discoverProjectRoot(pkgDir)
+	require.NoError(t, err)
+	assert.Equal(t, root, got)
+}
+
+func TestDiscoverProjectRoot_PrefixFlag(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "frontend")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "package.json"), []byte(`{"name":"fe"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "package-lock.json"), []byte(`{}`), 0644))
+
+	got, err := discoverProjectRootWithOptions(root, discoveryOptions{prefixDir: "frontend"})
+	require.NoError(t, err)
+	assert.Equal(t, sub, got)
+}
+
+func TestDiscoverProjectRoot_ShrinkwrapPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"app"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"lock":1}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "npm-shrinkwrap.json"), []byte(`{"shrink":1}`), 0644))
+
+	name, err := lockfileNameInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, shrinkwrapFileName, name)
+}
+
+func TestDiscoverProjectRoot_IndependentPackageLock(t *testing.T) {
+	root := t.TempDir()
+	svc := filepath.Join(root, "svc-a")
+	require.NoError(t, os.MkdirAll(svc, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"name":"root-no-ws"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(svc, "package.json"), []byte(`{"name":"svc-a"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(svc, "package-lock.json"), []byte(`{}`), 0644))
+
+	got, err := discoverProjectRoot(svc)
+	require.NoError(t, err)
+	assert.Equal(t, svc, got)
+}
+
+func TestDiscoverProjectRoot_NoProjectFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := discoverProjectRoot(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package.json")
+}
+
+func TestDiscoverProjectRoot_IgnoresStrayPackageJSONWhenLockAbove(t *testing.T) {
+	root := t.TempDir()
+	svc := filepath.Join(root, "svc")
+	stray := filepath.Join(svc, "samples")
+	require.NoError(t, os.MkdirAll(stray, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(svc, "package.json"), []byte(`{"name":"svc"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(svc, "package-lock.json"), []byte(`{}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(stray, "package.json"), []byte(`{"name":"sample"}`), 0644))
+
+	got, err := discoverProjectRoot(stray)
+	require.NoError(t, err)
+	assert.Equal(t, svc, got)
+}
+
+func TestDiscoverProjectRoot_PublishPath(t *testing.T) {
+	root := t.TempDir()
+	pkg := filepath.Join(root, "packages", "lib")
+	require.NoError(t, os.MkdirAll(pkg, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg, "package.json"), []byte(`{"name":"lib"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg, "package-lock.json"), []byte(`{}`), 0644))
+
+	got, err := discoverProjectRootWithOptions(root, discoveryOptions{publishPath: filepath.Join("packages", "lib")})
+	require.NoError(t, err)
+	assert.Equal(t, pkg, got)
+}
+
+func TestParsePackageJSON_WorkspacesArray(t *testing.T) {
+	p, err := parsePackageJSON([]byte(`{"workspaces":["packages/*"]}`))
+	require.NoError(t, err)
+	assert.True(t, p.hasWorkspaces())
+}
+
+func TestParsePackageJSON_WorkspacesObject(t *testing.T) {
+	p, err := parsePackageJSON([]byte(`{"workspaces":{"packages":["apps/*"],"nohoist":["**/react-native"]}}`))
+	require.NoError(t, err)
+	assert.True(t, p.hasWorkspaces())
+}
+
+func TestParsePackageJSON_NoWorkspaces(t *testing.T) {
+	p, err := parsePackageJSON([]byte(`{"name":"app"}`))
+	require.NoError(t, err)
+	assert.False(t, p.hasWorkspaces())
+}
+
+func TestParsePackageJSON_EmptyWorkspacesArray(t *testing.T) {
+	p, err := parsePackageJSON([]byte(`{"workspaces":[]}`))
+	require.NoError(t, err)
+	assert.False(t, p.hasWorkspaces())
+}

--- a/artifactory/zerotouchremediation/buildtool.go
+++ b/artifactory/zerotouchremediation/buildtool.go
@@ -1,0 +1,26 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"slices"
+)
+
+// CommandRunner runs a build-tool subprocess (injected for tests).
+type CommandRunner func(ctx context.Context, projectRoot string, args ...string) error
+
+// BuildTool describes a package manager for the generic resolution flow.
+type BuildTool interface {
+	ToolName() string
+	RelevantCommands() []string
+	// ProjectRoot resolves monorepo/reactor/solution root from workingDir.
+	ProjectRoot(workingDir string) (string, error)
+	// EnsureLockfiles materializes expected lock artifacts when absent and the command allows it.
+	// Returns paths (relative to project root) that were bootstrapped and did not exist before.
+	EnsureLockfiles(ctx context.Context, projectRoot, command string, runner CommandRunner, bootstrapArgs ...string) (bootstrapped []string, err error)
+	// DiscoverLockfiles returns all lockfiles (paths relative to project root).
+	DiscoverLockfiles(workingDir string) ([]Lockfile, error)
+}
+
+func IsRelevantCommand(tool BuildTool, command string) bool {
+	return slices.Contains(tool.RelevantCommands(), command)
+}

--- a/artifactory/zerotouchremediation/buildtool_test.go
+++ b/artifactory/zerotouchremediation/buildtool_test.go
@@ -1,0 +1,30 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeTool struct {
+	name     string
+	commands []string
+}
+
+func (f fakeTool) ToolName() string                       { return f.name }
+func (f fakeTool) RelevantCommands() []string             { return f.commands }
+func (f fakeTool) ProjectRoot(dir string) (string, error) { return dir, nil }
+func (f fakeTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunner, _ ...string) ([]string, error) {
+	return nil, nil
+}
+func (f fakeTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
+	return []Lockfile{{Path: "lock.json", Content: []byte(`{}`)}}, nil
+}
+
+func TestIsRelevantCommand(t *testing.T) {
+	tool := fakeTool{name: "fake", commands: []string{"install", "ci"}}
+	assert.True(t, IsRelevantCommand(tool, "install"))
+	assert.True(t, IsRelevantCommand(tool, "ci"))
+	assert.False(t, IsRelevantCommand(tool, "publish"))
+}

--- a/artifactory/zerotouchremediation/service.go
+++ b/artifactory/zerotouchremediation/service.go
@@ -1,0 +1,244 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+// ZtrComponentsEnabledEnvVar enables Zero Touch Remediation when set to "true".
+// Feature is disabled by default.
+const ZtrComponentsEnabledEnvVar = "JFROG_CLI_ZTR_COMPONENTS_ENABLED"
+
+const ZeroTouchRemediationMinVersion = "3.154.0"
+
+var noopRestore = func() error { return nil }
+
+// writeFile is os.WriteFile; tests replace it to simulate truncate-then-fail.
+var writeFile = os.WriteFile
+
+// SkipRemediation logs and returns without error. Zero Touch Remediation is best-effort and must not fail the caller's build.
+func SkipRemediation(message string, cause error) (func() error, bool, error) {
+	if cause != nil {
+		log.Debug(message + cause.Error())
+	} else {
+		log.Debug(message)
+	}
+	return noopRestore, false, nil
+}
+
+func skipRemediationWarn(message string, cause error) (func() error, bool, error) {
+	if cause != nil {
+		log.Warn(message + cause.Error())
+	} else {
+		log.Warn(message)
+	}
+	return noopRestore, false, nil
+}
+
+func IsComponentResolutionEnabled() bool {
+	return os.Getenv(ZtrComponentsEnabledEnvVar) == "true"
+}
+
+// Lockfile is a CLI-side lock artifact. Path is relative to project root (read/write only — not sent to Xray).
+type Lockfile struct {
+	Path    string
+	Content []byte
+}
+
+type lockfileBackup struct {
+	path    string
+	content []byte // nil means the file did not exist before apply
+}
+
+// ComponentResolutionClient resolves a single lockfile via Xray.
+type ComponentResolutionClient interface {
+	GetVersion() (string, error)
+	ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error)
+}
+
+// RunIfEnabled ensures lockfiles exist, discovers them, calls Xray once per file, writes remediated lockfiles when changes returned.
+// Operational failures are skipped (warn + continue) so remediation never fails the caller's build.
+// Returns a restore function to revert lockfile writes if the subsequent build-tool command fails, and remediated=true when at least one lockfile was updated.
+func RunIfEnabled(ctx context.Context, client ComponentResolutionClient, repo string, tool BuildTool, command, workingDir string, runner CommandRunner, bootstrapArgs ...string) (restore func() error, remediated bool, err error) {
+	if !IsComponentResolutionEnabled() || !IsRelevantCommand(tool, command) {
+		log.Debug("Zero Touch Remediation disabled or not relevant command: ", command)
+		return noopRestore, false, nil
+	}
+	version, err := client.GetVersion()
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not get Xray version: ", err)
+	}
+	log.Debug("Xray version: ", version)
+	if versionErr := clientutils.ValidateMinimumVersion(clientutils.Xray, version, ZeroTouchRemediationMinVersion); versionErr != nil {
+		return skipRemediationWarn("Zero Touch Remediation is not supported on the current Xray version. ", versionErr)
+	}
+	log.Debug("Running Zero Touch Remediation at '"+repo+"' RT repository for tool:", tool.ToolName())
+	projectRoot, err := tool.ProjectRoot(workingDir)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not resolve project root: ", err)
+	}
+	log.Debug("Ensuring lockfiles in project root: ", projectRoot)
+	bootstrapped, err := tool.EnsureLockfiles(ctx, projectRoot, command, runner, bootstrapArgs...)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+	}
+	lockfiles, err := tool.DiscoverLockfiles(workingDir)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: could not discover lockfiles: ", err)
+	}
+	log.Debug("Discovered lockfiles: ", getLockfilePaths(lockfiles))
+	var toWrite []Lockfile
+	var totalChanges int
+	for _, lf := range lockfiles {
+		resp, disabled, err := client.ZeroTouchRemediation(services.ComponentResolutionRequest{
+			BuildTool: tool.ToolName(),
+			Repo:      repo,
+			Lockfile:  string(lf.Content),
+		})
+		if err != nil {
+			return skipRemediationWarn("Zero Touch Remediation skipped: ", err)
+		}
+		if disabled {
+			log.Debug("Zero Touch Remediation skipped: the service is disabled on the server")
+			return noopRestore, false, nil
+		}
+		if len(resp.Changes) == 0 {
+			log.Debug("No changes for ", lf.Path)
+			continue
+		}
+		toWrite = append(toWrite, Lockfile{Path: lf.Path, Content: []byte(resp.Lockfile)})
+		totalChanges += len(resp.Changes)
+		log.Debug("Remediated", lf.Path, "with", len(resp.Changes), "package change(s)")
+		for _, ch := range resp.Changes {
+			log.Debug("  ", ch.Package, ":", ch.BeforeIntegrity, "→", ch.AfterIntegrity)
+		}
+	}
+	if len(toWrite) == 0 {
+		return noopRestore, false, nil
+	}
+	log.Debug("Applying", len(toWrite), "remediated lockfile(s)...")
+	restore, err = ApplyLockfiles(projectRoot, toWrite, bootstrapped)
+	if err != nil {
+		return skipRemediationWarn("Zero Touch Remediation skipped: failed to apply remediated lockfiles: ", err)
+	}
+	log.Info("Zero Touch Remediation applied", totalChanges, "package change(s) across", len(toWrite), "lockfile(s)")
+	return restore, true, nil
+}
+
+func getLockfilePaths(lockfiles []Lockfile) []string {
+	paths := make([]string, 0, len(lockfiles))
+	for _, lf := range lockfiles {
+		paths = append(paths, lf.Path)
+	}
+	return paths
+}
+
+// ApplyLockfiles backs up existing lockfiles under projectRoot, writes updates, returns restore func.
+// Paths listed in treatAsAbsent are restored by deletion even if they exist on disk (bootstrapped locks).
+func ApplyLockfiles(projectRoot string, lockfiles []Lockfile, treatAsAbsent []string) (restore func() error, err error) {
+	if len(lockfiles) == 0 {
+		return func() error { return nil }, nil
+	}
+
+	absent := make(map[string]bool, len(treatAsAbsent))
+	for _, path := range treatAsAbsent {
+		absent[path] = true
+	}
+
+	var backups []lockfileBackup
+	restoreWritten := func() error {
+		var restoreErr error
+		for _, backup := range backups {
+			if rbErr := restoreLockfileBackup(backup); rbErr != nil {
+				restoreErr = errors.Join(restoreErr, rbErr)
+			}
+		}
+		return restoreErr
+	}
+	fail := func(cause error) (func() error, error) {
+		if rbErr := restoreWritten(); rbErr != nil {
+			return nil, errors.Join(errorutils.CheckError(cause), rbErr)
+		}
+		return nil, errorutils.CheckError(cause)
+	}
+
+	for _, lf := range lockfiles {
+		fullPath, pathErr := containedLockfilePath(projectRoot, lf.Path)
+		if pathErr != nil {
+			return fail(pathErr)
+		}
+		if linkErr := rejectSymlink(fullPath); linkErr != nil {
+			return fail(linkErr)
+		}
+		backup := lockfileBackup{path: fullPath}
+		if !absent[lf.Path] {
+			data, readErr := os.ReadFile(fullPath)
+			if readErr == nil {
+				backup.content = data
+			} else if !os.IsNotExist(readErr) {
+				return fail(readErr)
+			}
+		}
+
+		backups = append(backups, backup)
+		if err = os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return fail(err)
+		}
+		if err = writeFile(fullPath, lf.Content, 0644); err != nil {
+			return fail(err)
+		}
+	}
+
+	return restoreWritten, nil
+}
+
+func restoreLockfileBackup(backup lockfileBackup) error {
+	if backup.content == nil {
+		if err := os.Remove(backup.path); err != nil && !os.IsNotExist(err) {
+			return errorutils.CheckError(err)
+		}
+		return nil
+	}
+	return errorutils.CheckError(os.WriteFile(backup.path, backup.content, 0644))
+}
+
+func containedLockfilePath(projectRoot, rel string) (string, error) {
+	if rel == "" || filepath.IsAbs(rel) {
+		return "", errorutils.CheckErrorf("lockfile path %q is not relative to the project root", rel)
+	}
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	full := filepath.Clean(filepath.Join(root, rel))
+	relToRoot, err := filepath.Rel(root, full)
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(os.PathSeparator)) {
+		return "", errorutils.CheckErrorf("lockfile path %q escapes project root", rel)
+	}
+	return full, nil
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errorutils.CheckError(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errorutils.CheckErrorf("refusing to write lockfile through symlink %s", path)
+	}
+	return nil
+}

--- a/artifactory/zerotouchremediation/service_test.go
+++ b/artifactory/zerotouchremediation/service_test.go
@@ -1,0 +1,406 @@
+package zerotouchremediation
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+type mockClient struct {
+	callCount    int
+	lastReq      services.ComponentResolutionRequest
+	resp         services.ComponentResolutionResponse
+	disabled     bool
+	version      string
+	versionErr   error
+	remediateErr error
+}
+
+func (m *mockClient) GetVersion() (string, error) {
+	if m.versionErr != nil {
+		return "", m.versionErr
+	}
+	if m.version != "" {
+		return m.version, nil
+	}
+	return ZeroTouchRemediationMinVersion, nil
+}
+
+func (m *mockClient) ZeroTouchRemediation(req services.ComponentResolutionRequest) (*services.ComponentResolutionResponse, bool, error) {
+	m.callCount++
+	m.lastReq = req
+	if m.remediateErr != nil {
+		return nil, false, m.remediateErr
+	}
+	return &m.resp, m.disabled, nil
+}
+
+type mockTool struct {
+	name      string
+	commands  []string
+	root      string
+	lockfiles []Lockfile
+	ensureErr error
+}
+
+func (m mockTool) ToolName() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "npm"
+}
+func (m mockTool) RelevantCommands() []string {
+	if len(m.commands) > 0 {
+		return m.commands
+	}
+	return []string{"install", "ci"}
+}
+func (m mockTool) ProjectRoot(_ string) (string, error) {
+	return m.root, nil
+}
+func (m mockTool) EnsureLockfiles(_ context.Context, _, _ string, _ CommandRunner, _ ...string) ([]string, error) {
+	if m.ensureErr != nil {
+		return nil, m.ensureErr
+	}
+	return nil, nil
+}
+func (m mockTool) DiscoverLockfiles(_ string) ([]Lockfile, error) {
+	return m.lockfiles, nil
+}
+
+func enableZTR(t *testing.T) {
+	t.Helper()
+	t.Setenv(ZtrComponentsEnabledEnvVar, "true")
+}
+
+func TestIsComponentResolutionEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "")
+		assert.False(t, IsComponentResolutionEnabled())
+	})
+	t.Run("enabled when env true", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "true")
+		assert.True(t, IsComponentResolutionEnabled())
+	})
+	t.Run("not enabled for other values", func(t *testing.T) {
+		t.Setenv(ZtrComponentsEnabledEnvVar, "false")
+		assert.False(t, IsComponentResolutionEnabled())
+	})
+}
+
+func TestRunIfEnabled_WritesRemediatedLockfiles(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: "remediated",
+		Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+	assert.Equal(t, "npm", client.lastReq.BuildTool)
+	assert.Equal(t, "npm-virtual", client.lastReq.Repo)
+	assert.Equal(t, "orig", client.lastReq.Lockfile)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "remediated", string(data))
+}
+
+func TestRunIfEnabled_WritesRemediatedNpmLockAsString(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	orig := `{"lockfileVersion":3,"name":"app"}`
+	require.NoError(t, os.WriteFile(lockPath, []byte(orig), 0644))
+
+	remediated := `{"lockfileVersion":3,"name":"app","remediated":true}`
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: remediated,
+		Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte(orig)}}}
+
+	_, remediatedFlag, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediatedFlag)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, remediated, string(data))
+	assert.Equal(t, orig, client.lastReq.Lockfile)
+}
+
+func TestRunIfEnabled_SkipsWhenServiceDisabled(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{disabled: true}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_SkipsWhenNotEnabled(t *testing.T) {
+	t.Setenv(ZtrComponentsEnabledEnvVar, "")
+	client := &mockClient{}
+	tool := mockTool{}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsWhenNoChanges(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{
+		Lockfile: "orig",
+		Changes:  nil,
+	}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_LoopsPerDiscoveredFile(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lock"), []byte("a"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lock"), []byte("b"), 0644))
+
+	client := &mockClient{resp: services.ComponentResolutionResponse{Lockfile: "x", Changes: nil}}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{
+		{Path: "a.lock", Content: []byte("a")},
+		{Path: "b.lock", Content: []byte("b")},
+	}}
+	_, _, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsIrrelevantCommand(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{}
+	tool := mockTool{}
+	_, _, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "version", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsEnsureLockfilesError(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{}
+	tool := mockTool{ensureErr: errors.New("package-lock.json is required for npm ci")}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "ci", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsGetVersionError(t *testing.T) {
+	enableZTR(t)
+	client := &mockClient{versionErr: errors.New("xray unavailable")}
+	tool := mockTool{root: t.TempDir(), lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+}
+
+func TestRunIfEnabled_SkipsRemediateError(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{remediateErr: errors.New("connection refused")}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_SkipsWhenXrayVersionTooLow(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{
+		version: "3.100.0",
+		resp: services.ComponentResolutionResponse{
+			Lockfile: "remediated",
+			Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+		},
+	}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.False(t, remediated)
+	assert.Equal(t, 0, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(data))
+}
+
+func TestRunIfEnabled_AllowsXrayDevVersion(t *testing.T) {
+	enableZTR(t)
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("orig"), 0644))
+
+	client := &mockClient{
+		version: "3.x-dev",
+		resp: services.ComponentResolutionResponse{
+			Lockfile: "remediated",
+			Changes:  []services.Change{{Package: "lodash", BeforeIntegrity: "a", AfterIntegrity: "b"}},
+		},
+	}
+	tool := mockTool{root: dir, lockfiles: []Lockfile{{Path: "package-lock.json", Content: []byte("orig")}}}
+
+	_, remediated, err := RunIfEnabled(context.Background(), client, "npm-virtual", tool, "install", dir, nil)
+	require.NoError(t, err)
+	assert.True(t, remediated)
+	assert.Equal(t, 1, client.callCount)
+
+	data, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, "remediated", string(data))
+}
+
+func TestApplyLockfiles_WritesMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("a"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "app"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app/gradle.lockfile"), []byte("b"), 0644))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("a-remediated")},
+		{Path: "app/gradle.lockfile", Content: []byte("b-remediated")},
+	}, nil)
+	require.NoError(t, err)
+	defer testsutils.RemoveAllAndAssert(t, dir)
+
+	a, _ := os.ReadFile(filepath.Join(dir, "package-lock.json"))
+	b, _ := os.ReadFile(filepath.Join(dir, "app/gradle.lockfile"))
+	assert.Equal(t, "a-remediated", string(a))
+	assert.Equal(t, "b-remediated", string(b))
+
+	require.NoError(t, restore())
+}
+
+func TestApplyLockfiles_RestoresWhenWriteTruncatesThenFails(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(lockPath, []byte("original-lock"), 0644))
+
+	origWrite := writeFile
+	t.Cleanup(func() { writeFile = origWrite })
+	writeFile = func(name string, data []byte, perm os.FileMode) error {
+		if err := origWrite(name, nil, perm); err != nil {
+			return err
+		}
+		return errors.New("disk full")
+	}
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+	assert.Contains(t, err.Error(), "disk full")
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "original-lock", string(data))
+}
+
+func TestApplyLockfiles_RollsBackOnLaterWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(firstPath, []byte("original-first"), 0644))
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not-a-dir"), 0644))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated-first")},
+		{Path: "blocker/nested.lock", Content: []byte("remediated-second")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+
+	data, readErr := os.ReadFile(firstPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "original-first", string(data))
+}
+
+func TestApplyLockfiles_RejectsPathEscapingProjectRoot(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(filepath.Dir(dir), "escaped.lock")
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "../escaped.lock", Content: []byte("pwned")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+	assert.NoFileExists(t, outside)
+}
+
+func TestApplyLockfiles_RejectsSymlinkLockfile(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "target.lock")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0644))
+	lockPath := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.Symlink(outside, lockPath))
+
+	restore, err := ApplyLockfiles(dir, []Lockfile{
+		{Path: "package-lock.json", Content: []byte("remediated")},
+	}, nil)
+	require.Error(t, err)
+	assert.Nil(t, restore)
+
+	data, readErr := os.ReadFile(outside)
+	require.NoError(t, readErr)
+	assert.Equal(t, "secret", string(data))
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260827111619-bee4d60fbdc7
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/jfrog/build-info-go v1.13.1-0.20260828071122-bb92ab7ba69b
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260827111619-bee4d60fbdc7
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260831061529-c6dd293bccca
 	github.com/jfrog/jfrog-cli-evidence v0.9.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJ
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049 h1:eogwWAzZFir1suYEgZ4ZrYrch8fhWs7ma2dxv06p/z8=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e h1:jAvx6jwQ/faEyKMfwbcIiTGxwEZfp1w5iWPpXBhulGA=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260830140313-a20bbd74622e/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,9 @@ github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260827111619-bee4d60fbdc7 h1:4ytBkQB+iBS/KbG+a974hiZbmTith6KuWa5g0Zvw+z4=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260827111619-bee4d60fbdc7/go.mod h1:vuARjRZopsCqVcZmWzCgw5Pr9QD1FWvwFxijV4bvJJI=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260831061529-c6dd293bccca h1:/Ox4k56Pbiow4qbkNrBOmgcnAHwIBjZOsJmS7dURJng=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260831061529-c6dd293bccca/go.mod h1:vuARjRZopsCqVcZmWzCgw5Pr9QD1FWvwFxijV4bvJJI=
 github.com/jfrog/jfrog-cli-evidence v0.9.0 h1:i9DhkQUxSZkhpp5oGR+N+SVAaqWDiUylbJcoDhM91uQ=
 github.com/jfrog/jfrog-cli-evidence v0.9.0/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049 h1:eogwWAzZFir1suYEgZ4ZrYrch8fhWs7ma2dxv06p/z8=


### PR DESCRIPTION
## Summary
- run Zero Touch Remediation before npm packages are packed and published
- restore remediated lockfiles when publication fails
- skip remediation when an existing tarball is supplied because lockfile changes cannot affect it

Depends on #543 and #544. This is PR 3 of the split from #491. It is draft because cross-fork PRs cannot target the preceding fork branch; its diff will shrink to this slice after the dependencies merge.

## Test plan
- [x] `go test ./artifactory/commands/npm`
- [x] `go vet ./artifactory/commands/npm`

Made with [Cursor](https://cursor.com)