### PR TITLE
RTECO-2022 - Fixed the bug in jf mvn --scan command

### DIFF
--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -3,6 +3,7 @@ package mvn
 import (
 	"encoding/json"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/jfrog/build-info-go/entities"
@@ -13,8 +14,10 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/common/project"
+	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -235,7 +238,7 @@ func (mc *MvnCommand) Run() error {
 		return err
 	}
 	if mc.IsXrayScan() {
-		return mc.conditionalUpload()
+		return mc.conditionalUpload(mvnParams.GetBuildInfoFilePath())
 	}
 	return nil
 }
@@ -271,7 +274,11 @@ func (mc *MvnCommand) CommandName() string {
 
 // ConditionalUpload will scan the artifact using Xray and will upload them only if the scan passes with no
 // violation.
-func (mc *MvnCommand) conditionalUpload() error {
+// If an upload fails, the artifacts that did not reach Artifactory are removed from the generated
+// build-info (see removeFailedArtifactsFromBuildInfo). Otherwise the build-info would reference
+// artifacts that don't exist in Artifactory, causing downstream build-based flows such as
+// `jf rbc` (release-bundle-create) to fail with "Unresolvable build artifact".
+func (mc *MvnCommand) conditionalUpload(buildInfoFilePath string) error {
 	// Initialize the server details (from config) if it hasn't been initialized yet.
 	_, err := mc.ServerDetails()
 	if err != nil {
@@ -295,15 +302,38 @@ func (mc *MvnCommand) conditionalUpload() error {
 	if binariesSpecFile == nil {
 		return nil
 	}
+	// Build-info cleanup on upload failure is only relevant when build-info is being collected.
+	// When it isn't, we keep the original, lighter upload behavior (no detailed summary, no cleanup).
+	collectBuildInfo := false
+	if mc.configuration != nil {
+		if collectBuildInfo, err = mc.configuration.IsCollectBuildInfo(); err != nil {
+			return err
+		}
+	}
 	// First upload binaries
 	if len(binariesSpecFile.Files) > 0 {
 		uploadCmd := generic.NewUploadCommand()
 		uploadConfiguration := new(utils.UploadConfiguration)
 		uploadConfiguration.Threads = mc.threads
 		uploadCmd.SetUploadConfiguration(uploadConfiguration).SetBuildConfiguration(mc.configuration).SetSpec(binariesSpecFile).SetServerDetails(mc.serverDetails)
-		err = uploadCmd.Run()
-		if err != nil {
+		// When build-info is collected, enable detailed summary so the command retains the list of
+		// successfully uploaded files, allowing us to remove only the artifacts that actually failed.
+		uploadCmd.SetDetailedSummary(collectBuildInfo)
+		if err = uploadCmd.Run(); err != nil {
+			if collectBuildInfo {
+				// Remove the binaries that were not uploaded successfully. The pom.xml's were not uploaded
+				// at all (we return below), so all of them are removed as well. This prevents the build-info
+				// from referencing artifacts that are not in Artifactory.
+				failedNames := failedUploadArtifactNames(binariesSpecFile, uploadCmd)
+				for name := range collectArtifactNames(pomSpecFile) {
+					failedNames[name] = true
+				}
+				mc.removeArtifactsFromBuildInfo(buildInfoFilePath, failedNames)
+			}
 			return err
+		}
+		if collectBuildInfo {
+			closeUploadResultReader(uploadCmd)
 		}
 	}
 	if len(pomSpecFile.Files) > 0 {
@@ -312,9 +342,134 @@ func (mc *MvnCommand) conditionalUpload() error {
 		uploadConfiguration := new(utils.UploadConfiguration)
 		uploadConfiguration.Threads = mc.threads
 		uploadCmd.SetUploadConfiguration(uploadConfiguration).SetBuildConfiguration(mc.configuration).SetSpec(pomSpecFile).SetServerDetails(mc.serverDetails)
-		err = uploadCmd.Run()
+		uploadCmd.SetDetailedSummary(collectBuildInfo)
+		if err = uploadCmd.Run(); err != nil {
+			if collectBuildInfo {
+				mc.removeArtifactsFromBuildInfo(buildInfoFilePath, failedUploadArtifactNames(pomSpecFile, uploadCmd))
+			}
+			return err
+		}
+		if collectBuildInfo {
+			closeUploadResultReader(uploadCmd)
+		}
 	}
-	return err
+	return nil
+}
+
+// failedUploadArtifactNames returns the set of artifact file names from specFile that were NOT
+// successfully uploaded by uploadCmd. It reads the upload's transfer-details reader (retained because
+// detailed summary is enabled on the command) to determine which files actually reached Artifactory,
+// so only the artifacts that truly failed are removed from the build-info. If no transfer details are
+// available (for example, the upload failed before any file was processed) every artifact in the spec
+// is considered failed.
+func failedUploadArtifactNames(specFile *spec.SpecFiles, uploadCmd *generic.UploadCommand) map[string]bool {
+	failedNames := collectArtifactNames(specFile)
+	reader := uploadCmd.Result().Reader()
+	if reader == nil {
+		return failedNames
+	}
+	defer func() {
+		if e := reader.Close(); e != nil {
+			log.Debug("Failed closing upload transfer-details reader: " + e.Error())
+		}
+	}()
+	reader.Reset()
+	for details := new(clientutils.FileTransferDetails); reader.NextRecord(details) == nil; details = new(clientutils.FileTransferDetails) {
+		// A file present in the transfer details was uploaded successfully - keep it in the build-info.
+		delete(failedNames, path.Base(details.TargetPath))
+	}
+	if e := reader.GetError(); e != nil {
+		log.Debug("Failed reading upload transfer-details: " + e.Error())
+	}
+	return failedNames
+}
+
+// closeUploadResultReader closes the transfer-details reader retained by the upload command (when
+// detailed summary is enabled) on the success path, to avoid leaking the backing temp file.
+func closeUploadResultReader(uploadCmd *generic.UploadCommand) {
+	if reader := uploadCmd.Result().Reader(); reader != nil {
+		if e := reader.Close(); e != nil {
+			log.Debug("Failed closing upload transfer-details reader: " + e.Error())
+		}
+	}
+}
+
+// removeArtifactsFromBuildInfo removes the artifacts whose names are in failedNames from the generated
+// build-info file. Keeping artifacts that failed to upload would leave the build-info referencing files
+// that never reached Artifactory, which breaks build-based flows like `jf rbc`.
+// This is best-effort: any failure here is logged at debug level and ignored so that it never masks
+// the original upload error.
+func (mc *MvnCommand) removeArtifactsFromBuildInfo(buildInfoFilePath string, failedNames map[string]bool) {
+	if buildInfoFilePath == "" || len(failedNames) == 0 {
+		return
+	}
+	exists, err := fileutils.IsFileExists(buildInfoFilePath, false)
+	if err != nil {
+		log.Debug("Skipping build-info cleanup, could not access build info file: " + err.Error())
+		return
+	}
+	if !exists {
+		return
+	}
+	content, err := os.ReadFile(buildInfoFilePath)
+	if err != nil {
+		log.Debug("Skipping build-info cleanup, could not read build info file: " + err.Error())
+		return
+	}
+	if len(content) == 0 {
+		return
+	}
+	buildInfo := new(entities.BuildInfo)
+	if err = json.Unmarshal(content, &buildInfo); err != nil {
+		log.Debug("Skipping build-info cleanup, could not parse build info file: " + err.Error())
+		return
+	}
+	removed := false
+	for moduleIndex := range buildInfo.Modules {
+		currModule := &buildInfo.Modules[moduleIndex]
+		keptArtifacts := currModule.Artifacts[:0]
+		for _, artifact := range currModule.Artifacts {
+			if failedNames[artifact.Name] {
+				removed = true
+				continue
+			}
+			keptArtifacts = append(keptArtifacts, artifact)
+		}
+		currModule.Artifacts = keptArtifacts
+	}
+	if !removed {
+		return
+	}
+	newBuildInfo, err := json.Marshal(buildInfo)
+	if err != nil {
+		log.Debug("Skipping build-info cleanup, could not serialize build info: " + err.Error())
+		return
+	}
+	if err = os.WriteFile(buildInfoFilePath, newBuildInfo, 0644); err != nil {
+		log.Debug("Skipping build-info cleanup, could not write build info file: " + err.Error())
+		return
+	}
+	log.Debug("Removed artifacts that failed to upload from the generated build-info to avoid unresolvable build artifacts.")
+}
+
+// collectArtifactNames returns the set of artifact file names (the base name of each spec file's
+// target path) contained in the given spec files. These names match the "name" field recorded for
+// each artifact in the generated build-info.
+func collectArtifactNames(specFiles ...*spec.SpecFiles) map[string]bool {
+	names := make(map[string]bool)
+	for _, specFile := range specFiles {
+		if specFile == nil {
+			continue
+		}
+		for i := 0; i < len(specFile.Files); i++ {
+			target := specFile.Get(i).Target
+			if target == "" {
+				continue
+			}
+			names[path.Base(target)] = true
+		}
+	}
+	return names
 }
 
 // updateBuildInfoArtifactsWithDeploymentRepo updates existing build-info temp file with the target repository for each artifact
@@ -360,7 +515,6 @@ func (mc *MvnCommand) updateBuildInfoArtifactsWithDeploymentRepo(vConfig *viper.
 
 	return os.WriteFile(buildInfoFilePath, newBuildInfo, 0644)
 }
-
 
 func updateArtifactRepo(artifact *entities.Artifact, snapshotRepo, releaseRepo string) {
 	if snapshotRepo != "" && strings.Contains(artifact.Path, "-SNAPSHOT") {

--- a/artifactory/commands/mvn/mvn_test.go
+++ b/artifactory/commands/mvn/mvn_test.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/gofrog/io"
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/v2/common/build"
+	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"os"
 	"path/filepath"
 	"testing"
@@ -205,4 +209,139 @@ func TestUpdateBuildInfoArtifactsWithTargetRepo(t *testing.T) {
 	assert.Len(t, artifacts, 2)
 	assert.Equal(t, "releases", artifacts[0].OriginalDeploymentRepo)
 	assert.Equal(t, "releases", artifacts[1].OriginalDeploymentRepo)
+}
+
+func TestCollectArtifactNames(t *testing.T) {
+	binaries := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+	}}
+	poms := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"},
+		{Target: ""}, // empty targets are ignored
+	}}
+
+	names := collectArtifactNames(binaries, poms, nil)
+
+	assert.Len(t, names, 2)
+	assert.True(t, names["atruvia-api-1.0.jar"])
+	assert.True(t, names["atruvia-api-1.0.pom"])
+}
+
+func TestRemoveFailedArtifactsFromBuildInfo(t *testing.T) {
+	tempDir := t.TempDir()
+	buildInfoFilePath := filepath.Join(tempDir, "buildinfo")
+
+	buildInfo := entities.BuildInfo{
+		Modules: []entities.Module{
+			{
+				Id: "com.atruvia:atruvia-api:1.0",
+				Artifacts: []entities.Artifact{
+					{Name: "atruvia-api-1.0.jar", Path: "com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+					{Name: "atruvia-api-1.0.pom", Path: "com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"},
+				},
+				Dependencies: []entities.Dependency{{Id: "junit:junit:4.11"}},
+			},
+		},
+	}
+	content, err := json.Marshal(buildInfo)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(buildInfoFilePath, content, 0644))
+
+	mc := MvnCommand{}
+	binaries := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+	}}
+	poms := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"},
+	}}
+
+	mc.removeArtifactsFromBuildInfo(buildInfoFilePath, collectArtifactNames(binaries, poms))
+
+	updatedContent, err := os.ReadFile(buildInfoFilePath)
+	assert.NoError(t, err)
+	var updated entities.BuildInfo
+	assert.NoError(t, json.Unmarshal(updatedContent, &updated))
+
+	assert.Len(t, updated.Modules, 1)
+	// The failed artifacts must be removed, but the dependencies must be preserved.
+	assert.Len(t, updated.Modules[0].Artifacts, 0)
+	assert.Len(t, updated.Modules[0].Dependencies, 1)
+}
+
+func TestRemoveFailedArtifactsFromBuildInfoKeepsSucceeded(t *testing.T) {
+	tempDir := t.TempDir()
+	buildInfoFilePath := filepath.Join(tempDir, "buildinfo")
+
+	buildInfo := entities.BuildInfo{
+		Modules: []entities.Module{
+			{
+				Id: "com.atruvia:atruvia-api:1.0",
+				Artifacts: []entities.Artifact{
+					{Name: "atruvia-api-1.0.jar", Path: "com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+					{Name: "atruvia-api-1.0.pom", Path: "com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"},
+				},
+			},
+		},
+	}
+	content, err := json.Marshal(buildInfo)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(buildInfoFilePath, content, 0644))
+
+	mc := MvnCommand{}
+	// Only the pom failed to upload - the jar must remain in the build-info.
+	poms := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"},
+	}}
+
+	mc.removeArtifactsFromBuildInfo(buildInfoFilePath, collectArtifactNames(poms))
+
+	updatedContent, err := os.ReadFile(buildInfoFilePath)
+	assert.NoError(t, err)
+	var updated entities.BuildInfo
+	assert.NoError(t, json.Unmarshal(updatedContent, &updated))
+
+	assert.Len(t, updated.Modules, 1)
+	assert.Len(t, updated.Modules[0].Artifacts, 1)
+	assert.Equal(t, "atruvia-api-1.0.jar", updated.Modules[0].Artifacts[0].Name)
+}
+
+func TestRemoveFailedArtifactsFromBuildInfoNoFilePath(t *testing.T) {
+	mc := MvnCommand{}
+	// Should be a no-op and must not panic when there is no build-info file.
+	mc.removeArtifactsFromBuildInfo("", map[string]bool{"a.jar": true})
+}
+
+func TestFailedUploadArtifactNames(t *testing.T) {
+	tempDir := t.TempDir()
+	transferFile := filepath.Join(tempDir, "transfer")
+	// Only the jar was uploaded successfully; the pom was not.
+	details := []clientutils.FileTransferDetails{
+		{SourcePath: "target/atruvia-api-1.0.jar", TargetPath: "http://host/maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+	}
+	assert.NoError(t, clientutils.SaveFileTransferDetailsInFile(transferFile, &details))
+
+	uploadCmd := generic.NewUploadCommand()
+	uploadCmd.Result().SetReader(content.NewContentReader(transferFile, "files"))
+
+	specFile := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"}, // succeeded
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.pom"}, // failed
+	}}
+
+	failed := failedUploadArtifactNames(specFile, uploadCmd)
+
+	assert.Len(t, failed, 1)
+	assert.True(t, failed["atruvia-api-1.0.pom"])
+	assert.False(t, failed["atruvia-api-1.0.jar"])
+}
+
+func TestFailedUploadArtifactNamesNoReader(t *testing.T) {
+	uploadCmd := generic.NewUploadCommand()
+	specFile := &spec.SpecFiles{Files: []spec.File{
+		{Target: "maven-dev-local/com/atruvia/atruvia-api/1.0/atruvia-api-1.0.jar"},
+	}}
+	// With no transfer details available, all artifacts in the spec are considered failed.
+	failed := failedUploadArtifactNames(specFile, uploadCmd)
+	assert.Len(t, failed, 1)
+	assert.True(t, failed["atruvia-api-1.0.jar"])
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
**Issue**

`jf mvn <goal> --scan` conditionally uploads the deployable artifacts after the Xray scan passes. When one of those uploads fails (for example, an overwrite into a release repo is denied because the user lacks DELETE permission → `403`), the generated build-info still references the artifact that never made it to Artifactory. Publishing that build-info and then running `jf rbc` (release-bundle-create) fails with `422 - Unresolvable build artifact`, because the referenced checksum does not exist in Artifactory.

**Root cause**

The Maven extractor records the deployable artifacts in the build-info regardless of whether the subsequent conditional upload succeeds. The generic upload path only records successful transfers, so on a partial/failed upload the build-info ends up referencing artifacts that were never uploaded — a dangling reference that later breaks `jf rbc`.

**Fix (`artifactory/commands/mvn/mvn.go`)**

The `--scan` scan-then-upload behavior is intentionally left **unchanged** (it is relied on by multiple customers). Instead, when an upload fails, only the artifacts that actually failed to upload are removed from the generated build-info, so it references only artifacts that are really present in Artifactory:

- The internal upload command enables detailed summary (only when build-info is being collected) so we can read the list of successfully uploaded files.
- Failed artifacts are computed **per-file** from the upload's transfer details and pruned from the build-info; dependencies are preserved.
- When build-info is not collected, the upload keeps its original, lighter behavior (no detailed summary, no pruning) — the change is a no-op on that path.

**Behavior**

- Scan/upload behavior is unchanged for all goals.
- On upload failure, the published build-info no longer references artifacts missing from Artifactory. `jf rbc` now fails cleanly with an honest `404 - Source artifacts not found` instead of a misleading `422 - Unresolvable build artifact`.

**Tests**

Added unit tests in `artifactory/commands/mvn/mvn_test.go` covering artifact-name collection, per-file failed-upload detection, and build-info pruning (removing failed artifacts while keeping succeeded ones and dependencies).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Build information now excludes artifacts that failed to upload, preventing downstream build-based workflows from referencing unavailable artifacts.
  - Failed uploads are matched using full repository-relative paths, avoiding incorrect removal of same-named artifacts from other modules.
  - If a binary upload fails, related POM artifacts are also excluded from build information.
  - Maven upload results are handled more reliably after successful transfers, including proper cleanup of transfer details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->