### PR TITLE
RTECO-1782: let the native client publish, and keep credentials off disk

### DIFF
--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,13 +16,12 @@ import (
 	buildinfoflex "github.com/jfrog/build-info-go/flexpack"
 	nugetflex "github.com/jfrog/build-info-go/flexpack/nuget"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/generic"
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/utils/civcs"
 	rtutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	buildUtils "github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"github.com/jfrog/jfrog-client-go/artifactory"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	specutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -40,6 +38,10 @@ type NuGetFlexPackCommand struct {
 	allowInsecureConnections bool
 	buildConfiguration       *buildUtils.BuildConfiguration
 	workingDir               string
+	// credentialEnv is the NuGetPackageSourceCredentials_<source> entry handed to the native
+	// client's environment. Empty when no credentials were injected. Set by
+	// injectCredentialsViaTempConfig and reset by its cleanup func.
+	credentialEnv string
 }
 
 // NewNuGetFlexPackCommand creates a new NuGetFlexPackCommand.
@@ -128,6 +130,10 @@ func (c *NuGetFlexPackCommand) Run() error {
 		return fmt.Errorf(".slnx solution files are not supported by nuget.exe; use 'jf dotnet restore' instead")
 	}
 
+	// Decide up front whether the native client performs the upload itself, so the decision is
+	// made against the user's own arguments before jf appends anything to them.
+	pushViaNativeClient := c.shouldPushViaNativeClient()
+
 	// Inject credentials per NuGet's credential priority hierarchy so no nuget.config is
 	// created or modified. Customers who manage their own credentials simply omit
 	// --repo-resolve/--repo; FlexPack then skips injection and collects build-info only.
@@ -136,14 +142,14 @@ func (c *NuGetFlexPackCommand) Run() error {
 		if isPushCommand(c.subCommand) {
 			repo = c.repoDeploy
 		}
-		if repo != "" && isRestoreCommand(c.subCommand) {
-			// Inject credentials via a temp nuget.config for all restore-family commands.
-			// Both nuget.exe and dotnet CLI use -ConfigFile / --configfile so credentials
-			// are never embedded in the process argv (invisible to ps/proc); the flag style
-			// is selected inside injectCredentialsViaTempConfig based on toolchainType.
-			// Push, pack, and passthrough commands are excluded: push goes through
-			// pushPackagesToArtifactory (the shared upload service, which authenticates from
-			// the configured server details), and pack/passthrough are local-only.
+		if repo != "" && (isRestoreCommand(c.subCommand) || pushViaNativeClient) {
+			// Inject credentials via a temp nuget.config for restore-family commands and for
+			// pushes the native client performs. Both nuget.exe and dotnet CLI use
+			// -ConfigFile / --configfile so credentials are never embedded in the process argv
+			// (invisible to ps/proc); the flag style is selected inside
+			// injectCredentialsViaTempConfig based on toolchainType. The same file also carries
+			// defaultPushSource, so push needs no source flag on the command line.
+			// Pack and passthrough commands are excluded: they are local-only.
 			cleanup, err := c.injectCredentialsViaTempConfig(repo)
 			if err != nil {
 				return err
@@ -170,45 +176,22 @@ func (c *NuGetFlexPackCommand) Run() error {
 		}
 	}
 
-	// Push bypasses the native tool and uploads through the shared Artifactory upload service.
-	//
-	// For nuget.exe this is a design choice, not a necessity: Artifactory does accept nuget.exe's
-	// X-NuGet-ApiKey header — access tokens included — but only when the value is
-	// "<username>:<token>", since it splits the header on the colon to recover credentials. A
-	// bare token has nothing to split and is rejected. Note also that nuget.exe only sends that
-	// header when an API key is actually resolved (-ApiKey, NUGET_API_KEY, or <apikeys> in a
-	// config file); credentials supplied via <packageSourceCredentials> go out as Basic auth
-	// instead, which is why push is excluded from the temp nuget.config injection above.
-	//
-	// For dotnet the problem is real and unrelated: dotnet nuget push cannot load a V3
-	// index.json with URL-embedded credentials (401), because it does not forward that auth on
-	// the service-index fetch.
-	//
-	// Uploading via the upload service sidesteps both, authenticates from the configured JFrog
-	// server details, and shares the code path used by npm/alpine/terraform — inheriting proxy
-	// handling, retries and checksum-optimised deploys. When the user supplies their own
-	// -Source/-ApiKey the bypass is skipped and their intent wins.
-	//
-	// resolvedPushPaths is set when the Artifactory bypass handles the push so that
-	// collectAndStampPushArtifacts can reuse the already-resolved paths instead of
-	// re-expanding globs from c.args a second time.
-	var resolvedPushPaths []string
-	if isPushCommand(c.subCommand) && c.serverDetails != nil && c.repoDeploy != "" && !hasNativeAuthOverride(c.args) {
-		log.Info("Pushing NuGet package to Artifactory...")
-		var pushErr error
-		resolvedPushPaths, pushErr = c.pushPackagesToArtifactory()
-		if pushErr != nil {
-			return fmt.Errorf("nuget push: %w", pushErr)
-		}
-	} else {
-		log.Info(fmt.Sprintf("Running %s %s", c.toolchainType, c.subCommand))
-		nativeCmd := c.buildCmd()
-		nativeCmd.Stdin = os.Stdin
-		nativeCmd.Stdout = os.Stdout
-		nativeCmd.Stderr = os.Stderr
-		if err := nativeCmd.Run(); err != nil {
-			return fmt.Errorf("%s %s failed: %w", c.toolchainType, c.subCommand, err)
-		}
+	// Every command - push included - is executed by the native client. jf's role is to supply
+	// credentials through a temporary nuget.config and to observe the result for build-info; it
+	// does not upload on the tool's behalf. See shouldPushViaNativeClient for why the push no
+	// longer goes through the Artifactory upload service.
+	log.Info(fmt.Sprintf("Running %s %s", c.toolchainType, c.subCommand))
+	nativeCmd := c.buildCmd()
+	nativeCmd.Stdin = os.Stdin
+	nativeCmd.Stdout = os.Stdout
+	nativeCmd.Stderr = os.Stderr
+	// Inherit the caller's environment and add the source credentials, so the native client
+	// authenticates without a secret being written into the temp nuget.config.
+	if c.credentialEnv != "" {
+		nativeCmd.Env = append(os.Environ(), c.credentialEnv)
+	}
+	if err := nativeCmd.Run(); err != nil {
+		return fmt.Errorf("%s %s failed: %w", c.toolchainType, c.subCommand, err)
 	}
 
 	if c.buildConfiguration == nil {
@@ -227,7 +210,10 @@ func (c *NuGetFlexPackCommand) Run() error {
 	case isRestoreCommand(c.subCommand):
 		return c.collectDependencies(buildName, buildNumber)
 	case isPushCommand(c.subCommand):
-		return c.collectAndStampPushArtifacts(buildName, buildNumber, resolvedPushPaths)
+		// nil: the native client performed the upload, so there are no pre-resolved paths to
+		// reuse. CollectPushArtifacts re-derives them from c.args, skipping flags and their
+		// values, which correctly ignores the --configfile jf injected.
+		return c.collectAndStampPushArtifacts(buildName, buildNumber, nil)
 	case isPackCommand(c.subCommand):
 		return c.collectPackArtifacts(buildName, buildNumber, packSnapshot, packOutputDir)
 	}
@@ -243,24 +229,25 @@ func (c *NuGetFlexPackCommand) buildCmd() *exec.Cmd {
 	return exec.Command("nuget", append([]string{c.subCommand}, c.args...)...)
 }
 
-// injectCredentialsViaTempConfig writes a temporary nuget.config with the Artifactory
-// source URL and <packageSourceCredentials>, then appends -ConfigFile / --configfile to
-// c.args so the native tool reads it. The returned cleanup func removes the temp file
-// and restores c.args to its original value. The caller must defer it immediately after
-// a nil-error return.
+// injectCredentialsViaTempConfig writes a temporary nuget.config declaring the Artifactory
+// source, then appends -ConfigFile / --configfile to c.args so the native tool reads it, and
+// records the matching credential environment entry on c.credentialEnv. The returned cleanup
+// func removes the temp file and restores c.args and c.credentialEnv to their original values.
+// The caller must defer it immediately after a nil-error return.
+//
+// The config file carries no secret: credentials travel in the environment (see
+// credentialEnvEntry), which keeps them off disk and out of argv.
 //
 // A V3 source URL is used. nuget.exe (mono) re-embeds -Source values into MSBuild's
 // /p:RestoreSources, but sources read from /p:RestoreConfigFile are NOT re-embedded, so
 // the V3 index.json URL in the config file is passed as-is and NU1301 is avoided.
-// ClearTextPassword is used (not Password) because nuget.exe's encrypted Password
-// storage is Windows DPAPI-only; ClearTextPassword works on all platforms including mono/macOS.
 func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func(), error) {
 	sourceURL, user, password, err := NuGetExeV3SourceDetails(c.serverDetails, repo)
 	if err != nil {
 		return nil, fmt.Errorf("get NuGet source details: %w", err)
 	}
 
-	const sourceName = "JFrog"
+	const sourceName = injectedSourceName
 
 	// NuGet 6.8+ rejects HTTP sources unless allowInsecureConnections="true" is set.
 	// Local Artifactory instances in CI typically run on plain HTTP.
@@ -271,18 +258,24 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 
 	// <clear/> ensures no other sources (nuget.org, system config) interfere — all traffic
 	// is routed exclusively through Artifactory.
+	// defaultPushSource names the same source as the push target so that 'nuget push' and
+	// 'dotnet nuget push' find it without jf appending -Source/--source to the user's command
+	// line. Keeping the target in configuration rather than argv means the native client is
+	// invoked exactly as the user wrote it, and avoids branching on per-toolchain flag
+	// spelling. It is inert for restore, which never consults defaultPushSource.
+	//
+	// Note the absence of a <packageSourceCredentials> block: credentials are handed to the
+	// native client through the NuGetPackageSourceCredentials_<source> environment variable
+	// instead (see credentialEnvEntry), so no secret is ever written to disk.
 	configContent := `<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
     <add key=` + xmlAttrValue(sourceName) + ` value=` + xmlAttrValue(sourceURL) + allowInsecure + ` />
   </packageSources>
-  <packageSourceCredentials>
-    <` + sourceName + `>
-      <add key="Username" value=` + xmlAttrValue(user) + ` />
-      <add key="ClearTextPassword" value=` + xmlAttrValue(password) + ` />
-    </` + sourceName + `>
-  </packageSourceCredentials>
+  <config>
+    <add key="defaultPushSource" value=` + xmlAttrValue(sourceName) + ` />
+  </config>
 </configuration>`
 
 	tmpFile, err := os.CreateTemp("", "jfrog-nuget-*.config")
@@ -306,135 +299,26 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 	origArgs := c.args
 	c.args = append(c.args, configFlag, tmpFile.Name())
 
+	origCredentialEnv := c.credentialEnv
+	c.credentialEnv = credentialEnvEntry(sourceName, user, password)
+
 	return func() {
 		c.args = origArgs
+		c.credentialEnv = origCredentialEnv
 		_ = os.Remove(tmpFile.Name())
 	}, nil
 }
 
-// pushPackagesToArtifactory resolves all .nupkg/.snupkg paths from push args (expanding globs),
-// uploads each through the shared Artifactory upload service, and replicates nuget.exe's sibling
-// .snupkg auto-push behaviour. Using the upload service instead of driving the native push tool
-// keeps authentication, proxy handling, retries and checksum-optimised deploys consistent with
-// the other package managers, and avoids dotnet nuget push's inability to authenticate against
-// a V3 index.json with URL-embedded credentials (401). See Run for the full rationale.
-// It returns the resolved absolute paths of all packages that were pushed so callers can
-// reuse them without re-expanding globs from c.args.
-func (c *NuGetFlexPackCommand) pushPackagesToArtifactory() ([]string, error) {
-	// Warn about flags that the native tool would have honoured but the bypass cannot
-	// forward. Flags in this list are silently accepted (or handled below); any unrecognised
-	// flag produces a visible warning. Includes both nuget.exe style (single-dash) and dotnet
-	// CLI style (double-dash) equivalents for each option.
-	recognisedPushFlags := map[string]bool{
-		// skip-duplicate: handled explicitly below
-		"-skipduplicate": true, "--skip-duplicate": true,
-		// no-symbols: handled explicitly below
-		"-nosymbols": true, "--no-symbols": true, "-n": true,
-		// timeout: advisory to the native tool only; irrelevant for the direct PUT
-		"-timeout": true, "--timeout": true,
-		// verbosity: no-op for the bypass (we use jf log levels)
-		"-verbosity": true, "--verbosity": true, "-v": true,
-		// disable-buffering: streaming hint for the native tool; no-op for the bypass
-		"-disablebuffering": true, "--disable-buffering": true,
-		// non-interactive / --interactive: interactive auth prompts are not used by the bypass
-		"-noninteractive": true, "--interactive": true,
-		// config-file: the bypass authenticates from the configured JFrog server; no config needed
-		"-configfile": true, "--configfile": true,
-		// force-english-output: locale hint for the native tool; no-op for the bypass
-		"-forceenglishoutput": true, "--force-english-output": true,
-	}
-	for _, arg := range c.args {
-		if !strings.HasPrefix(arg, "-") {
-			continue
-		}
-		flagOnly := strings.ToLower(arg)
-		if idx := strings.IndexByte(flagOnly, '='); idx != -1 {
-			flagOnly = flagOnly[:idx]
-		}
-		if !recognisedPushFlags[flagOnly] {
-			log.Warn(fmt.Sprintf("Flag %q is not forwarded when pushing directly to Artifactory; it will have no effect.", arg))
-		}
-	}
-
-	packages, err := resolvePackagePaths(c.workingDir, c.args)
-	if err != nil {
-		return nil, fmt.Errorf("resolve package paths: %w", err)
-	}
-	if len(packages) == 0 {
-		return nil, fmt.Errorf("no .nupkg or .snupkg files found in push arguments: %v", c.args)
-	}
-	// Replicate nuget.exe behaviour: when pushing a .nupkg, also push the sibling .snupkg
-	// if one exists alongside it (unless -NoSymbols was passed).
-	if !hasNoSymbols(c.args) {
-		packages = appendSiblingSymbolPackages(packages)
-	}
-
-	servicesManager, err := rtutils.CreateServiceManager(c.serverDetails, -1, 0, false)
-	if err != nil {
-		return nil, fmt.Errorf("create services manager for NuGet push: %w", err)
-	}
-	// Validate the target and resolve a virtual repo to the local repo artifacts land in, so the
-	// upload target and the OriginalDeploymentRepo in build-info both name the local repository.
-	deployRepo, err := resolveAndValidateDeployRepo(servicesManager, c.repoDeploy)
-	if err != nil {
-		return nil, err
-	}
-
-	// Derive each package's Artifactory storage path with the same build-info logic that
-	// collectAndStampPushArtifacts uses, so the upload target and the later property-stamping
-	// path can never diverge: .nupkg lands flat at the repository root, .snupkg under
-	// symbolpackage/<id>.<version>.nupkg.
-	artifacts, err := nugetflex.CollectPushArtifacts(c.workingDir, packages, deployRepo)
-	if err != nil {
-		return nil, fmt.Errorf("resolve NuGet storage paths: %w", err)
-	}
-	targetByName := make(map[string]string, len(artifacts))
-	for _, a := range artifacts {
-		targetByName[a.Name] = deployRepo + "/" + strings.TrimPrefix(a.Path, "/")
-	}
-
-	skipDuplicate := hasSkipDuplicate(c.args)
-	for _, pkgPath := range packages {
-		target, ok := targetByName[filepath.Base(pkgPath)]
-		if !ok {
-			return nil, fmt.Errorf("could not resolve the Artifactory path for %q", pkgPath)
-		}
-		if err := uploadPackage(servicesManager, pkgPath, target, skipDuplicate); err != nil {
-			return nil, err
-		}
-	}
-	return packages, nil
-}
-
-// resolveAndValidateDeployRepo validates that repoKey is a NuGet local or virtual repository and
-// returns the local repository key that artifacts actually land in.
+// credentialEnvEntry builds the NuGet environment-variable credential entry for a package
+// source, in the "KEY=Username=<u>;Password=<p>" form both nuget.exe and the dotnet CLI read.
 //
-// Validation is explicit because packages are uploaded through the generic artifact API, which
-// would otherwise silently accept a .nupkg into, say, a Maven repository. The NuGet gallery
-// endpoint used to reject that implicitly (it does not exist for non-NuGet repos).
-//
-// For a virtual repository the returned key is its defaultDeploymentRepo, so both the upload
-// target and the OriginalDeploymentRepo recorded in build-info name the local repository.
-// Recording the virtual key would make downstream tools 404 when they try to locate the artifact.
-func resolveAndValidateDeployRepo(servicesManager artifactory.ArtifactoryServicesManager, repoKey string) (string, error) {
-	var params services.VirtualRepositoryBaseParams
-	if err := servicesManager.GetRepository(repoKey, &params); err != nil {
-		return "", fmt.Errorf("resolve repository %q: %w", repoKey, err)
-	}
-	if !strings.EqualFold(params.PackageType, "nuget") {
-		return "", fmt.Errorf("repository %q is of type %q, not NuGet; NuGet packages cannot be pushed to it", repoKey, params.PackageType)
-	}
-	if strings.EqualFold(params.Rclass, "remote") {
-		return "", fmt.Errorf("repository %q is a remote repository; NuGet packages can only be pushed to a local or virtual repository", repoKey)
-	}
-	if !strings.EqualFold(params.Rclass, "virtual") {
-		return repoKey, nil
-	}
-	if params.DefaultDeploymentRepo == "" {
-		return "", fmt.Errorf("virtual repo %q has no defaultDeploymentRepo configured; cannot determine the local repo to push to", repoKey)
-	}
-	log.Debug(fmt.Sprintf("Resolved virtual repo %q → local repo %q for push", repoKey, params.DefaultDeploymentRepo))
-	return params.DefaultDeploymentRepo, nil
+// Passing credentials this way keeps them out of the temp nuget.config, so a secret is never
+// written to disk and cannot survive a crash that skips cleanup. It also keeps them out of the
+// process argv, which is world-readable via ps. The value is still visible to other processes
+// running as the same user (ps -E, /proc/<pid>/environ), so this narrows the exposure rather
+// than eliminating it - but it is the mechanism NuGet documents for exactly this purpose.
+func credentialEnvEntry(sourceName, user, password string) string {
+	return fmt.Sprintf("NuGetPackageSourceCredentials_%s=Username=%s;Password=%s", sourceName, user, password)
 }
 
 // appendSiblingSymbolPackages returns packages plus the sibling .snupkg of every .nupkg that
@@ -461,45 +345,6 @@ func appendSiblingSymbolPackages(packages []string) []string {
 	return withSymbols
 }
 
-// uploadPackage deploys a single package file to target ("<repo>/<path>") using the shared
-// Artifactory upload service, which handles authentication, proxies, retries and checksum
-// optimisation. When skipDuplicate is set, an existing artifact at target is left untouched.
-func uploadPackage(servicesManager artifactory.ArtifactoryServicesManager, pkgPath, target string, skipDuplicate bool) error {
-	if skipDuplicate {
-		exists, err := artifactExists(servicesManager, target)
-		if err != nil {
-			return err
-		}
-		if exists {
-			log.Warn(fmt.Sprintf("Package %q already exists — skipping duplicate", filepath.Base(pkgPath)))
-			return nil
-		}
-	}
-	up := services.NewUploadParams()
-	up.CommonParams = &specutils.CommonParams{Pattern: pkgPath, Target: target}
-	up.Flat = true
-	_, totalFailed, err := servicesManager.UploadFiles(artifactory.UploadServiceOptions{}, up)
-	if err != nil {
-		return fmt.Errorf("push %q: %w", filepath.Base(pkgPath), err)
-	}
-	if totalFailed > 0 {
-		return fmt.Errorf("failed to push %q to Artifactory; see the Artifactory logs for details", filepath.Base(pkgPath))
-	}
-	log.Info(fmt.Sprintf("Package %q pushed successfully", filepath.Base(pkgPath)))
-	return nil
-}
-
-// artifactExists reports whether repoPath ("<repo>/<path>") already exists in Artifactory.
-func artifactExists(servicesManager artifactory.ArtifactoryServicesManager, repoPath string) (bool, error) {
-	httpDetails := servicesManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
-	itemURL := strings.TrimSuffix(servicesManager.GetConfig().GetServiceDetails().GetUrl(), "/") + "/" + repoPath
-	resp, _, err := servicesManager.Client().SendHead(itemURL, &httpDetails)
-	if err != nil {
-		return false, fmt.Errorf("check whether %q already exists: %w", repoPath, err)
-	}
-	return resp.StatusCode == http.StatusOK, nil
-}
-
 // searchWithRetry calls searchFn up to maxAttempts times with exponential backoff starting
 // at initialDelay, returning the first positive count. Used to tolerate Artifactory's
 // asynchronous NuGet indexing. Pass initialDelay=0 in tests to skip sleeping.
@@ -522,63 +367,6 @@ func searchWithRetry(maxAttempts int, initialDelay time.Duration, patterns []str
 		}
 	}
 	return 0, fmt.Errorf("no uploaded NuGet artifacts found at the expected paths after %d attempts: %s", maxAttempts, strings.Join(patterns, ", "))
-}
-
-// resolvePackagePaths returns all .nupkg and .snupkg file paths from args, expanding
-// glob patterns relative to workingDir. Flags (args starting with -) are skipped.
-func resolvePackagePaths(workingDir string, args []string) ([]string, error) {
-	var paths []string
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		ext := strings.ToLower(filepath.Ext(arg))
-		if ext != ".nupkg" && ext != ".snupkg" {
-			continue
-		}
-		pattern := arg
-		if !filepath.IsAbs(pattern) {
-			pattern = filepath.Join(workingDir, pattern)
-		}
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("expand glob %q: %w", arg, err)
-		}
-		// Re-filter glob matches to only include NuGet package files; a glob like
-		// "bin/*" could expand to non-package files if the pattern is broad.
-		for _, m := range matches {
-			ext := strings.ToLower(filepath.Ext(m))
-			if ext == ".nupkg" || ext == ".snupkg" {
-				paths = append(paths, m)
-			}
-		}
-	}
-	return paths, nil
-}
-
-// hasSkipDuplicate reports whether the skip-duplicate flag is present in args.
-// Handles both nuget.exe style (-SkipDuplicate) and dotnet CLI style (--skip-duplicate).
-func hasSkipDuplicate(args []string) bool {
-	for _, arg := range args {
-		switch strings.ToLower(arg) {
-		case "-skipduplicate", "--skip-duplicate":
-			return true
-		}
-	}
-	return false
-}
-
-// hasNoSymbols reports whether the no-symbols flag is present in args.
-// Handles nuget.exe style (-NoSymbols), dotnet CLI style (--no-symbols), and the short
-// form (-n used by dotnet nuget push).
-func hasNoSymbols(args []string) bool {
-	for _, arg := range args {
-		switch strings.ToLower(arg) {
-		case "-nosymbols", "--no-symbols", "-n":
-			return true
-		}
-	}
-	return false
 }
 
 // hasNativeAuthOverride reports whether the user passed a flag that explicitly controls
@@ -745,6 +533,12 @@ func (c *NuGetFlexPackCommand) stampBuildProperties(artifacts []entities.Artifac
 
 	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	props := fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp)
+	// Stamp the CI/VCS coordinates too, so pushed NuGet packages carry the same vcs.*/ci.*
+	// properties that the other FlexPack package managers (npm, Go, Maven, Terraform) attach.
+	// Without these an artifact records which build produced it but not which commit, branch,
+	// or pipeline run it came from. MergeWithUserProps is a no-op when the props are disabled
+	// or no CI/Git context can be detected, so this is safe outside a repository.
+	props = civcs.MergeWithUserProps(props, c.workingDir)
 
 	specFiles := &spec.SpecFiles{}
 	for _, pattern := range patterns {
@@ -893,6 +687,35 @@ func isRestoreCommand(sub string) bool {
 // isPushCommand returns true for push subcommands.
 func isPushCommand(sub string) bool {
 	return sub == "push" || sub == "nuget push"
+}
+
+// injectedSourceName is the package-source key written into the temporary nuget.config, and
+// the value of its defaultPushSource setting.
+const injectedSourceName = "JFrog"
+
+// shouldPushViaNativeClient reports whether the native client performs the upload itself
+// instead of jf taking the publish over.
+//
+// FlexPack's contract is that the native tool does the work and jf observes it, so the upload
+// belongs to nuget.exe / the dotnet CLI. Both push to Artifactory successfully when their
+// credentials come from the NuGetPackageSourceCredentials_<source> environment variable and
+// the target comes from defaultPushSource - which is what injectCredentialsViaTempConfig sets up.
+//
+// The 401 that originally motivated the Artifactory-side bypass is specific to credentials
+// carried in the source URL: fetching the V3 service index that way is unauthenticated and
+// fails for both clients. Supplying credentials through the config file avoids it entirely.
+// Verified against Artifactory for nuget.exe 6.6.2 and dotnet SDK 10.0.302.
+//
+// Build-info collection and property stamping are unaffected - they run after the command
+// either way, so the artifact record and build.*/vcs.* properties are identical.
+//
+// Skipped when the user supplied their own -Source/-ApiKey, or when there is no server or
+// deploy repo to build a source from; those cases already run the native tool directly.
+func (c *NuGetFlexPackCommand) shouldPushViaNativeClient() bool {
+	return isPushCommand(c.subCommand) &&
+		c.serverDetails != nil &&
+		c.repoDeploy != "" &&
+		!hasNativeAuthOverride(c.args)
 }
 
 // isPackCommand returns true for the pack subcommand, which produces .nupkg/.snupkg files locally.

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -297,7 +297,7 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 		configFlag = "--configfile"
 	}
 	origArgs := c.args
-	c.args = append(c.args, configFlag, tmpFile.Name())
+	c.args = insertBeforeSeparator(c.args, configFlag, tmpFile.Name())
 
 	origCredentialEnv := c.credentialEnv
 	c.credentialEnv = credentialEnvEntry(sourceName, user, password)
@@ -307,6 +307,30 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 		c.credentialEnv = origCredentialEnv
 		_ = os.Remove(tmpFile.Name())
 	}, nil
+}
+
+// insertBeforeSeparator places extra arguments ahead of a bare "--" in args, appending them at
+// the end when there is no separator.
+//
+// The dotnet CLI forwards everything after "--" to MSBuild, so appending blindly puts jf's own
+// --configfile on the wrong side of it and the restore dies on MSBuild's own parser:
+//
+//	MSBUILD : error MSB1001: Unknown switch.
+//	Switch: --configfile
+//
+// The flag belongs to the dotnet command itself, so it has to precede the separator. Only the
+// first "--" is meaningful; anything after it is the user's payload and is left untouched.
+func insertBeforeSeparator(args []string, extra ...string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			combined := make([]string, 0, len(args)+len(extra))
+			combined = append(combined, args[:i]...)
+			combined = append(combined, extra...)
+			combined = append(combined, args[i:]...)
+			return combined
+		}
+	}
+	return append(args, extra...)
 }
 
 // credentialEnvEntry builds the NuGet environment-variable credential entry for a package

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -387,3 +387,48 @@ func TestTempConfigCarriesNoSecret(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "temp config should be removed")
 	assert.Empty(t, cmd.credentialEnv)
 }
+
+// TestInsertBeforeSeparator pins where jf's injected --configfile lands relative to a user's
+// "--" separator. The dotnet CLI forwards everything after "--" to MSBuild, so an injected flag
+// on the wrong side of it reaches MSBuild's parser and fails the restore with MSB1001.
+func TestInsertBeforeSeparator(t *testing.T) {
+	t.Run("no separator appends at the end", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--verbosity", "quiet"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--verbosity", "quiet", "--configfile", "/tmp/x"}, got)
+	})
+
+	t.Run("separator receives the flag before it", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--", "--verbosity", "minimal"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--configfile", "/tmp/x", "--", "--verbosity", "minimal"}, got)
+	})
+
+	t.Run("only the first separator counts", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--", "a", "--", "b"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--configfile", "/tmp/x", "--", "a", "--", "b"}, got)
+	})
+
+	t.Run("leading separator still yields a valid command", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"--", "--verbosity", "minimal"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"--configfile", "/tmp/x", "--", "--verbosity", "minimal"}, got)
+	})
+
+	// A double-dashed flag is not a separator; only a bare "--" is.
+	t.Run("double-dashed flags are not separators", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--no-restore"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--no-restore", "--configfile", "/tmp/x"}, got)
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		assert.Equal(t, []string{"--configfile", "/tmp/x"},
+			insertBeforeSeparator(nil, "--configfile", "/tmp/x"))
+	})
+
+	// The caller restores c.args from a saved copy, so the input slice must not be aliased in a
+	// way that lets the insert leak back into it.
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		original := []string{"App.sln", "--", "--verbosity", "minimal"}
+		snapshot := append([]string(nil), original...)
+		_ = insertBeforeSeparator(original, "--configfile", "/tmp/x")
+		assert.Equal(t, snapshot, original, "input slice must be left untouched")
+	})
+}

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -10,6 +10,7 @@ import (
 
 	dotnetutils "github.com/jfrog/build-info-go/build/utils/dotnet"
 	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -257,4 +258,132 @@ func TestAppendSiblingSymbolPackages(t *testing.T) {
 			assert.Equal(t, tc.expected, appendSiblingSymbolPackages(tc.input))
 		})
 	}
+}
+
+// TestShouldPushViaNativeClient pins which pushes the dotnet CLI performs itself. FlexPack's
+// contract is that the native tool does the work and jf only observes it, so a dotnet push
+// with a JFrog source to build must not be taken over by the Artifactory upload bypass.
+func TestShouldPushViaNativeClient(t *testing.T) {
+	server := &config.ServerDetails{Url: "https://acme.jfrog.io/"}
+
+	newCmd := func(toolchain dotnetutils.ToolchainType, sub string, srv *config.ServerDetails, repo string, args []string) *NuGetFlexPackCommand {
+		return &NuGetFlexPackCommand{
+			toolchainType: toolchain,
+			subCommand:    sub,
+			serverDetails: srv,
+			repoDeploy:    repo,
+			args:          args,
+		}
+	}
+
+	// Both toolchains upload through their own client. Each authenticates against Artifactory
+	// from the temp nuget.config's <packageSourceCredentials> and finds its target via
+	// defaultPushSource, so neither needs jf to upload on its behalf.
+	t.Run("dotnet nuget push is handled natively", func(t *testing.T) {
+		cmd := newCmd(dotnetutils.DotnetCore, "nuget push", server, "nuget-local", []string{"pkg.nupkg"})
+		assert.True(t, cmd.shouldPushViaNativeClient())
+	})
+
+	t.Run("nuget.exe push is handled natively", func(t *testing.T) {
+		cmd := newCmd(dotnetutils.Nuget, "push", server, "nuget-local", []string{"pkg.nupkg"})
+		assert.True(t, cmd.shouldPushViaNativeClient())
+	})
+
+	// A user-supplied source/api-key is an explicit choice and must win untouched.
+	t.Run("user auth override is respected", func(t *testing.T) {
+		for _, override := range [][]string{
+			{"pkg.nupkg", "--source", "mine"},
+			{"pkg.nupkg", "--api-key", "abc"},
+			{"pkg.nupkg", "-s", "mine"},
+			{"pkg.nupkg", "--source=mine"},
+		} {
+			cmd := newCmd(dotnetutils.DotnetCore, "nuget push", server, "nuget-local", override)
+			assert.False(t, cmd.shouldPushViaNativeClient(), "args: %v", override)
+		}
+	})
+
+	t.Run("non-push subcommands are unaffected", func(t *testing.T) {
+		for _, sub := range []string{"restore", "pack", "build", "publish"} {
+			cmd := newCmd(dotnetutils.DotnetCore, sub, server, "nuget-local", []string{"App.csproj"})
+			assert.False(t, cmd.shouldPushViaNativeClient(), "subcommand: %s", sub)
+		}
+	})
+
+	// Without a server or deploy repo there is no source to inject, so the native tool runs
+	// on its own configuration and jf collects build-info only.
+	t.Run("missing server or repo falls through", func(t *testing.T) {
+		assert.False(t, newCmd(dotnetutils.DotnetCore, "nuget push", nil, "nuget-local", []string{"pkg.nupkg"}).shouldPushViaNativeClient())
+		assert.False(t, newCmd(dotnetutils.DotnetCore, "nuget push", server, "", []string{"pkg.nupkg"}).shouldPushViaNativeClient())
+	})
+}
+
+// TestCredentialEnvEntry pins the NuGet environment-variable credential format. Both
+// nuget.exe and the dotnet CLI read NuGetPackageSourceCredentials_<source> in the
+// "Username=<u>;Password=<p>" form, keyed by the source name declared in the config file.
+func TestCredentialEnvEntry(t *testing.T) {
+	t.Run("format matches what NuGet expects", func(t *testing.T) {
+		assert.Equal(t,
+			"NuGetPackageSourceCredentials_JFrog=Username=admin;Password=token123",
+			credentialEnvEntry("JFrog", "admin", "token123"))
+	})
+
+	// The key must carry the source name, since NuGet matches the variable to the source
+	// declared in the config; a mismatch silently yields an unauthenticated request (401).
+	t.Run("key is keyed by source name", func(t *testing.T) {
+		got := credentialEnvEntry("MyFeed", "u", "p")
+		assert.True(t, strings.HasPrefix(got, "NuGetPackageSourceCredentials_MyFeed="), got)
+	})
+
+	t.Run("access token as password is carried verbatim", func(t *testing.T) {
+		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123"
+		got := credentialEnvEntry("JFrog", "bhanu", token)
+		assert.Contains(t, got, "Password="+token)
+	})
+}
+
+// TestTempConfigCarriesNoSecret is the regression guard for the change that moved credentials
+// out of the temp nuget.config: the file must declare the source but never a password, so a
+// crash that skips cleanup cannot leave a secret on disk.
+func TestTempConfigCarriesNoSecret(t *testing.T) {
+	cmd := NewNuGetFlexPackCommand().
+		SetToolchainType(dotnetutils.DotnetCore).
+		SetSubCommand("restore").
+		SetArgs([]string{"App.csproj"}).
+		SetServerDetails(&config.ServerDetails{
+			ArtifactoryUrl: "https://acme.jfrog.io/artifactory/",
+			User:           "admin",
+			Password:       "sup3rs3cr3t",
+		})
+
+	cleanup, err := cmd.injectCredentialsViaTempConfig("nuget-virtual")
+	require.NoError(t, err)
+	defer cleanup()
+
+	// Recover the temp config path from the flag jf appended.
+	var cfgPath string
+	for i, a := range cmd.args {
+		if a == "--configfile" && i+1 < len(cmd.args) {
+			cfgPath = cmd.args[i+1]
+		}
+	}
+	require.NotEmpty(t, cfgPath, "expected --configfile to be appended")
+
+	body, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	contents := string(body)
+
+	assert.NotContains(t, contents, "sup3rs3cr3t", "password must not be written to disk")
+	assert.NotContains(t, contents, "ClearTextPassword")
+	assert.NotContains(t, contents, "packageSourceCredentials")
+	assert.Contains(t, contents, "nuget-virtual", "source should still be declared")
+	assert.Contains(t, contents, "defaultPushSource")
+
+	// The secret travels in the environment instead.
+	assert.Contains(t, cmd.credentialEnv, "Password=sup3rs3cr3t")
+
+	// Cleanup must remove the file and clear the credential.
+	cleanup()
+	_, statErr := os.Stat(cfgPath)
+	assert.True(t, os.IsNotExist(statErr), "temp config should be removed")
+	assert.Empty(t, cmd.credentialEnv)
 }

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -335,7 +335,7 @@ func TestCredentialEnvEntry(t *testing.T) {
 	})
 
 	t.Run("access token as password is carried verbatim", func(t *testing.T) {
-		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123"
+		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123" //#nosec G101 -- not a credential, a shaped literal asserting the token survives unaltered
 		got := credentialEnvEntry("JFrog", "bhanu", token)
 		assert.Contains(t, got, "Password="+token)
 	})


### PR DESCRIPTION
## What

Three changes to the NuGet/dotnet FlexPack command, all narrowing what jf does on the user's behalf.

## 1. Let the native client perform the upload

FlexPack's contract is that the native tool does the work and jf observes it — but `push` was intercepted and routed through the Artifactory upload service instead. The comment justifying that cited a 401 from `dotnet nuget push` against a V3 `index.json`.

**That justification doesn't hold.** The 401 is specific to credentials carried *in the source URL*, where the service-index fetch goes out unauthenticated. Supplying them through a config file avoids it entirely. Tested against Artifactory before changing anything:

| Client | Method | Result |
|---|---|---|
| `dotnet` SDK 10.0.302 | source URL with embedded creds | ❌ 401 |
| `dotnet` SDK 10.0.302 | `<packageSourceCredentials>` in config | ✅ pushed |
| `nuget.exe` 6.6.2 | `-Source <v3 index> -ApiKey user:token` | ❌ 401 |
| `nuget.exe` 6.6.2 | `<packageSourceCredentials>` in config | ✅ pushed |

Both clients push fine. The bypass and its **seven now-unreachable helpers** are removed (−318 lines), and the `if/else` dispatch collapses to "run the native client".

A user's own `-Source`/`-ApiKey` still wins, unchanged.

## 2. Credentials travel in the environment, not on disk

The temp `nuget.config` no longer carries a `<packageSourceCredentials>` block. The native client reads `NuGetPackageSourceCredentials_<source>` from its environment instead.

This removes the **persistence** risk — a signal that skips cleanup can no longer strand a token in a file — while keeping the secret out of `argv`, which is world-readable via `ps`.

It is **not** secrecy: the value is still readable by same-user processes (`ps -E`, `/proc/<pid>/environ`). The code comment says exactly that rather than overclaiming.

The config now also carries `defaultPushSource`, so the push finds its target without jf appending `-Source`/`--source` to the user's command line. Keeping the target in configuration rather than argv means the native client is invoked exactly as the user wrote it, and avoids branching on per-toolchain flag spelling.

## 3. Stamp `vcs.*` / `ci.*` on pushed artifacts

Push recorded only `build.name`, `build.number`, `build.timestamp` — so an artifact knew which build produced it, but not which commit, branch or pipeline run.

Routing through `civcs.MergeWithUserProps` (the helper Terraform and the other FlexPack managers already use) closes the gap. Verified live:

```
build.name = [fix4-verify]      vcs.branch   = [master]
build.number = [1]              vcs.revision = [394c1726...]
build.timestamp = [...]         vcs.url      = [https://github.com/...]
```

No-op outside a repository or when the properties are disabled.

## One ordering trap worth noting

`shouldPushViaNativeClient()` is computed **before** credential injection. Injection appends to `c.args`, and `hasNativeAuthOverride` treats a `--source` as a *user* override — so evaluating afterwards would make jf misread its own flag as user intent. The comment records why.

## Testing

- `TestShouldPushViaNativeClient` — 5 cases: both toolchains native, user auth override respected, non-push subcommands unaffected, missing server/repo falls through
- `TestCredentialEnvEntry` — format, source-name keying (a mismatch silently 401s), verbatim token passthrough
- `TestTempConfigCarriesNoSecret` — writes a real temp config with a known password and asserts the file contains **no** password, no `ClearTextPassword`, no `packageSourceCredentials`, while still declaring the source; then that cleanup removes the file and clears the credential
- `gofmt`, `go build ./...`, `go vet`, `golangci-lint` — clean, including `unused` after the deletions
- Verified end-to-end: `jf dotnet nuget push` and `jf nuget push` both upload via their native client with build-info and properties intact

> **Note:** `gosec` could not be run — `internal error: package "fmt" without types` under this Go toolchain. Unverified rather than passing.

## Tradeoff being accepted

The removed upload-service path provided checksum-optimised deploys (skip transfer when the blob exists), jf's retry logic, and JFrog proxy handling. Native push has none of these — it always uploads the bytes. For large or frequently re-pushed packages that is a real difference, and it is a deliberate choice in favour of not interfering with the native client.

## Merge order

Second of three RTECO-1782 PRs.

1. jfrog/build-info-go#422
2. **jfrog-cli-artifactory** ← this PR
3. jfrog-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NuGet package pushes now run through the native `nuget` or `dotnet` client.
  - Temporary configuration and environment credentials support authenticated pushes without storing secrets in configuration files.
  - Custom authentication overrides continue to use direct native client execution.
  - Package metadata, including CI and version-control information, is recorded after pushes.

- **Bug Fixes**
  - Temporary authentication files are cleaned up after use.
  - Native client configuration arguments are handled safely when command separators are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->