### PR TITLE
[PM Fixer] Add pnpm 12.x case to TestPnpmVersionValidation

### DIFF
--- a/artifactory/commands/pnpm/pnpm_test.go
+++ b/artifactory/commands/pnpm/pnpm_test.go
@@ -519,6 +519,10 @@ func TestPnpmVersionValidation(t *testing.T) {
 	pnpm11 := version.NewVersion("11.0.0")
 	assert.LessOrEqual(t, pnpm11.Compare(minSupportedPnpmVersion), 0, "pnpm 11.0.0 should meet minimum")
 
+	// pnpm 12.x should also meet minimum (no upper bound)
+	pnpm12 := version.NewVersion("12.2.1")
+	assert.LessOrEqual(t, pnpm12.Compare(minSupportedPnpmVersion), 0, "pnpm 12.2.1 should meet minimum")
+
 	// Exact minimum should pass
 	exactPnpm := version.NewVersion(minSupportedPnpmVersion)
 	assert.Equal(t, 0, exactPnpm.Compare(minSupportedPnpmVersion), "exact minimum should pass")


### PR DESCRIPTION
## Summary
`TestPnpmVersionValidation` already asserts pnpm 10.x and 11.x meet `minSupportedPnpmVersion`'s floor, explicitly documenting "no upper bound" for the 11.x case. pnpm 12.x is now the actual latest tested version (jfrog/jfrog-cli#3692 fixed a real pnpm 12 compatibility bug), so this extends the same explicit pattern to 12.x.

## Fix
Added a `pnpm12 := version.NewVersion("12.2.1")` case to `TestPnpmVersionValidation`, mirroring the existing pnpm10/pnpm11 cases exactly.

## Compatibility impact
Test-only change. No production code touched, no exported symbols changed.

## Test plan
- `go test ./artifactory/commands/pnpm/... -run TestPnpmVersionValidation -v` — passes
- `go test ./artifactory/commands/pnpm/...` (full package) — passes
- `gofmt -l`, `go vet ./...`, `go build ./...` — all clean

---
_Opened by PM Compat Fixer follow-up, prompted by review of [jfrog/jfrog-cli#3692](https://github.com/jfrog/jfrog-cli/pull/3692)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that pnpm version 12.2.1 meets the minimum supported version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->