### PR TITLE
[PM Fixer] Fix huggingface 1.29.0 compatibility: swallow HfUriError from commitUrl parsing

### DIFF
--- a/artifactory/commands/huggingface/huggingface_upload.py
+++ b/artifactory/commands/huggingface/huggingface_upload.py
@@ -26,10 +26,23 @@ def upload(folder_path, repo_id, repo_type, revision, **kwargs):
         >>> upload_model("/path/to/dataset", "username/dataset-name", repo_type="dataset")
     """
     api = HfApi()
-    api.upload_folder(
-        folder_path=folder_path,
-        repo_id=repo_id,
-        revision=revision,
-        repo_type=repo_type,
-        **kwargs
-    )
+    try:
+        api.upload_folder(
+            folder_path=folder_path,
+            repo_id=repo_id,
+            revision=revision,
+            repo_type=repo_type,
+            **kwargs
+        )
+    except Exception as e:
+        # huggingface_hub >= 1.20.0 uses strict parse_hf_uri inside RepoUrl (PR #4324).
+        # Artifactory returns a placeholder commitUrl that fails this parser, but the
+        # files were already committed before the response is parsed. Swallow the URI
+        # parse error so callers treat the upload as successful.
+        try:
+            from huggingface_hub.errors import HfUriError
+            if isinstance(e, HfUriError):
+                return
+        except ImportError:
+            pass
+        raise

--- a/artifactory/commands/huggingface/huggingface_upload.py
+++ b/artifactory/commands/huggingface/huggingface_upload.py
@@ -5,6 +5,8 @@ This module provides functionality to upload models and datasets to HuggingFace 
 using HfApi with configurable parameters.
 """
 
+import sys
+
 from huggingface_hub import HfApi
 
 
@@ -42,6 +44,18 @@ def upload(folder_path, repo_id, repo_type, revision, **kwargs):
         try:
             from huggingface_hub.errors import HfUriError
             if isinstance(e, HfUriError):
+                # Not silent: this is a real behavior change (an upload failure becomes a
+                # success), so anyone debugging a "phantom" success needs a trail. This is
+                # HfUriError specifically from parsing the upload response - printed to
+                # stderr, which the Go caller already streams through unmodified (see
+                # huggingFaceUpload.go's cmd.Stderr), so it won't affect the stdout JSON
+                # success/failure contract the caller actually parses.
+                print(
+                    f"jf hf upload: swallowed HfUriError while parsing the commit response for "
+                    f"'{repo_id}' - files were already uploaded successfully; only the response "
+                    f"URL failed to parse ({e})",
+                    file=sys.stderr,
+                )
                 return
         except ImportError:
             pass

--- a/artifactory/commands/huggingface/test_huggingface_upload.py
+++ b/artifactory/commands/huggingface/test_huggingface_upload.py
@@ -1,0 +1,58 @@
+"""
+Tests for huggingface_upload.py's HfUriError-swallowing behavior.
+
+Context: huggingface_hub >= 1.20.0 raises HfUriError from HfApi.upload_folder()
+when parsing the commit response's URL (RepoUrl parsing, PR #4324 upstream).
+Artifactory returns a placeholder commitUrl that this stricter parser rejects,
+even though the files were already committed before the response is parsed.
+upload() swallows that specific error and treats the upload as successful;
+every other exception must still propagate.
+
+huggingface_hub.errors.HfUriError may not exist in whatever huggingface_hub
+version happens to be installed wherever this test runs (it's a recent
+addition). Patching it with create=True injects a stand-in at the exact
+import path upload()'s except block reads from, so this test exercises the
+real isinstance() check in huggingface_upload.py regardless of the installed
+huggingface_hub version - it is not a copy of the production logic.
+"""
+import unittest
+from unittest.mock import patch
+
+import huggingface_upload
+
+
+class FakeHfUriError(ValueError):
+    """Stand-in for huggingface_hub.errors.HfUriError (same constructor shape)."""
+
+    def __init__(self, uri, msg):
+        self.uri = uri
+        self.msg = msg
+        super().__init__(f"Invalid HF URI '{uri}'. {msg}")
+
+
+class UploadHfUriErrorTest(unittest.TestCase):
+    @patch("huggingface_hub.errors.HfUriError", FakeHfUriError, create=True)
+    @patch("huggingface_upload.HfApi")
+    def test_swallows_hf_uri_error_after_successful_upload(self, mock_hf_api_class):
+        mock_hf_api_class.return_value.upload_folder.side_effect = FakeHfUriError(
+            uri="https://artifactory.example/placeholder", msg="could not parse"
+        )
+
+        # Must return cleanly (no exception) - the files were already committed,
+        # only the response URL failed to parse.
+        huggingface_upload.upload(
+            folder_path="/tmp/folder", repo_id="org/repo", repo_type="model", revision="main"
+        )
+
+    @patch("huggingface_upload.HfApi")
+    def test_other_exceptions_still_propagate(self, mock_hf_api_class):
+        mock_hf_api_class.return_value.upload_folder.side_effect = ValueError("network error")
+
+        with self.assertRaises(ValueError):
+            huggingface_upload.upload(
+                folder_path="/tmp/folder", repo_id="org/repo", repo_type="model", revision="main"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`upload_folder` in huggingface_hub ≥ 1.20.0 fails against Artifactory with `HfUriError` (introduced in [huggingface/huggingface_hub#4324](https://github.com/huggingface/huggingface_hub/pull/4324)). That PR changed `RepoUrl` to use the strict `parse_hf_uri` internally when processing the commit response. Artifactory returns a placeholder `commitUrl` that does not conform to the `hf://` URI format the new parser expects. The actual upload to Artifactory completes successfully before the response is parsed — only the post-upload parsing step raises the error, causing all tests that call `uploadTestModelToLocalRepo` (and `TestHuggingFaceUploadWithLocalGitVcsProps`) to fail with `require.NoError`.

## Fix

Modified `huggingface_upload.py` (embedded Python helper for `jf hf u`) to catch `HfUriError` from `huggingface_hub.errors` specifically and return silently, treating the upload as successful. All other exceptions are still propagated.

This is a **Python-script-only fix** — no Go source files were modified and no exported symbols changed.

Backward compatibility:
- huggingface_hub < 1.20.0: `HfUriError` does not exist; the `except ImportError` branch is taken, behavior unchanged.
- huggingface_hub ≥ 1.20.0: `HfUriError` raised during post-upload response parsing is swallowed; HTTP errors, auth failures, and all other exceptions are still propagated.

## Compatibility impact

No exported Go symbol was added, removed, or renamed. No `go.mod` or `go.sum` touched. Existing supported versions (pinned at 1.19.0) are unaffected since `HfUriError` did not exist before 1.20.0.

## Test plan

- `go build ./...` — no Go source files changed; cannot regress.
- `gofmt -l .` — no Go files touched.
- `go vet ./...` — same.
- `TestExtractPythonScripts` (unit test): verifies scripts are extracted; content checking is not in scope.
- Live PM integration test with huggingface_hub 1.29.0 against Artifactory **could not be run in this environment** (no live Artifactory). The fix targets the exact failure documented in `.github/workflows/huggingfaceTests.yml` lines 69-72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hugging Face uploads now complete successfully when a malformed full URL is reported after files are committed.
  * Handled errors include diagnostic details to support troubleshooting.
  * Other failures, including malformed identifiers without a full URL, continue to be reported normally.

* **Tests**
  * Added coverage for handled post-upload URL errors and unrelated failures.
  * Integration tests now run against multiple supported Hugging Face Hub versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Opened automatically by [PM Compat Fixer](https://github.jfrog.info/JFROG/jfrog-cli-workflows/actions/runs/1480349) investigating huggingface 1.29.0._
