### PR TITLE
Add APM-Tests job to CLI Integration Tests workflow

### DIFF
--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -992,6 +992,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Checkout all JFrog repositories
         uses: ./.github/actions/checkout-jfrog-repos

--- a/.github/workflows/cli-integration-tests.yml
+++ b/.github/workflows/cli-integration-tests.yml
@@ -970,3 +970,84 @@ jobs:
       - name: Run agent skills tests
         working-directory: jfrog-cli
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.agentSkills
+
+  APM-Tests:
+    name: agent-apm ${{ matrix.os.name }}
+    needs: Detect-Deps
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu
+            version: 24.04
+          - name: windows
+            version: 2022
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    env:
+      JFROG_CLI_LOG_LEVEL: DEBUG
+    steps:
+      - name: Checkout jfrog-cli-artifactory
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout all JFrog repositories
+        uses: ./.github/actions/checkout-jfrog-repos
+        with:
+          build_info_go_repo: ${{ needs.Detect-Deps.outputs.build_info_go_repo }}
+          build_info_go_ref: ${{ needs.Detect-Deps.outputs.build_info_go_ref }}
+          jfrog_client_go_repo: ${{ needs.Detect-Deps.outputs.jfrog_client_go_repo }}
+          jfrog_client_go_ref: ${{ needs.Detect-Deps.outputs.jfrog_client_go_ref }}
+          jfrog_cli_core_repo: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_repo }}
+          jfrog_cli_core_ref: ${{ needs.Detect-Deps.outputs.jfrog_cli_core_ref }}
+
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Setup Go workspace
+        uses: ./.github/actions/setup-go-workspace
+        with:
+          os_name: ${{ matrix.os.name }}
+
+      - name: Install APM (Linux)
+        if: matrix.os.name == 'ubuntu'
+        run: |
+          APM_VERSION="v0.23.1"
+          OS="linux"
+          ARCH="x86_64"
+          curl -sL "https://github.com/microsoft/apm/releases/download/${APM_VERSION}/apm-${OS}-${ARCH}.tar.gz" -o apm.tar.gz
+          tar -xzf apm.tar.gz
+          sudo mkdir -p /opt/apm
+          sudo mv apm-${OS}-${ARCH}/* /opt/apm/
+          sudo chmod +x /opt/apm/apm
+          echo "/opt/apm" >> $GITHUB_PATH
+          rm -rf apm-${OS}-${ARCH} apm.tar.gz
+          /opt/apm/apm --version
+
+      - name: Install APM (Windows)
+        if: matrix.os.name == 'windows'
+        shell: pwsh
+        run: |
+          $APM_VERSION = "v0.28.0"
+          $OS = "windows"
+          $ARCH = "x86_64"
+          $APM_URL = "https://github.com/microsoft/apm/releases/download/${APM_VERSION}/apm-${OS}-${ARCH}.zip"
+          curl.exe -sL "$APM_URL" -o apm.zip
+          Expand-Archive -Path apm.zip -DestinationPath .
+          New-Item -ItemType Directory -Path "C:\tools\apm" -Force | Out-Null
+          Move-Item -Path "apm-${OS}-${ARCH}\*" -Destination "C:\tools\apm\" -Force
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\tools\apm"
+          Remove-Item -Path "apm-${OS}-${ARCH}", "apm.zip" -Recurse -Force
+          & "C:\tools\apm\apm.exe" --version
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
+          RT_CONNECTION_TIMEOUT_SECONDS: '1200'
+
+      - name: Run agent apm tests
+        working-directory: jfrog-cli
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.apm


### PR DESCRIPTION
Mirrors Agent-Plugins-Tests/Agent-Skills-Tests: checks out jfrog-cli and sibling repos, sets up the Go workspace, installs the apm binary (ubuntu/windows, per JGC-413 macOS is skipped), spins up a local Artifactory, and runs jfrog-cli's --test.apm suite against this jfrog-cli-artifactory branch.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] Appropriate label is added to auto generate release notes.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] PR description is clear and concise, and it includes the proposed solution/fix.
-----


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated APM integration test coverage for Ubuntu and Windows environments.
  * Integration tests now validate compatibility with platform-specific Microsoft APM components.
  * Tests run alongside a local Artifactory service to improve coverage of agent installation and integration scenarios.
  * Automated workflows help detect platform-specific issues earlier and support more reliable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->