### PR TITLE
RTECO-1782: let the native client publish, and keep credentials off disk

### DIFF
--- a/artifactory/commands/nuget/auth.go
+++ b/artifactory/commands/nuget/auth.go
@@ -1,45 +1,19 @@
 package nuget
 
 import (
-	"fmt"
-	"net/url"
-
 	dotnetcmd "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/dotnet"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 )
 
-// SourceURLWithCredentials builds an Artifactory NuGet feed URL with credentials embedded
-// as https://user:password@host/... so they can be passed directly as a -Source flag.
-// This is rank-1 (command-line flag) in NuGet's credential priority hierarchy and requires
-// no nuget.config modification.
-func SourceURLWithCredentials(serverDetails *config.ServerDetails, repoName string, useV2 bool) (string, error) {
-	sourceURL, user, password, err := dotnetcmd.GetSourceDetails(serverDetails, repoName, useV2)
-	if err != nil {
-		return "", fmt.Errorf("get NuGet source details: %w", err)
-	}
-
-	u, err := url.Parse(sourceURL)
-	if err != nil {
-		return "", fmt.Errorf("parse NuGet source URL: %w", err)
-	}
-	u.User = url.UserPassword(user, password)
-	return u.String(), nil
-}
-
-// NuGetExeV3SourceDetails returns the V3 source URL, username, and password for use in a
-// temp nuget.config for restore operations. V3 is safe here because the URL goes into
-// <packageSources> in the config file, not as a -Source CLI flag. When no -Source flag is
-// passed, nuget.exe does NOT re-embed the URL into MSBuild's /p:RestoreSources — MSBuild
-// reads the source directly from the config file via /p:RestoreConfigFile and loads the V3
-// service index normally.
+// NuGetExeV3SourceDetails returns the V3 source URL, username and password for the temp
+// nuget.config FlexPack writes. V3 is safe here because the URL goes into <packageSources> in
+// the config file rather than onto the command line as -Source: with no -Source flag, nuget.exe
+// does not re-embed the URL into MSBuild's /p:RestoreSources, and MSBuild instead reads the
+// source from the config file via /p:RestoreConfigFile and loads the V3 service index normally.
+//
+// Both restore and push use this: the service index is what advertises PackagePublish and
+// SymbolPackagePublish, so a V2 source would leave the native client with nowhere to send a
+// symbol package.
 func NuGetExeV3SourceDetails(serverDetails *config.ServerDetails, repoName string) (sourceURL, user, password string, err error) {
 	return dotnetcmd.GetSourceDetails(serverDetails, repoName, false /* V3 */)
-}
-
-// NuGetExeV2SourceDetails returns the V2 source URL, username, and password for push
-// operations. Push is handled by nuget.exe directly (not MSBuild), so named source lookup
-// from -ConfigFile works. V2 is fine for push (no service index needed) and avoids the
-// /p:RestoreSources re-embedding issue entirely.
-func NuGetExeV2SourceDetails(serverDetails *config.ServerDetails, repoName string) (sourceURL, user, password string, err error) {
-	return dotnetcmd.GetSourceDetails(serverDetails, repoName, true /* V2 */)
 }

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -355,16 +355,23 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 // The flag belongs to the dotnet command itself, so it has to precede the separator. Only the
 // first "--" is meaningful; anything after it is the user's payload and is left untouched.
 func insertBeforeSeparator(args []string, extra ...string) []string {
+	// Insert before the first bare "--", or at the end when there is none.
+	at := len(args)
 	for i, arg := range args {
 		if arg == "--" {
-			combined := make([]string, 0, len(args)+len(extra))
-			combined = append(combined, args[:i]...)
-			combined = append(combined, extra...)
-			combined = append(combined, args[i:]...)
-			return combined
+			at = i
+			break
 		}
 	}
-	return append(args, extra...)
+	// Always build a fresh slice. "append(args, extra...)" for the no-separator case wrote into
+	// the caller's backing array whenever it had spare capacity, which contradicts this
+	// function's contract: the caller keeps a saved reference to restore c.args from after the
+	// command runs.
+	combined := make([]string, 0, len(args)+len(extra))
+	combined = append(combined, args[:at]...)
+	combined = append(combined, extra...)
+	combined = append(combined, args[at:]...)
+	return combined
 }
 
 // credentialEnvEntry builds the NuGet environment-variable credential entry for a package

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,13 +16,12 @@ import (
 	buildinfoflex "github.com/jfrog/build-info-go/flexpack"
 	nugetflex "github.com/jfrog/build-info-go/flexpack/nuget"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/generic"
+	"github.com/jfrog/jfrog-cli-artifactory/artifactory/utils/civcs"
 	rtutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	buildUtils "github.com/jfrog/jfrog-cli-core/v2/common/build"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"github.com/jfrog/jfrog-client-go/artifactory"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	specutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
@@ -40,6 +38,10 @@ type NuGetFlexPackCommand struct {
 	allowInsecureConnections bool
 	buildConfiguration       *buildUtils.BuildConfiguration
 	workingDir               string
+	// credentialEnv is the NuGetPackageSourceCredentials_<source> entry handed to the native
+	// client's environment. Empty when no credentials were injected. Set by
+	// injectCredentialsViaTempConfig and reset by its cleanup func.
+	credentialEnv string
 }
 
 // NewNuGetFlexPackCommand creates a new NuGetFlexPackCommand.
@@ -128,6 +130,10 @@ func (c *NuGetFlexPackCommand) Run() error {
 		return fmt.Errorf(".slnx solution files are not supported by nuget.exe; use 'jf dotnet restore' instead")
 	}
 
+	// Decide up front whether the native client performs the upload itself, so the decision is
+	// made against the user's own arguments before jf appends anything to them.
+	pushViaNativeClient := c.shouldPushViaNativeClient()
+
 	// Inject credentials per NuGet's credential priority hierarchy so no nuget.config is
 	// created or modified. Customers who manage their own credentials simply omit
 	// --repo-resolve/--repo; FlexPack then skips injection and collects build-info only.
@@ -136,14 +142,14 @@ func (c *NuGetFlexPackCommand) Run() error {
 		if isPushCommand(c.subCommand) {
 			repo = c.repoDeploy
 		}
-		if repo != "" && isRestoreCommand(c.subCommand) {
-			// Inject credentials via a temp nuget.config for all restore-family commands.
-			// Both nuget.exe and dotnet CLI use -ConfigFile / --configfile so credentials
-			// are never embedded in the process argv (invisible to ps/proc); the flag style
-			// is selected inside injectCredentialsViaTempConfig based on toolchainType.
-			// Push, pack, and passthrough commands are excluded: push goes through
-			// pushPackagesToArtifactory (the shared upload service, which authenticates from
-			// the configured server details), and pack/passthrough are local-only.
+		if repo != "" && (isRestoreCommand(c.subCommand) || pushViaNativeClient) {
+			// Inject credentials via a temp nuget.config for restore-family commands and for
+			// pushes the native client performs. Both nuget.exe and dotnet CLI use
+			// -ConfigFile / --configfile so credentials are never embedded in the process argv
+			// (invisible to ps/proc); the flag style is selected inside
+			// injectCredentialsViaTempConfig based on toolchainType. The same file also carries
+			// defaultPushSource, so push needs no source flag on the command line.
+			// Pack and passthrough commands are excluded: they are local-only.
 			cleanup, err := c.injectCredentialsViaTempConfig(repo)
 			if err != nil {
 				return err
@@ -170,45 +176,22 @@ func (c *NuGetFlexPackCommand) Run() error {
 		}
 	}
 
-	// Push bypasses the native tool and uploads through the shared Artifactory upload service.
-	//
-	// For nuget.exe this is a design choice, not a necessity: Artifactory does accept nuget.exe's
-	// X-NuGet-ApiKey header — access tokens included — but only when the value is
-	// "<username>:<token>", since it splits the header on the colon to recover credentials. A
-	// bare token has nothing to split and is rejected. Note also that nuget.exe only sends that
-	// header when an API key is actually resolved (-ApiKey, NUGET_API_KEY, or <apikeys> in a
-	// config file); credentials supplied via <packageSourceCredentials> go out as Basic auth
-	// instead, which is why push is excluded from the temp nuget.config injection above.
-	//
-	// For dotnet the problem is real and unrelated: dotnet nuget push cannot load a V3
-	// index.json with URL-embedded credentials (401), because it does not forward that auth on
-	// the service-index fetch.
-	//
-	// Uploading via the upload service sidesteps both, authenticates from the configured JFrog
-	// server details, and shares the code path used by npm/alpine/terraform — inheriting proxy
-	// handling, retries and checksum-optimised deploys. When the user supplies their own
-	// -Source/-ApiKey the bypass is skipped and their intent wins.
-	//
-	// resolvedPushPaths is set when the Artifactory bypass handles the push so that
-	// collectAndStampPushArtifacts can reuse the already-resolved paths instead of
-	// re-expanding globs from c.args a second time.
-	var resolvedPushPaths []string
-	if isPushCommand(c.subCommand) && c.serverDetails != nil && c.repoDeploy != "" && !hasNativeAuthOverride(c.args) {
-		log.Info("Pushing NuGet package to Artifactory...")
-		var pushErr error
-		resolvedPushPaths, pushErr = c.pushPackagesToArtifactory()
-		if pushErr != nil {
-			return fmt.Errorf("nuget push: %w", pushErr)
-		}
-	} else {
-		log.Info(fmt.Sprintf("Running %s %s", c.toolchainType, c.subCommand))
-		nativeCmd := c.buildCmd()
-		nativeCmd.Stdin = os.Stdin
-		nativeCmd.Stdout = os.Stdout
-		nativeCmd.Stderr = os.Stderr
-		if err := nativeCmd.Run(); err != nil {
-			return fmt.Errorf("%s %s failed: %w", c.toolchainType, c.subCommand, err)
-		}
+	// Every command - push included - is executed by the native client. jf's role is to supply
+	// credentials through a temporary nuget.config and to observe the result for build-info; it
+	// does not upload on the tool's behalf. See shouldPushViaNativeClient for why the push no
+	// longer goes through the Artifactory upload service.
+	log.Info(fmt.Sprintf("Running %s %s", c.toolchainType, c.subCommand))
+	nativeCmd := c.buildCmd()
+	nativeCmd.Stdin = os.Stdin
+	nativeCmd.Stdout = os.Stdout
+	nativeCmd.Stderr = os.Stderr
+	// Inherit the caller's environment and add the source credentials, so the native client
+	// authenticates without a secret being written into the temp nuget.config.
+	if c.credentialEnv != "" {
+		nativeCmd.Env = append(os.Environ(), c.credentialEnv)
+	}
+	if err := nativeCmd.Run(); err != nil {
+		return fmt.Errorf("%s %s failed: %w", c.toolchainType, c.subCommand, err)
 	}
 
 	if c.buildConfiguration == nil {
@@ -227,7 +210,10 @@ func (c *NuGetFlexPackCommand) Run() error {
 	case isRestoreCommand(c.subCommand):
 		return c.collectDependencies(buildName, buildNumber)
 	case isPushCommand(c.subCommand):
-		return c.collectAndStampPushArtifacts(buildName, buildNumber, resolvedPushPaths)
+		// nil: the native client performed the upload, so there are no pre-resolved paths to
+		// reuse. CollectPushArtifacts re-derives them from c.args, skipping flags and their
+		// values, which correctly ignores the --configfile jf injected.
+		return c.collectAndStampPushArtifacts(buildName, buildNumber, nil)
 	case isPackCommand(c.subCommand):
 		return c.collectPackArtifacts(buildName, buildNumber, packSnapshot, packOutputDir)
 	}
@@ -243,24 +229,25 @@ func (c *NuGetFlexPackCommand) buildCmd() *exec.Cmd {
 	return exec.Command("nuget", append([]string{c.subCommand}, c.args...)...)
 }
 
-// injectCredentialsViaTempConfig writes a temporary nuget.config with the Artifactory
-// source URL and <packageSourceCredentials>, then appends -ConfigFile / --configfile to
-// c.args so the native tool reads it. The returned cleanup func removes the temp file
-// and restores c.args to its original value. The caller must defer it immediately after
-// a nil-error return.
+// injectCredentialsViaTempConfig writes a temporary nuget.config declaring the Artifactory
+// source, then appends -ConfigFile / --configfile to c.args so the native tool reads it, and
+// records the matching credential environment entry on c.credentialEnv. The returned cleanup
+// func removes the temp file and restores c.args and c.credentialEnv to their original values.
+// The caller must defer it immediately after a nil-error return.
+//
+// The config file carries no secret: credentials travel in the environment (see
+// credentialEnvEntry), which keeps them off disk and out of argv.
 //
 // A V3 source URL is used. nuget.exe (mono) re-embeds -Source values into MSBuild's
 // /p:RestoreSources, but sources read from /p:RestoreConfigFile are NOT re-embedded, so
 // the V3 index.json URL in the config file is passed as-is and NU1301 is avoided.
-// ClearTextPassword is used (not Password) because nuget.exe's encrypted Password
-// storage is Windows DPAPI-only; ClearTextPassword works on all platforms including mono/macOS.
 func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func(), error) {
 	sourceURL, user, password, err := NuGetExeV3SourceDetails(c.serverDetails, repo)
 	if err != nil {
 		return nil, fmt.Errorf("get NuGet source details: %w", err)
 	}
 
-	const sourceName = "JFrog"
+	const sourceName = injectedSourceName
 
 	// NuGet 6.8+ rejects HTTP sources unless allowInsecureConnections="true" is set.
 	// Local Artifactory instances in CI typically run on plain HTTP.
@@ -271,18 +258,24 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 
 	// <clear/> ensures no other sources (nuget.org, system config) interfere — all traffic
 	// is routed exclusively through Artifactory.
+	// defaultPushSource names the same source as the push target so that 'nuget push' and
+	// 'dotnet nuget push' find it without jf appending -Source/--source to the user's command
+	// line. Keeping the target in configuration rather than argv means the native client is
+	// invoked exactly as the user wrote it, and avoids branching on per-toolchain flag
+	// spelling. It is inert for restore, which never consults defaultPushSource.
+	//
+	// Note the absence of a <packageSourceCredentials> block: credentials are handed to the
+	// native client through the NuGetPackageSourceCredentials_<source> environment variable
+	// instead (see credentialEnvEntry), so no secret is ever written to disk.
 	configContent := `<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
     <add key=` + xmlAttrValue(sourceName) + ` value=` + xmlAttrValue(sourceURL) + allowInsecure + ` />
   </packageSources>
-  <packageSourceCredentials>
-    <` + sourceName + `>
-      <add key="Username" value=` + xmlAttrValue(user) + ` />
-      <add key="ClearTextPassword" value=` + xmlAttrValue(password) + ` />
-    </` + sourceName + `>
-  </packageSourceCredentials>
+  <config>
+    <add key="defaultPushSource" value=` + xmlAttrValue(sourceName) + ` />
+  </config>
 </configuration>`
 
 	tmpFile, err := os.CreateTemp("", "jfrog-nuget-*.config")
@@ -306,135 +299,26 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 	origArgs := c.args
 	c.args = append(c.args, configFlag, tmpFile.Name())
 
+	origCredentialEnv := c.credentialEnv
+	c.credentialEnv = credentialEnvEntry(sourceName, user, password)
+
 	return func() {
 		c.args = origArgs
+		c.credentialEnv = origCredentialEnv
 		_ = os.Remove(tmpFile.Name())
 	}, nil
 }
 
-// pushPackagesToArtifactory resolves all .nupkg/.snupkg paths from push args (expanding globs),
-// uploads each through the shared Artifactory upload service, and replicates nuget.exe's sibling
-// .snupkg auto-push behaviour. Using the upload service instead of driving the native push tool
-// keeps authentication, proxy handling, retries and checksum-optimised deploys consistent with
-// the other package managers, and avoids dotnet nuget push's inability to authenticate against
-// a V3 index.json with URL-embedded credentials (401). See Run for the full rationale.
-// It returns the resolved absolute paths of all packages that were pushed so callers can
-// reuse them without re-expanding globs from c.args.
-func (c *NuGetFlexPackCommand) pushPackagesToArtifactory() ([]string, error) {
-	// Warn about flags that the native tool would have honoured but the bypass cannot
-	// forward. Flags in this list are silently accepted (or handled below); any unrecognised
-	// flag produces a visible warning. Includes both nuget.exe style (single-dash) and dotnet
-	// CLI style (double-dash) equivalents for each option.
-	recognisedPushFlags := map[string]bool{
-		// skip-duplicate: handled explicitly below
-		"-skipduplicate": true, "--skip-duplicate": true,
-		// no-symbols: handled explicitly below
-		"-nosymbols": true, "--no-symbols": true, "-n": true,
-		// timeout: advisory to the native tool only; irrelevant for the direct PUT
-		"-timeout": true, "--timeout": true,
-		// verbosity: no-op for the bypass (we use jf log levels)
-		"-verbosity": true, "--verbosity": true, "-v": true,
-		// disable-buffering: streaming hint for the native tool; no-op for the bypass
-		"-disablebuffering": true, "--disable-buffering": true,
-		// non-interactive / --interactive: interactive auth prompts are not used by the bypass
-		"-noninteractive": true, "--interactive": true,
-		// config-file: the bypass authenticates from the configured JFrog server; no config needed
-		"-configfile": true, "--configfile": true,
-		// force-english-output: locale hint for the native tool; no-op for the bypass
-		"-forceenglishoutput": true, "--force-english-output": true,
-	}
-	for _, arg := range c.args {
-		if !strings.HasPrefix(arg, "-") {
-			continue
-		}
-		flagOnly := strings.ToLower(arg)
-		if idx := strings.IndexByte(flagOnly, '='); idx != -1 {
-			flagOnly = flagOnly[:idx]
-		}
-		if !recognisedPushFlags[flagOnly] {
-			log.Warn(fmt.Sprintf("Flag %q is not forwarded when pushing directly to Artifactory; it will have no effect.", arg))
-		}
-	}
-
-	packages, err := resolvePackagePaths(c.workingDir, c.args)
-	if err != nil {
-		return nil, fmt.Errorf("resolve package paths: %w", err)
-	}
-	if len(packages) == 0 {
-		return nil, fmt.Errorf("no .nupkg or .snupkg files found in push arguments: %v", c.args)
-	}
-	// Replicate nuget.exe behaviour: when pushing a .nupkg, also push the sibling .snupkg
-	// if one exists alongside it (unless -NoSymbols was passed).
-	if !hasNoSymbols(c.args) {
-		packages = appendSiblingSymbolPackages(packages)
-	}
-
-	servicesManager, err := rtutils.CreateServiceManager(c.serverDetails, -1, 0, false)
-	if err != nil {
-		return nil, fmt.Errorf("create services manager for NuGet push: %w", err)
-	}
-	// Validate the target and resolve a virtual repo to the local repo artifacts land in, so the
-	// upload target and the OriginalDeploymentRepo in build-info both name the local repository.
-	deployRepo, err := resolveAndValidateDeployRepo(servicesManager, c.repoDeploy)
-	if err != nil {
-		return nil, err
-	}
-
-	// Derive each package's Artifactory storage path with the same build-info logic that
-	// collectAndStampPushArtifacts uses, so the upload target and the later property-stamping
-	// path can never diverge: .nupkg lands flat at the repository root, .snupkg under
-	// symbolpackage/<id>.<version>.nupkg.
-	artifacts, err := nugetflex.CollectPushArtifacts(c.workingDir, packages, deployRepo)
-	if err != nil {
-		return nil, fmt.Errorf("resolve NuGet storage paths: %w", err)
-	}
-	targetByName := make(map[string]string, len(artifacts))
-	for _, a := range artifacts {
-		targetByName[a.Name] = deployRepo + "/" + strings.TrimPrefix(a.Path, "/")
-	}
-
-	skipDuplicate := hasSkipDuplicate(c.args)
-	for _, pkgPath := range packages {
-		target, ok := targetByName[filepath.Base(pkgPath)]
-		if !ok {
-			return nil, fmt.Errorf("could not resolve the Artifactory path for %q", pkgPath)
-		}
-		if err := uploadPackage(servicesManager, pkgPath, target, skipDuplicate); err != nil {
-			return nil, err
-		}
-	}
-	return packages, nil
-}
-
-// resolveAndValidateDeployRepo validates that repoKey is a NuGet local or virtual repository and
-// returns the local repository key that artifacts actually land in.
+// credentialEnvEntry builds the NuGet environment-variable credential entry for a package
+// source, in the "KEY=Username=<u>;Password=<p>" form both nuget.exe and the dotnet CLI read.
 //
-// Validation is explicit because packages are uploaded through the generic artifact API, which
-// would otherwise silently accept a .nupkg into, say, a Maven repository. The NuGet gallery
-// endpoint used to reject that implicitly (it does not exist for non-NuGet repos).
-//
-// For a virtual repository the returned key is its defaultDeploymentRepo, so both the upload
-// target and the OriginalDeploymentRepo recorded in build-info name the local repository.
-// Recording the virtual key would make downstream tools 404 when they try to locate the artifact.
-func resolveAndValidateDeployRepo(servicesManager artifactory.ArtifactoryServicesManager, repoKey string) (string, error) {
-	var params services.VirtualRepositoryBaseParams
-	if err := servicesManager.GetRepository(repoKey, &params); err != nil {
-		return "", fmt.Errorf("resolve repository %q: %w", repoKey, err)
-	}
-	if !strings.EqualFold(params.PackageType, "nuget") {
-		return "", fmt.Errorf("repository %q is of type %q, not NuGet; NuGet packages cannot be pushed to it", repoKey, params.PackageType)
-	}
-	if strings.EqualFold(params.Rclass, "remote") {
-		return "", fmt.Errorf("repository %q is a remote repository; NuGet packages can only be pushed to a local or virtual repository", repoKey)
-	}
-	if !strings.EqualFold(params.Rclass, "virtual") {
-		return repoKey, nil
-	}
-	if params.DefaultDeploymentRepo == "" {
-		return "", fmt.Errorf("virtual repo %q has no defaultDeploymentRepo configured; cannot determine the local repo to push to", repoKey)
-	}
-	log.Debug(fmt.Sprintf("Resolved virtual repo %q → local repo %q for push", repoKey, params.DefaultDeploymentRepo))
-	return params.DefaultDeploymentRepo, nil
+// Passing credentials this way keeps them out of the temp nuget.config, so a secret is never
+// written to disk and cannot survive a crash that skips cleanup. It also keeps them out of the
+// process argv, which is world-readable via ps. The value is still visible to other processes
+// running as the same user (ps -E, /proc/<pid>/environ), so this narrows the exposure rather
+// than eliminating it - but it is the mechanism NuGet documents for exactly this purpose.
+func credentialEnvEntry(sourceName, user, password string) string {
+	return fmt.Sprintf("NuGetPackageSourceCredentials_%s=Username=%s;Password=%s", sourceName, user, password)
 }
 
 // appendSiblingSymbolPackages returns packages plus the sibling .snupkg of every .nupkg that
@@ -461,45 +345,6 @@ func appendSiblingSymbolPackages(packages []string) []string {
 	return withSymbols
 }
 
-// uploadPackage deploys a single package file to target ("<repo>/<path>") using the shared
-// Artifactory upload service, which handles authentication, proxies, retries and checksum
-// optimisation. When skipDuplicate is set, an existing artifact at target is left untouched.
-func uploadPackage(servicesManager artifactory.ArtifactoryServicesManager, pkgPath, target string, skipDuplicate bool) error {
-	if skipDuplicate {
-		exists, err := artifactExists(servicesManager, target)
-		if err != nil {
-			return err
-		}
-		if exists {
-			log.Warn(fmt.Sprintf("Package %q already exists — skipping duplicate", filepath.Base(pkgPath)))
-			return nil
-		}
-	}
-	up := services.NewUploadParams()
-	up.CommonParams = &specutils.CommonParams{Pattern: pkgPath, Target: target}
-	up.Flat = true
-	_, totalFailed, err := servicesManager.UploadFiles(artifactory.UploadServiceOptions{}, up)
-	if err != nil {
-		return fmt.Errorf("push %q: %w", filepath.Base(pkgPath), err)
-	}
-	if totalFailed > 0 {
-		return fmt.Errorf("failed to push %q to Artifactory; see the Artifactory logs for details", filepath.Base(pkgPath))
-	}
-	log.Info(fmt.Sprintf("Package %q pushed successfully", filepath.Base(pkgPath)))
-	return nil
-}
-
-// artifactExists reports whether repoPath ("<repo>/<path>") already exists in Artifactory.
-func artifactExists(servicesManager artifactory.ArtifactoryServicesManager, repoPath string) (bool, error) {
-	httpDetails := servicesManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
-	itemURL := strings.TrimSuffix(servicesManager.GetConfig().GetServiceDetails().GetUrl(), "/") + "/" + repoPath
-	resp, _, err := servicesManager.Client().SendHead(itemURL, &httpDetails)
-	if err != nil {
-		return false, fmt.Errorf("check whether %q already exists: %w", repoPath, err)
-	}
-	return resp.StatusCode == http.StatusOK, nil
-}
-
 // searchWithRetry calls searchFn up to maxAttempts times with exponential backoff starting
 // at initialDelay, returning the first positive count. Used to tolerate Artifactory's
 // asynchronous NuGet indexing. Pass initialDelay=0 in tests to skip sleeping.
@@ -522,63 +367,6 @@ func searchWithRetry(maxAttempts int, initialDelay time.Duration, patterns []str
 		}
 	}
 	return 0, fmt.Errorf("no uploaded NuGet artifacts found at the expected paths after %d attempts: %s", maxAttempts, strings.Join(patterns, ", "))
-}
-
-// resolvePackagePaths returns all .nupkg and .snupkg file paths from args, expanding
-// glob patterns relative to workingDir. Flags (args starting with -) are skipped.
-func resolvePackagePaths(workingDir string, args []string) ([]string, error) {
-	var paths []string
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		ext := strings.ToLower(filepath.Ext(arg))
-		if ext != ".nupkg" && ext != ".snupkg" {
-			continue
-		}
-		pattern := arg
-		if !filepath.IsAbs(pattern) {
-			pattern = filepath.Join(workingDir, pattern)
-		}
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("expand glob %q: %w", arg, err)
-		}
-		// Re-filter glob matches to only include NuGet package files; a glob like
-		// "bin/*" could expand to non-package files if the pattern is broad.
-		for _, m := range matches {
-			ext := strings.ToLower(filepath.Ext(m))
-			if ext == ".nupkg" || ext == ".snupkg" {
-				paths = append(paths, m)
-			}
-		}
-	}
-	return paths, nil
-}
-
-// hasSkipDuplicate reports whether the skip-duplicate flag is present in args.
-// Handles both nuget.exe style (-SkipDuplicate) and dotnet CLI style (--skip-duplicate).
-func hasSkipDuplicate(args []string) bool {
-	for _, arg := range args {
-		switch strings.ToLower(arg) {
-		case "-skipduplicate", "--skip-duplicate":
-			return true
-		}
-	}
-	return false
-}
-
-// hasNoSymbols reports whether the no-symbols flag is present in args.
-// Handles nuget.exe style (-NoSymbols), dotnet CLI style (--no-symbols), and the short
-// form (-n used by dotnet nuget push).
-func hasNoSymbols(args []string) bool {
-	for _, arg := range args {
-		switch strings.ToLower(arg) {
-		case "-nosymbols", "--no-symbols", "-n":
-			return true
-		}
-	}
-	return false
 }
 
 // hasNativeAuthOverride reports whether the user passed a flag that explicitly controls
@@ -745,6 +533,12 @@ func (c *NuGetFlexPackCommand) stampBuildProperties(artifacts []entities.Artifac
 
 	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
 	props := fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp)
+	// Stamp the CI/VCS coordinates too, so pushed NuGet packages carry the same vcs.*/ci.*
+	// properties that the other FlexPack package managers (npm, Go, Maven, Terraform) attach.
+	// Without these an artifact records which build produced it but not which commit, branch,
+	// or pipeline run it came from. MergeWithUserProps is a no-op when the props are disabled
+	// or no CI/Git context can be detected, so this is safe outside a repository.
+	props = civcs.MergeWithUserProps(props, c.workingDir)
 
 	specFiles := &spec.SpecFiles{}
 	for _, pattern := range patterns {
@@ -893,6 +687,35 @@ func isRestoreCommand(sub string) bool {
 // isPushCommand returns true for push subcommands.
 func isPushCommand(sub string) bool {
 	return sub == "push" || sub == "nuget push"
+}
+
+// injectedSourceName is the package-source key written into the temporary nuget.config, and
+// the value of its defaultPushSource setting.
+const injectedSourceName = "JFrog"
+
+// shouldPushViaNativeClient reports whether the native client performs the upload itself
+// instead of jf taking the publish over.
+//
+// FlexPack's contract is that the native tool does the work and jf observes it, so the upload
+// belongs to nuget.exe / the dotnet CLI. Both push to Artifactory successfully when their
+// credentials come from the NuGetPackageSourceCredentials_<source> environment variable and
+// the target comes from defaultPushSource - which is what injectCredentialsViaTempConfig sets up.
+//
+// The 401 that originally motivated the Artifactory-side bypass is specific to credentials
+// carried in the source URL: fetching the V3 service index that way is unauthenticated and
+// fails for both clients. Supplying credentials through the config file avoids it entirely.
+// Verified against Artifactory for nuget.exe 6.6.2 and dotnet SDK 10.0.302.
+//
+// Build-info collection and property stamping are unaffected - they run after the command
+// either way, so the artifact record and build.*/vcs.* properties are identical.
+//
+// Skipped when the user supplied their own -Source/-ApiKey, or when there is no server or
+// deploy repo to build a source from; those cases already run the native tool directly.
+func (c *NuGetFlexPackCommand) shouldPushViaNativeClient() bool {
+	return isPushCommand(c.subCommand) &&
+		c.serverDetails != nil &&
+		c.repoDeploy != "" &&
+		!hasNativeAuthOverride(c.args)
 }
 
 // isPackCommand returns true for the pack subcommand, which produces .nupkg/.snupkg files locally.

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -297,7 +297,7 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 		configFlag = "--configfile"
 	}
 	origArgs := c.args
-	c.args = append(c.args, configFlag, tmpFile.Name())
+	c.args = insertBeforeSeparator(c.args, configFlag, tmpFile.Name())
 
 	origCredentialEnv := c.credentialEnv
 	c.credentialEnv = credentialEnvEntry(sourceName, user, password)
@@ -307,6 +307,30 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 		c.credentialEnv = origCredentialEnv
 		_ = os.Remove(tmpFile.Name())
 	}, nil
+}
+
+// insertBeforeSeparator places extra arguments ahead of a bare "--" in args, appending them at
+// the end when there is no separator.
+//
+// The dotnet CLI forwards everything after "--" to MSBuild, so appending blindly puts jf's own
+// --configfile on the wrong side of it and the restore dies on MSBuild's own parser:
+//
+//	MSBUILD : error MSB1001: Unknown switch.
+//	Switch: --configfile
+//
+// The flag belongs to the dotnet command itself, so it has to precede the separator. Only the
+// first "--" is meaningful; anything after it is the user's payload and is left untouched.
+func insertBeforeSeparator(args []string, extra ...string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			combined := make([]string, 0, len(args)+len(extra))
+			combined = append(combined, args[:i]...)
+			combined = append(combined, extra...)
+			combined = append(combined, args[i:]...)
+			return combined
+		}
+	}
+	return append(args, extra...)
 }
 
 // credentialEnvEntry builds the NuGet environment-variable credential entry for a package

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -210,10 +210,7 @@ func (c *NuGetFlexPackCommand) Run() error {
 	case isRestoreCommand(c.subCommand):
 		return c.collectDependencies(buildName, buildNumber)
 	case isPushCommand(c.subCommand):
-		// nil: the native client performed the upload, so there are no pre-resolved paths to
-		// reuse. CollectPushArtifacts re-derives them from c.args, skipping flags and their
-		// values, which correctly ignores the --configfile jf injected.
-		return c.collectAndStampPushArtifacts(buildName, buildNumber, nil)
+		return c.collectAndStampPushArtifacts(buildName, buildNumber)
 	case isPackCommand(c.subCommand):
 		return c.collectPackArtifacts(buildName, buildNumber, packSnapshot, packOutputDir)
 	}
@@ -312,6 +309,10 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 // insertBeforeSeparator places extra arguments ahead of a bare "--" in args, appending them at
 // the end when there is no separator.
 //
+// The ruby command package solves the identical problem in rubyAppendToolArgs
+// (commands/ruby/native_ruby.go) - gem forwards everything after "--" to the C extension
+// build the same way. Keep the two in step; they are a candidate for one shared helper.
+//
 // The dotnet CLI forwards everything after "--" to MSBuild, so appending blindly puts jf's own
 // --configfile on the wrong side of it and the restore dies on MSBuild's own parser:
 //
@@ -343,30 +344,6 @@ func insertBeforeSeparator(args []string, extra ...string) []string {
 // than eliminating it - but it is the mechanism NuGet documents for exactly this purpose.
 func credentialEnvEntry(sourceName, user, password string) string {
 	return fmt.Sprintf("NuGetPackageSourceCredentials_%s=Username=%s;Password=%s", sourceName, user, password)
-}
-
-// appendSiblingSymbolPackages returns packages plus the sibling .snupkg of every .nupkg that
-// has one on disk, preserving order and skipping any path already present.
-func appendSiblingSymbolPackages(packages []string) []string {
-	seen := make(map[string]bool, len(packages))
-	for _, p := range packages {
-		seen[p] = true
-	}
-	withSymbols := packages
-	for _, pkgPath := range packages {
-		if !strings.HasSuffix(strings.ToLower(pkgPath), ".nupkg") {
-			continue
-		}
-		snupkgPath := pkgPath[:len(pkgPath)-len(".nupkg")] + ".snupkg"
-		if seen[snupkgPath] {
-			continue
-		}
-		if _, statErr := os.Stat(snupkgPath); statErr == nil {
-			seen[snupkgPath] = true
-			withSymbols = append(withSymbols, snupkgPath)
-		}
-	}
-	return withSymbols
 }
 
 // searchWithRetry calls searchFn up to maxAttempts times with exponential backoff starting
@@ -439,10 +416,7 @@ func (c *NuGetFlexPackCommand) collectDependencies(buildName, buildNumber string
 // build properties on their exact Artifactory paths, and records them in local build-info.
 // The native push has already succeeded at this point, so it is never re-run; a stamping
 // failure is surfaced as an error without masking the push.
-//
-// resolvedPaths contains the absolute package paths already resolved by pushPackagesToArtifactory
-// (Artifactory bypass path). When nil (native-tool push path), paths are re-resolved from c.args.
-func (c *NuGetFlexPackCommand) collectAndStampPushArtifacts(buildName, buildNumber string, resolvedPaths []string) error {
+func (c *NuGetFlexPackCommand) collectAndStampPushArtifacts(buildName, buildNumber string) error {
 	log.Info(fmt.Sprintf("Collecting NuGet artifact info for %s/%s", buildName, buildNumber))
 	// Resolve the actual local repo so OriginalDeploymentRepo is always a local repo key.
 	// When the user pushes to a virtual repo, Artifactory routes to its defaultDeploymentRepo;
@@ -451,13 +425,9 @@ func (c *NuGetFlexPackCommand) collectAndStampPushArtifacts(buildName, buildNumb
 	if err != nil {
 		return fmt.Errorf("resolve deployment repo: %w", err)
 	}
-	// Use pre-resolved paths when available (Artifactory bypass) to avoid re-expanding globs.
-	// Pass them as pushArgs: resolvePushPackagePaths handles absolute literal paths correctly.
-	pushArgs := c.args
-	if len(resolvedPaths) > 0 {
-		pushArgs = resolvedPaths
-	}
-	artifacts, err := nugetflex.CollectPushArtifacts(c.workingDir, pushArgs, deployRepo)
+	// c.args is passed verbatim: CollectPushArtifacts needs the flags as well as the package
+	// paths, since -NoSymbols / --no-symbols decides whether a sibling .snupkg is recorded.
+	artifacts, err := nugetflex.CollectPushArtifacts(c.workingDir, c.args, deployRepo)
 	if err != nil {
 		return fmt.Errorf("collect pushed NuGet artifacts: %w", err)
 	}
@@ -536,10 +506,9 @@ func artifactPatterns(artifacts []entities.Artifact) []string {
 }
 
 // stampBuildProperties attaches build.name/build.number/build.timestamp to each uploaded
-// package at its exact, deterministic Artifactory path. Primary packages (.nupkg) are stored
-// flat at the repository root; symbol packages (.snupkg) are stored at
-// symbolpackage/<id>.<version>.nupkg. Both paths are captured in artifact.Path by
-// newArtifactFromFile. Fully-qualified patterns are used so no repository-wide scan is performed.
+// package at its exact Artifactory path, taken verbatim from artifact.Path - build-info-go's
+// newArtifactFromFile owns where a package lands, so no storage-layout knowledge is needed or
+// duplicated here. Fully-qualified patterns are used so no repository-wide scan is performed.
 func (c *NuGetFlexPackCommand) stampBuildProperties(artifacts []entities.Artifact, buildName, buildNumber string) error {
 	if c.serverDetails == nil || c.repoDeploy == "" {
 		// Anonymous push or no deploy repo: there is no JFrog target to stamp.

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -137,12 +137,33 @@ func (c *NuGetFlexPackCommand) Run() error {
 	// Inject credentials per NuGet's credential priority hierarchy so no nuget.config is
 	// created or modified. Customers who manage their own credentials simply omit
 	// --repo-resolve/--repo; FlexPack then skips injection and collects build-info only.
-	if c.serverDetails != nil {
-		repo := c.repoResolve
-		if isPushCommand(c.subCommand) {
-			repo = c.repoDeploy
-		}
-		if repo != "" && (isRestoreCommand(c.subCommand) || pushViaNativeClient) {
+	// A configured server means one with a URL, not merely a non-nil struct: when nothing is
+	// configured, GetSpecificConfig hands back an empty *ServerDetails and a nil error, and an
+	// empty ArtifactoryUrl turns the source into the relative path "api/nuget/v3/<repo>/index.json"
+	// that NuGet then reports as a missing LOCAL folder ("NU1301: The local source ... doesn't
+	// exist"), never naming the real problem.
+	repo := c.repoResolve
+	if isPushCommand(c.subCommand) {
+		repo = c.repoDeploy
+	}
+	if repo != "" && (c.serverDetails == nil || c.serverDetails.ArtifactoryUrl == "") {
+		return fmt.Errorf("a repository was requested (%q) but no JFrog server is configured; run 'jf c add' or pass --server-id", repo)
+	}
+	if c.serverDetails != nil && c.serverDetails.ArtifactoryUrl != "" {
+		if repo != "" && hasUserConfigFile(c.args) {
+			// The user brought their own config file. Injecting a second -ConfigFile/--configfile
+			// is not additive: the dotnet CLI rejects the duplicate outright ("Option
+			// '--configfile' expects a single argument but 2 were provided"), and nuget.exe
+			// silently honours only the last one, discarding the user's sources and any
+			// packageSourceCredentials they declared for their other private feeds. Step aside
+			// and say so, the same way an explicit -Source/-ApiKey suppresses injection.
+			log.Warn(fmt.Sprintf("A NuGet config file was supplied on the command line, so %q is being used as-is and no credentials are injected for repository %q. Remove the config file flag to let JFrog CLI configure the source, or add the Artifactory source to that file yourself.", userConfigFilePath(c.args), repo))
+		} else if repo != "" && isRestoreCommand(c.subCommand) && !c.acceptsConfigFile() {
+			// The subcommand restores packages but has no config-file option to inject into.
+			// Say so rather than letting --repo-resolve look effective: the restore will go to
+			// whatever sources the user's own configuration names.
+			log.Warn(fmt.Sprintf("'%s %s' does not accept a NuGet config file, so --repo-resolve=%s cannot be applied and packages will resolve from your configured sources. Run 'jf %s restore --repo-resolve=%s' first, or pass the source explicitly.", c.toolchainType, c.subCommand, repo, c.toolchainType, repo))
+		} else if repo != "" && (isRestoreCommand(c.subCommand) || pushViaNativeClient) {
 			// Inject credentials via a temp nuget.config for restore-family commands and for
 			// pushes the native client performs. Both nuget.exe and dotnet CLI use
 			// -ConfigFile / --configfile so credentials are never embedded in the process argv
@@ -297,7 +318,13 @@ func (c *NuGetFlexPackCommand) injectCredentialsViaTempConfig(repo string) (func
 	c.args = insertBeforeSeparator(c.args, configFlag, tmpFile.Name())
 
 	origCredentialEnv := c.credentialEnv
-	c.credentialEnv = credentialEnvEntry(sourceName, user, password)
+	// Only pass credentials when there are credentials. With both empty the entry would be
+	// "Username=;Password=", which NuGet sends as an empty Basic header rather than omitting
+	// authentication - turning a working anonymous repository into a rejected request. The legacy
+	// config writer makes the same distinction.
+	if user != "" || password != "" {
+		c.credentialEnv = credentialEnvEntry(sourceName, user, password)
+	}
 
 	return func() {
 		c.args = origArgs
@@ -392,6 +419,37 @@ func hasNativeAuthOverride(args []string) bool {
 		}
 	}
 	return false
+}
+
+// configFileFlags are the spellings both clients accept for "read settings from this file":
+// nuget.exe uses -ConfigFile, the dotnet CLI --configfile. Matching is case-insensitive because
+// nuget.exe's own parser is.
+var configFileFlags = map[string]bool{"-configfile": true, "--configfile": true}
+
+// hasUserConfigFile reports whether the user already passed a NuGet config file, in either the
+// space-separated or the inline-equals form. Both clients take a single value for it, so jf must
+// not append another.
+func hasUserConfigFile(args []string) bool {
+	return userConfigFilePath(args) != ""
+}
+
+// userConfigFilePath returns the config file the user asked for, or "" if they did not. When the
+// flag is present with no value the flag itself is returned, which is enough for a warning.
+func userConfigFilePath(args []string) string {
+	for i, arg := range args {
+		flag, inlineValue, hasInline := strings.Cut(arg, "=")
+		if !configFileFlags[strings.ToLower(flag)] {
+			continue
+		}
+		if hasInline {
+			return inlineValue
+		}
+		if i+1 < len(args) {
+			return args[i+1]
+		}
+		return arg
+	}
+	return ""
 }
 
 func (c *NuGetFlexPackCommand) collectDependencies(buildName, buildNumber string) error {
@@ -669,6 +727,17 @@ func hasSlnxTarget(args []string) bool {
 }
 
 // isRestoreCommand returns true for commands that download packages (need dependency collection).
+// acceptsConfigFile reports whether the subcommand has a -ConfigFile/--configfile option to
+// inject into. "dotnet add package" restores, and so is in the restore family, but the SDK gives
+// it no config-file option at all - it takes -s/--source instead - so injecting one makes the
+// command fail with an unknown-option error. nuget.exe's own "add" does accept -ConfigFile.
+func (c *NuGetFlexPackCommand) acceptsConfigFile() bool {
+	if c.toolchainType == dotnetutils.DotnetCore && c.subCommand == "add" {
+		return false
+	}
+	return true
+}
+
 func isRestoreCommand(sub string) bool {
 	switch sub {
 	case "restore", "install", "update", "build", "add":

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -149,8 +149,9 @@ func (c *NuGetFlexPackCommand) Run() error {
 	if repo != "" && (c.serverDetails == nil || c.serverDetails.ArtifactoryUrl == "") {
 		return fmt.Errorf("a repository was requested (%q) but no JFrog server is configured; run 'jf c add' or pass --server-id", repo)
 	}
-	if c.serverDetails != nil && c.serverDetails.ArtifactoryUrl != "" {
-		if repo != "" && hasUserConfigFile(c.args) {
+	if repo != "" && c.serverDetails != nil && c.serverDetails.ArtifactoryUrl != "" {
+		switch {
+		case hasUserConfigFile(c.args):
 			// The user brought their own config file. Injecting a second -ConfigFile/--configfile
 			// is not additive: the dotnet CLI rejects the duplicate outright ("Option
 			// '--configfile' expects a single argument but 2 were provided"), and nuget.exe
@@ -158,12 +159,12 @@ func (c *NuGetFlexPackCommand) Run() error {
 			// packageSourceCredentials they declared for their other private feeds. Step aside
 			// and say so, the same way an explicit -Source/-ApiKey suppresses injection.
 			log.Warn(fmt.Sprintf("A NuGet config file was supplied on the command line, so %q is being used as-is and no credentials are injected for repository %q. Remove the config file flag to let JFrog CLI configure the source, or add the Artifactory source to that file yourself.", userConfigFilePath(c.args), repo))
-		} else if repo != "" && performsRestore(c.subCommand) && !c.acceptsConfigFile() {
+		case performsRestore(c.subCommand) && !c.acceptsConfigFile():
 			// The subcommand restores packages but has no config-file option to inject into.
 			// Say so rather than letting --repo-resolve look effective: the restore will go to
 			// whatever sources the user's own configuration names.
 			log.Warn(fmt.Sprintf("'%s %s' does not accept a NuGet config file, so --repo-resolve=%s cannot be applied and packages will resolve from your configured sources. Run 'jf %s restore --repo-resolve=%s' first, or pass the source explicitly.", c.toolchainType, c.subCommand, repo, c.toolchainType, repo))
-		} else if repo != "" && (performsRestore(c.subCommand) || pushViaNativeClient) {
+		case performsRestore(c.subCommand) || pushViaNativeClient:
 			// Inject credentials via a temp nuget.config for restore-family commands and for
 			// pushes the native client performs. Both nuget.exe and dotnet CLI use
 			// -ConfigFile / --configfile so credentials are never embedded in the process argv

--- a/artifactory/commands/nuget/command.go
+++ b/artifactory/commands/nuget/command.go
@@ -158,12 +158,12 @@ func (c *NuGetFlexPackCommand) Run() error {
 			// packageSourceCredentials they declared for their other private feeds. Step aside
 			// and say so, the same way an explicit -Source/-ApiKey suppresses injection.
 			log.Warn(fmt.Sprintf("A NuGet config file was supplied on the command line, so %q is being used as-is and no credentials are injected for repository %q. Remove the config file flag to let JFrog CLI configure the source, or add the Artifactory source to that file yourself.", userConfigFilePath(c.args), repo))
-		} else if repo != "" && isRestoreCommand(c.subCommand) && !c.acceptsConfigFile() {
+		} else if repo != "" && performsRestore(c.subCommand) && !c.acceptsConfigFile() {
 			// The subcommand restores packages but has no config-file option to inject into.
 			// Say so rather than letting --repo-resolve look effective: the restore will go to
 			// whatever sources the user's own configuration names.
 			log.Warn(fmt.Sprintf("'%s %s' does not accept a NuGet config file, so --repo-resolve=%s cannot be applied and packages will resolve from your configured sources. Run 'jf %s restore --repo-resolve=%s' first, or pass the source explicitly.", c.toolchainType, c.subCommand, repo, c.toolchainType, repo))
-		} else if repo != "" && (isRestoreCommand(c.subCommand) || pushViaNativeClient) {
+		} else if repo != "" && (performsRestore(c.subCommand) || pushViaNativeClient) {
 			// Inject credentials via a temp nuget.config for restore-family commands and for
 			// pushes the native client performs. Both nuget.exe and dotnet CLI use
 			// -ConfigFile / --configfile so credentials are never embedded in the process argv
@@ -190,6 +190,12 @@ func (c *NuGetFlexPackCommand) Run() error {
 		if packOutputDir != "" {
 			extraDirs = append(extraDirs, packOutputDir)
 		}
+		// Without --output, each project writes to its OWN bin/<Configuration>. When the target
+		// lives below the working directory - "pack src/Lib/Lib.csproj", or any .sln whose
+		// projects sit in sub-directories - none of that is under <workingDir>/bin, so nothing
+		// would be collected and build-info would be persisted with no modules at all, while the
+		// command still reported success. Snapshot the target's own directory too.
+		extraDirs = append(extraDirs, packTargetDirs(c.workingDir, c.args)...)
 		var snapErr error
 		packSnapshot, snapErr = nugetflex.SnapshotPackageFiles(c.workingDir, extraDirs...)
 		if snapErr != nil {
@@ -717,6 +723,69 @@ func restoreOptionTakesValue(arg string) bool {
 
 // hasSlnxTarget returns true if any positional arg is a .slnx file. Used to detect SDK-only
 // solution formats before passing them to nuget.exe, which has no .slnx parser.
+// performsRestore reports whether the subcommand downloads packages and therefore needs the
+// Artifactory source declared.
+//
+// It is wider than isRestoreCommand: "pack" and "publish" restore implicitly unless --no-restore
+// is passed, and both accept -ConfigFile/--configfile, which steers that restore (verified
+// against SDK 10.0.302 - a config naming an unreachable source makes both fail in NuGet.targets).
+// Leaving them out meant --repo-resolve was accepted, stripped from argv and then silently
+// dropped, so the implicit restore went to whatever sources the user's own configuration named,
+// typically nuget.org - no curation, no audit trail, no warning. Injecting for a command that
+// turns out not to restore is harmless: the config file is simply unused.
+func performsRestore(sub string) bool {
+	return isRestoreCommand(sub) || isPackCommand(sub) || sub == "publish"
+}
+
+// packTargetSuffixes are the positional targets a pack command accepts. A directory argument is
+// covered by the generic non-flag branch in packTargetDirs.
+var packTargetSuffixes = []string{".csproj", ".fsproj", ".vbproj", ".sln", ".slnx", ".nuspec"}
+
+// packTargetDirs returns the directories that hold the project or solution being packed, resolved
+// against workingDir. Without an explicit --output every project writes to its own
+// bin/<Configuration>, so these are where produced packages appear.
+func packTargetDirs(workingDir string, args []string) []string {
+	var dirs []string
+	seen := map[string]bool{}
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") {
+				skipNext = true
+			}
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(arg))
+		isTarget := false
+		for _, suffix := range packTargetSuffixes {
+			if ext == suffix {
+				isTarget = true
+				break
+			}
+		}
+		candidate := arg
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(workingDir, candidate)
+		}
+		dir := candidate
+		if isTarget {
+			dir = filepath.Dir(candidate)
+		} else if info, err := os.Stat(candidate); err != nil || !info.IsDir() {
+			// Neither a recognised project/solution file nor an existing directory.
+			continue
+		}
+		if !seen[dir] {
+			seen[dir] = true
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
 func hasSlnxTarget(args []string) bool {
 	for _, arg := range args {
 		if strings.EqualFold(filepath.Ext(arg), ".slnx") {

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -363,6 +363,49 @@ func TestTempConfigCarriesNoSecret(t *testing.T) {
 // TestInsertBeforeSeparator pins where jf's injected --configfile lands relative to a user's
 // "--" separator. The dotnet CLI forwards everything after "--" to MSBuild, so an injected flag
 // on the wrong side of it reaches MSBuild's parser and fails the restore with MSB1001.
+// TestPackTargetDirs pins the directories a pack command can write packages to. Without --output
+// each project writes to its own bin/<Configuration>, so packing a target below the working
+// directory produced nothing under <workingDir>/bin and build-info was persisted with no modules
+// while the command still reported success.
+func TestPackTargetDirs(t *testing.T) {
+	workingDir := t.TempDir()
+	nested := filepath.Join(workingDir, "src", "Lib")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{"no target", []string{"--configuration", "Release"}, nil},
+		{"relative project", []string{filepath.Join("src", "Lib", "Lib.csproj")}, []string{nested}},
+		{"solution", []string{filepath.Join("src", "Lib", "App.sln")}, []string{nested}},
+		{"fsproj and vbproj", []string{"a.fsproj", "b.vbproj"}, []string{workingDir}},
+		{"nuspec", []string{"Pkg.nuspec"}, []string{workingDir}},
+		{"existing directory argument", []string{filepath.Join("src", "Lib")}, []string{nested}},
+		// A flag value that happens to look like a path must not be treated as a target.
+		{"flag value is not a target", []string{"--configuration", "Release", "x.csproj"}, []string{workingDir}},
+		// A non-existent, non-project positional is not a directory to snapshot.
+		{"unknown positional ignored", []string{"Release"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, packTargetDirs(workingDir, tc.args))
+		})
+	}
+}
+
+// TestPerformsRestore pins which sub-commands need the Artifactory source declared. pack and
+// publish restore implicitly unless --no-restore is given, and both accept --configfile; omitting
+// them meant --repo-resolve was accepted and then silently dropped.
+func TestPerformsRestore(t *testing.T) {
+	for _, sub := range []string{"restore", "install", "update", "build", "add", "pack", "publish"} {
+		assert.True(t, performsRestore(sub), "%s restores and needs the source declared", sub)
+	}
+	for _, sub := range []string{"push", "nuget push", "locals", "list"} {
+		assert.False(t, performsRestore(sub), "%s does not restore", sub)
+	}
+}
+
 // TestUserConfigFileDetection pins that a config file the user supplied is recognised in every
 // spelling both clients accept, so jf steps aside instead of appending a second one. The dotnet
 // CLI rejects a duplicate --configfile outright, and nuget.exe silently honours only the last,

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -363,6 +363,35 @@ func TestTempConfigCarriesNoSecret(t *testing.T) {
 // TestInsertBeforeSeparator pins where jf's injected --configfile lands relative to a user's
 // "--" separator. The dotnet CLI forwards everything after "--" to MSBuild, so an injected flag
 // on the wrong side of it reaches MSBuild's parser and fails the restore with MSB1001.
+// TestUserConfigFileDetection pins that a config file the user supplied is recognised in every
+// spelling both clients accept, so jf steps aside instead of appending a second one. The dotnet
+// CLI rejects a duplicate --configfile outright, and nuget.exe silently honours only the last,
+// discarding the user's own sources and packageSourceCredentials.
+func TestUserConfigFileDetection(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{"none", []string{"restore", "App.sln", "--no-restore"}, ""},
+		{"dotnet space form", []string{"restore", "--configfile", "corp.config"}, "corp.config"},
+		{"dotnet inline form", []string{"restore", "--configfile=corp.config"}, "corp.config"},
+		{"nuget space form", []string{"restore", "-ConfigFile", "corp.config"}, "corp.config"},
+		{"nuget inline form", []string{"restore", "-ConfigFile=corp.config"}, "corp.config"},
+		{"case insensitive", []string{"restore", "-CONFIGFILE", "corp.config"}, "corp.config"},
+		// A trailing flag with no value is still the user asking for their own file; report the
+		// flag rather than silently treating it as absent and injecting a second one.
+		{"flag with no value", []string{"restore", "--configfile"}, "--configfile"},
+		// Must not be confused with a different flag that merely starts the same way.
+		{"similar flag is not a match", []string{"restore", "--configfile-ish", "x"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, userConfigFilePath(tc.args))
+			assert.Equal(t, tc.expected != "", hasUserConfigFile(tc.args))
+		})
+	}
+}
+
 func TestInsertBeforeSeparator(t *testing.T) {
 	t.Run("no separator appends at the end", func(t *testing.T) {
 		got := insertBeforeSeparator([]string{"App.sln", "--verbosity", "quiet"}, "--configfile", "/tmp/x")

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -387,3 +387,48 @@ func TestTempConfigCarriesNoSecret(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "temp config should be removed")
 	assert.Empty(t, cmd.credentialEnv)
 }
+
+// TestInsertBeforeSeparator pins where jf's injected --configfile lands relative to a user's
+// "--" separator. The dotnet CLI forwards everything after "--" to MSBuild, so an injected flag
+// on the wrong side of it reaches MSBuild's parser and fails the restore with MSB1001.
+func TestInsertBeforeSeparator(t *testing.T) {
+	t.Run("no separator appends at the end", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--verbosity", "quiet"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--verbosity", "quiet", "--configfile", "/tmp/x"}, got)
+	})
+
+	t.Run("separator receives the flag before it", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--", "--verbosity", "minimal"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--configfile", "/tmp/x", "--", "--verbosity", "minimal"}, got)
+	})
+
+	t.Run("only the first separator counts", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--", "a", "--", "b"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--configfile", "/tmp/x", "--", "a", "--", "b"}, got)
+	})
+
+	t.Run("leading separator still yields a valid command", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"--", "--verbosity", "minimal"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"--configfile", "/tmp/x", "--", "--verbosity", "minimal"}, got)
+	})
+
+	// A double-dashed flag is not a separator; only a bare "--" is.
+	t.Run("double-dashed flags are not separators", func(t *testing.T) {
+		got := insertBeforeSeparator([]string{"App.sln", "--no-restore"}, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--no-restore", "--configfile", "/tmp/x"}, got)
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		assert.Equal(t, []string{"--configfile", "/tmp/x"},
+			insertBeforeSeparator(nil, "--configfile", "/tmp/x"))
+	})
+
+	// The caller restores c.args from a saved copy, so the input slice must not be aliased in a
+	// way that lets the insert leak back into it.
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		original := []string{"App.sln", "--", "--verbosity", "minimal"}
+		snapshot := append([]string(nil), original...)
+		_ = insertBeforeSeparator(original, "--configfile", "/tmp/x")
+		assert.Equal(t, snapshot, original, "input slice must be left untouched")
+	})
+}

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -475,4 +475,21 @@ func TestInsertBeforeSeparator(t *testing.T) {
 		_ = insertBeforeSeparator(original, "--configfile", "/tmp/x")
 		assert.Equal(t, snapshot, original, "input slice must be left untouched")
 	})
+
+	// The case above only exercises the separator branch, which always allocates a fresh slice
+	// and therefore cannot alias. The append branch can write into the caller's backing array
+	// when it has spare capacity, and the caller restores c.args from a saved reference - so that
+	// is the branch where aliasing would actually bite.
+	t.Run("append branch does not write into the caller's spare capacity", func(t *testing.T) {
+		backing := make([]string, 1, 8)
+		backing[0] = "App.sln"
+		backing = append(backing, "sentinel-one", "sentinel-two")
+		args := backing[:1]
+
+		got := insertBeforeSeparator(args, "--configfile", "/tmp/x")
+		assert.Equal(t, []string{"App.sln", "--configfile", "/tmp/x"}, got)
+		assert.Equal(t, []string{"App.sln"}, args, "the caller's slice must keep its own length and contents")
+		assert.Equal(t, []string{"sentinel-one", "sentinel-two"}, backing[1:3],
+			"the caller's backing array beyond len must not be overwritten")
+	})
 }

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -10,6 +10,7 @@ import (
 
 	dotnetutils "github.com/jfrog/build-info-go/build/utils/dotnet"
 	"github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -257,4 +258,132 @@ func TestAppendSiblingSymbolPackages(t *testing.T) {
 			assert.Equal(t, tc.expected, appendSiblingSymbolPackages(tc.input))
 		})
 	}
+}
+
+// TestShouldPushViaNativeClient pins which pushes the dotnet CLI performs itself. FlexPack's
+// contract is that the native tool does the work and jf only observes it, so a dotnet push
+// with a JFrog source to build must not be taken over by the Artifactory upload bypass.
+func TestShouldPushViaNativeClient(t *testing.T) {
+	server := &config.ServerDetails{Url: "https://acme.jfrog.io/"}
+
+	newCmd := func(toolchain dotnetutils.ToolchainType, sub string, srv *config.ServerDetails, repo string, args []string) *NuGetFlexPackCommand {
+		return &NuGetFlexPackCommand{
+			toolchainType: toolchain,
+			subCommand:    sub,
+			serverDetails: srv,
+			repoDeploy:    repo,
+			args:          args,
+		}
+	}
+
+	// Both toolchains upload through their own client. Each authenticates against Artifactory
+	// from the temp nuget.config's <packageSourceCredentials> and finds its target via
+	// defaultPushSource, so neither needs jf to upload on its behalf.
+	t.Run("dotnet nuget push is handled natively", func(t *testing.T) {
+		cmd := newCmd(dotnetutils.DotnetCore, "nuget push", server, "nuget-local", []string{"pkg.nupkg"})
+		assert.True(t, cmd.shouldPushViaNativeClient())
+	})
+
+	t.Run("nuget.exe push is handled natively", func(t *testing.T) {
+		cmd := newCmd(dotnetutils.Nuget, "push", server, "nuget-local", []string{"pkg.nupkg"})
+		assert.True(t, cmd.shouldPushViaNativeClient())
+	})
+
+	// A user-supplied source/api-key is an explicit choice and must win untouched.
+	t.Run("user auth override is respected", func(t *testing.T) {
+		for _, override := range [][]string{
+			{"pkg.nupkg", "--source", "mine"},
+			{"pkg.nupkg", "--api-key", "abc"},
+			{"pkg.nupkg", "-s", "mine"},
+			{"pkg.nupkg", "--source=mine"},
+		} {
+			cmd := newCmd(dotnetutils.DotnetCore, "nuget push", server, "nuget-local", override)
+			assert.False(t, cmd.shouldPushViaNativeClient(), "args: %v", override)
+		}
+	})
+
+	t.Run("non-push subcommands are unaffected", func(t *testing.T) {
+		for _, sub := range []string{"restore", "pack", "build", "publish"} {
+			cmd := newCmd(dotnetutils.DotnetCore, sub, server, "nuget-local", []string{"App.csproj"})
+			assert.False(t, cmd.shouldPushViaNativeClient(), "subcommand: %s", sub)
+		}
+	})
+
+	// Without a server or deploy repo there is no source to inject, so the native tool runs
+	// on its own configuration and jf collects build-info only.
+	t.Run("missing server or repo falls through", func(t *testing.T) {
+		assert.False(t, newCmd(dotnetutils.DotnetCore, "nuget push", nil, "nuget-local", []string{"pkg.nupkg"}).shouldPushViaNativeClient())
+		assert.False(t, newCmd(dotnetutils.DotnetCore, "nuget push", server, "", []string{"pkg.nupkg"}).shouldPushViaNativeClient())
+	})
+}
+
+// TestCredentialEnvEntry pins the NuGet environment-variable credential format. Both
+// nuget.exe and the dotnet CLI read NuGetPackageSourceCredentials_<source> in the
+// "Username=<u>;Password=<p>" form, keyed by the source name declared in the config file.
+func TestCredentialEnvEntry(t *testing.T) {
+	t.Run("format matches what NuGet expects", func(t *testing.T) {
+		assert.Equal(t,
+			"NuGetPackageSourceCredentials_JFrog=Username=admin;Password=token123",
+			credentialEnvEntry("JFrog", "admin", "token123"))
+	})
+
+	// The key must carry the source name, since NuGet matches the variable to the source
+	// declared in the config; a mismatch silently yields an unauthenticated request (401).
+	t.Run("key is keyed by source name", func(t *testing.T) {
+		got := credentialEnvEntry("MyFeed", "u", "p")
+		assert.True(t, strings.HasPrefix(got, "NuGetPackageSourceCredentials_MyFeed="), got)
+	})
+
+	t.Run("access token as password is carried verbatim", func(t *testing.T) {
+		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123"
+		got := credentialEnvEntry("JFrog", "bhanu", token)
+		assert.Contains(t, got, "Password="+token)
+	})
+}
+
+// TestTempConfigCarriesNoSecret is the regression guard for the change that moved credentials
+// out of the temp nuget.config: the file must declare the source but never a password, so a
+// crash that skips cleanup cannot leave a secret on disk.
+func TestTempConfigCarriesNoSecret(t *testing.T) {
+	cmd := NewNuGetFlexPackCommand().
+		SetToolchainType(dotnetutils.DotnetCore).
+		SetSubCommand("restore").
+		SetArgs([]string{"App.csproj"}).
+		SetServerDetails(&config.ServerDetails{
+			ArtifactoryUrl: "https://acme.jfrog.io/artifactory/",
+			User:           "admin",
+			Password:       "sup3rs3cr3t",
+		})
+
+	cleanup, err := cmd.injectCredentialsViaTempConfig("nuget-virtual")
+	require.NoError(t, err)
+	defer cleanup()
+
+	// Recover the temp config path from the flag jf appended.
+	var cfgPath string
+	for i, a := range cmd.args {
+		if a == "--configfile" && i+1 < len(cmd.args) {
+			cfgPath = cmd.args[i+1]
+		}
+	}
+	require.NotEmpty(t, cfgPath, "expected --configfile to be appended")
+
+	body, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	contents := string(body)
+
+	assert.NotContains(t, contents, "sup3rs3cr3t", "password must not be written to disk")
+	assert.NotContains(t, contents, "ClearTextPassword")
+	assert.NotContains(t, contents, "packageSourceCredentials")
+	assert.Contains(t, contents, "nuget-virtual", "source should still be declared")
+	assert.Contains(t, contents, "defaultPushSource")
+
+	// The secret travels in the environment instead.
+	assert.Contains(t, cmd.credentialEnv, "Password=sup3rs3cr3t")
+
+	// Cleanup must remove the file and clear the credential.
+	cleanup()
+	_, statErr := os.Stat(cfgPath)
+	assert.True(t, os.IsNotExist(statErr), "temp config should be removed")
+	assert.Empty(t, cmd.credentialEnv)
 }

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -232,34 +232,6 @@ func TestIsPushCommand(t *testing.T) {
 	}
 }
 
-func TestAppendSiblingSymbolPackages(t *testing.T) {
-	dir := t.TempDir()
-	write := func(name string) string {
-		p := filepath.Join(dir, name)
-		require.NoError(t, os.WriteFile(p, []byte("pkg"), 0o600))
-		return p
-	}
-	nupkg := write("Foo.1.0.0.nupkg")
-	snupkg := write("Foo.1.0.0.snupkg")
-	lonely := write("Bar.2.0.0.nupkg")
-
-	tests := []struct {
-		name     string
-		input    []string
-		expected []string
-	}{
-		{name: "adds sibling snupkg", input: []string{nupkg}, expected: []string{nupkg, snupkg}},
-		{name: "no sibling on disk", input: []string{lonely}, expected: []string{lonely}},
-		{name: "does not duplicate an explicit snupkg", input: []string{nupkg, snupkg}, expected: []string{nupkg, snupkg}},
-		{name: "snupkg input is left alone", input: []string{snupkg}, expected: []string{snupkg}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, appendSiblingSymbolPackages(tc.input))
-		})
-	}
-}
-
 // TestShouldPushViaNativeClient pins which pushes the dotnet CLI performs itself. FlexPack's
 // contract is that the native tool does the work and jf only observes it, so a dotnet push
 // with a JFrog source to build must not be taken over by the Artifactory upload bypass.

--- a/artifactory/commands/nuget/command_test.go
+++ b/artifactory/commands/nuget/command_test.go
@@ -335,7 +335,7 @@ func TestCredentialEnvEntry(t *testing.T) {
 	})
 
 	t.Run("access token as password is carried verbatim", func(t *testing.T) {
-		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123"
+		token := "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIn0.abc-DEF_123" //#nosec G101 -- not a credential, a shaped literal asserting the token survives unaltered
 		got := credentialEnvEntry("JFrog", "bhanu", token)
 		assert.Contains(t, got, "Password="+token)
 	})


### PR DESCRIPTION
## What

Three changes to the NuGet/dotnet FlexPack command, all narrowing what jf does on the user's behalf.

## 1. Let the native client perform the upload

FlexPack's contract is that the native tool does the work and jf observes it — but `push` was intercepted and routed through the Artifactory upload service instead. The comment justifying that cited a 401 from `dotnet nuget push` against a V3 `index.json`.

**That justification doesn't hold.** The 401 is specific to credentials carried *in the source URL*, where the service-index fetch goes out unauthenticated. Supplying them through a config file avoids it entirely. Tested against Artifactory before changing anything:

| Client | Method | Result |
|---|---|---|
| `dotnet` SDK 10.0.302 | source URL with embedded creds | ❌ 401 |
| `dotnet` SDK 10.0.302 | `<packageSourceCredentials>` in config | ✅ pushed |
| `nuget.exe` 6.6.2 | `-Source <v3 index> -ApiKey user:token` | ❌ 401 |
| `nuget.exe` 6.6.2 | `<packageSourceCredentials>` in config | ✅ pushed |

Both clients push fine. The bypass and its **seven now-unreachable helpers** are removed (−318 lines), and the `if/else` dispatch collapses to "run the native client".

A user's own `-Source`/`-ApiKey` still wins, unchanged.

## 2. Credentials travel in the environment, not on disk

The temp `nuget.config` no longer carries a `<packageSourceCredentials>` block. The native client reads `NuGetPackageSourceCredentials_<source>` from its environment instead.

This removes the **persistence** risk — a signal that skips cleanup can no longer strand a token in a file — while keeping the secret out of `argv`, which is world-readable via `ps`.

It is **not** secrecy: the value is still readable by same-user processes (`ps -E`, `/proc/<pid>/environ`). The code comment says exactly that rather than overclaiming.

The config now also carries `defaultPushSource`, so the push finds its target without jf appending `-Source`/`--source` to the user's command line. Keeping the target in configuration rather than argv means the native client is invoked exactly as the user wrote it, and avoids branching on per-toolchain flag spelling.

## 3. Stamp `vcs.*` / `ci.*` on pushed artifacts

Push recorded only `build.name`, `build.number`, `build.timestamp` — so an artifact knew which build produced it, but not which commit, branch or pipeline run.

Routing through `civcs.MergeWithUserProps` (the helper Terraform and the other FlexPack managers already use) closes the gap. Verified live:

```
build.name = [fix4-verify]      vcs.branch   = [master]
build.number = [1]              vcs.revision = [394c1726...]
build.timestamp = [...]         vcs.url      = [https://github.com/...]
```

No-op outside a repository or when the properties are disabled.

## One ordering trap worth noting

`shouldPushViaNativeClient()` is computed **before** credential injection. Injection appends to `c.args`, and `hasNativeAuthOverride` treats a `--source` as a *user* override — so evaluating afterwards would make jf misread its own flag as user intent. The comment records why.

## Testing

- `TestShouldPushViaNativeClient` — 5 cases: both toolchains native, user auth override respected, non-push subcommands unaffected, missing server/repo falls through
- `TestCredentialEnvEntry` — format, source-name keying (a mismatch silently 401s), verbatim token passthrough
- `TestTempConfigCarriesNoSecret` — writes a real temp config with a known password and asserts the file contains **no** password, no `ClearTextPassword`, no `packageSourceCredentials`, while still declaring the source; then that cleanup removes the file and clears the credential
- `gofmt`, `go build ./...`, `go vet`, `golangci-lint` — clean, including `unused` after the deletions
- Verified end-to-end: `jf dotnet nuget push` and `jf nuget push` both upload via their native client with build-info and properties intact

> **Note:** `gosec` could not be run — `internal error: package "fmt" without types` under this Go toolchain. Unverified rather than passing.

## Tradeoff being accepted

The removed upload-service path provided checksum-optimised deploys (skip transfer when the blob exists), jf's retry logic, and JFrog proxy handling. Native push has none of these — it always uploads the bytes. For large or frequently re-pushed packages that is a real difference, and it is a deliberate choice in favour of not interfering with the native client.

## Merge order

Second of three RTECO-1782 PRs.

1. jfrog/build-info-go#422
2. **jfrog-cli-artifactory** ← this PR
3. jfrog-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NuGet restore operations triggered by `pack` and `publish` now apply supported temporary configuration and credentials.
  - Package collection includes nested target project or solution directories when no output directory is specified.
  - NuGet package pushes use the native `nuget` or `dotnet` client by default.
  - Artifactory sources, authentication, build information, and CI/version-control details are configured automatically.

- **Bug Fixes**
  - Temporary configuration files avoid storing secrets and are cleaned up after operations.
  - User-provided configuration files are detected and preserved.
  - Push commands correctly handle options placed after `--`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->