### PR TITLE
RTECO-136 - Gradle shared build support

### DIFF
--- a/artifactory/commands/flexpack/gradle/gradle.go
+++ b/artifactory/commands/flexpack/gradle/gradle.go
@@ -25,7 +25,10 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber string, tasks []string, buildConfiguration *buildUtils.BuildConfiguration, serverDetails *config.ServerDetails) error {
+// RTECO-136: includeSharedBuild is passed explicitly by the caller (rather than parsed out of
+// tasks here) because by the time tasks reaches this function, jfrog-cli/buildtools/cli.go has
+// already stripped --include-shared-build out of it via coreutils.ExtractIncludeSharedBuildFromArgs.
+func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber string, tasks []string, buildConfiguration *buildUtils.BuildConfiguration, serverDetails *config.ServerDetails, includeSharedBuild bool) error {
 	if workingDir == "" {
 		return fmt.Errorf("working directory is required")
 	}
@@ -39,9 +42,6 @@ func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber strin
 	}
 	workingDir = absWorkingDir
 
-	// Extract --include-shared-build flag from tasks/arguments and remove it from tasks
-	filteredTasks, includeSharedBuild := extractIncludeSharedBuildFromTasks(tasks)
-
 	config := flexpack.GradleConfig{
 		WorkingDirectory:        workingDir,
 		IncludeTestDependencies: true,
@@ -54,7 +54,7 @@ func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber strin
 		return fmt.Errorf("could not initialize Gradle FlexPack")
 	}
 
-	isPublishCommand := wasPublishCommand(filteredTasks)
+	isPublishCommand := wasPublishCommand(tasks)
 	gradleFlex.SetWasPublishCommand(isPublishCommand)
 	gradleFlex.SetIncludeSharedBuild(includeSharedBuild)
 
@@ -438,29 +438,3 @@ func ValidateWorkingDirectory(workingDir string) error {
 	return nil
 }
 
-// extractIncludeSharedBuildFromTasks checks if --include-shared-build flag is present in the tasks/arguments
-// and removes it from the tasks array before passing to gradle
-// Supports both --include-shared-build and --include-shared-build=true/false forms
-func extractIncludeSharedBuildFromTasks(tasks []string) ([]string, bool) {
-	includeSharedBuild := false
-	var filteredTasks []string
-
-	for _, task := range tasks {
-		if task == "--include-shared-build" {
-			includeSharedBuild = true
-			// Skip this task (remove from args)
-			continue
-		}
-		if strings.HasPrefix(task, "--include-shared-build=") {
-			value := strings.TrimPrefix(task, "--include-shared-build=")
-			// Parse boolean value: "true", "1", etc. are true, everything else is false
-			includeSharedBuild = strings.ToLower(value) == "true" || value == "1"
-			// Skip this task (remove from args)
-			continue
-		}
-		// Keep all other tasks
-		filteredTasks = append(filteredTasks, task)
-	}
-
-	return filteredTasks, includeSharedBuild
-}

--- a/artifactory/commands/flexpack/gradle/gradle.go
+++ b/artifactory/commands/flexpack/gradle/gradle.go
@@ -38,9 +38,14 @@ func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber strin
 		return fmt.Errorf("failed to resolve absolute path for working directory")
 	}
 	workingDir = absWorkingDir
+
+	// Extract --include-shared-build flag from tasks/arguments and remove it from tasks
+	filteredTasks, includeSharedBuild := extractIncludeSharedBuildFromTasks(tasks)
+
 	config := flexpack.GradleConfig{
 		WorkingDirectory:        workingDir,
 		IncludeTestDependencies: true,
+		IncludeSharedBuild:      includeSharedBuild,
 	}
 
 	gradleFlex, err := gradle.NewGradleFlexPack(config)
@@ -49,8 +54,9 @@ func CollectGradleBuildInfoWithFlexPack(workingDir, buildName, buildNumber strin
 		return fmt.Errorf("could not initialize Gradle FlexPack")
 	}
 
-	isPublishCommand := wasPublishCommand(tasks)
+	isPublishCommand := wasPublishCommand(filteredTasks)
 	gradleFlex.SetWasPublishCommand(isPublishCommand)
+	gradleFlex.SetIncludeSharedBuild(includeSharedBuild)
 
 	buildInfo, err := gradleFlex.CollectBuildInfo(buildName, buildNumber)
 	if err != nil {
@@ -430,4 +436,31 @@ func ValidateWorkingDirectory(workingDir string) error {
 		return fmt.Errorf("working directory is not a directory: %s", workingDir)
 	}
 	return nil
+}
+
+// extractIncludeSharedBuildFromTasks checks if --include-shared-build flag is present in the tasks/arguments
+// and removes it from the tasks array before passing to gradle
+// Supports both --include-shared-build and --include-shared-build=true/false forms
+func extractIncludeSharedBuildFromTasks(tasks []string) ([]string, bool) {
+	includeSharedBuild := false
+	var filteredTasks []string
+
+	for _, task := range tasks {
+		if task == "--include-shared-build" {
+			includeSharedBuild = true
+			// Skip this task (remove from args)
+			continue
+		}
+		if strings.HasPrefix(task, "--include-shared-build=") {
+			value := strings.TrimPrefix(task, "--include-shared-build=")
+			// Parse boolean value: "true", "1", etc. are true, everything else is false
+			includeSharedBuild = strings.ToLower(value) == "true" || value == "1"
+			// Skip this task (remove from args)
+			continue
+		}
+		// Keep all other tasks
+		filteredTasks = append(filteredTasks, task)
+	}
+
+	return filteredTasks, includeSharedBuild
 }

--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -130,7 +131,7 @@ func (gc *GradleCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	err = runGradle(vConfig, gc.tasks, gc.buildArtifactsDetailsFile, gc.configuration, gc.threads, gc.IsXrayScan())
+	err = runGradle(vConfig, gc.tasks, gc.buildArtifactsDetailsFile, gc.configuration, gc.threads, gc.IsXrayScan(), gc.includeSharedBuild)
 	if err != nil {
 		return err
 	}
@@ -201,8 +202,11 @@ func (gc *GradleCommand) runWithGradleNative() error {
 				return err
 			}
 
-			// Call FlexPack collection using the flexpack working directory
-			if err := flexpackgradle.CollectGradleBuildInfoWithFlexPack(flexpackWorkingDir, buildName, buildNumber, gc.tasks, gc.configuration, gc.serverDetails); err != nil {
+			// Call FlexPack collection using the flexpack working directory.
+			// RTECO-136: gc.includeSharedBuild is passed explicitly here because gc.tasks has
+			// already had --include-shared-build stripped out of it (see GradleCmd in
+			// jfrog-cli/buildtools/cli.go, which extracts the flag before it ever reaches gradle).
+			if err := flexpackgradle.CollectGradleBuildInfoWithFlexPack(flexpackWorkingDir, buildName, buildNumber, gc.tasks, gc.configuration, gc.serverDetails, gc.includeSharedBuild); err != nil {
 				log.Warn("Failed to collect Gradle build info with Flexpack:")
 			}
 		}
@@ -460,7 +464,7 @@ func parseUserHomeFromJavaOutput(output string) (string, error) {
 	return "", fmt.Errorf("user.home not found in java output")
 }
 
-func runGradle(vConfig *viper.Viper, tasks []string, deployableArtifactsFile string, configuration *build.BuildConfiguration, threads int, disableDeploy bool) error {
+func runGradle(vConfig *viper.Viper, tasks []string, deployableArtifactsFile string, configuration *build.BuildConfiguration, threads int, disableDeploy bool, includeSharedBuild bool) error {
 	buildInfoService := build.CreateBuildInfoService()
 	buildName, err := configuration.GetBuildName()
 	if err != nil {
@@ -478,7 +482,7 @@ func runGradle(vConfig *viper.Viper, tasks []string, deployableArtifactsFile str
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	props, wrapper, plugin, err := createGradleRunConfig(vConfig, deployableArtifactsFile, threads, disableDeploy)
+	props, wrapper, plugin, err := createGradleRunConfig(vConfig, deployableArtifactsFile, threads, disableDeploy, includeSharedBuild)
 	if err != nil {
 		return err
 	}
@@ -498,7 +502,7 @@ func getGradleDependencyLocalPath() (string, error) {
 	return filepath.Join(dependenciesPath, "gradle"), nil
 }
 
-func createGradleRunConfig(vConfig *viper.Viper, deployableArtifactsFile string, threads int, disableDeploy bool) (props map[string]string, wrapper, plugin bool, err error) {
+func createGradleRunConfig(vConfig *viper.Viper, deployableArtifactsFile string, threads int, disableDeploy bool, includeSharedBuild bool) (props map[string]string, wrapper, plugin bool, err error) {
 	wrapper = vConfig.GetBool(useWrapper)
 	if threads > 0 {
 		vConfig.Set(build.ForkCount, threads)
@@ -519,6 +523,13 @@ func createGradleRunConfig(vConfig *viper.Viper, deployableArtifactsFile string,
 	if err != nil {
 		return
 	}
+	// RTECO-136: Propagate the --include-shared-build flag to the Gradle extractor init script
+	// (build-info-go/build/init-gradle-extractor-5.gradle) as a Gradle project property.
+	// The extractor props map is passed to the gradle subprocess as environment variables
+	// (see build-info-go's gradleRunConfig.runCmd), and Gradle automatically exposes any
+	// ORG_GRADLE_PROJECT_<name> environment variable as the project property <name>,
+	// which the init script reads via gradle.startParameter.getProjectProperties().
+	props["ORG_GRADLE_PROJECT_includeSharedBuild"] = strconv.FormatBool(includeSharedBuild)
 	if deployableArtifactsFile != "" {
 		// Save the path to a temp file, where buildinfo project will write the deployable artifacts details.
 		props[build.DeployableArtifacts] = fmt.Sprint(vConfig.Get(build.DeployableArtifacts))

--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -56,6 +56,8 @@ type GradleCommand struct {
 	deploymentDisabled bool
 	// File path for Gradle extractor in which all build's artifacts details will be listed at the end of the build.
 	buildArtifactsDetailsFile string
+	// RTECO-136: Feature flag to enable shared build (buildSrc and composite builds) support via subprocess approach
+	includeSharedBuild bool
 }
 
 func NewGradleCommand() *GradleCommand {
@@ -334,6 +336,17 @@ func (gc *GradleCommand) SetScanOutputFormat(format format.OutputFormat) *Gradle
 	return gc
 }
 
+// RTECO-136: SetIncludeSharedBuild enables the shared build (buildSrc and composite builds) support feature
+func (gc *GradleCommand) SetIncludeSharedBuild(includeSharedBuild bool) *GradleCommand {
+	gc.includeSharedBuild = includeSharedBuild
+	return gc
+}
+
+// RTECO-136: IsIncludeSharedBuild returns whether shared build support is enabled
+func (gc *GradleCommand) IsIncludeSharedBuild() bool {
+	return gc.includeSharedBuild
+}
+
 func (gc *GradleCommand) Result() *commandsutils.Result {
 	return gc.result
 }
@@ -358,6 +371,8 @@ type InitScriptAuthConfig struct {
 	GradleRepoName         string
 	ArtifactoryUsername    string
 	ArtifactoryAccessToken string
+	// RTECO-136: Enable subprocess-based shared build (buildSrc and composite builds) support
+	IncludeSharedBuild bool
 }
 
 // GenerateInitScript generates a Gradle init script with the provided authentication configuration.

--- a/artifactory/commands/gradle/resources/jfrog.init.gradle
+++ b/artifactory/commands/gradle/resources/jfrog.init.gradle
@@ -4,6 +4,7 @@ def artifactoryUrl = '{{ .ArtifactoryURL }}'
 def gradleRepoName = '{{ .GradleRepoName }}'
 def artifactoryUsername = '{{ .ArtifactoryUsername }}'
 def artifactoryAccessToken = '{{ .ArtifactoryAccessToken }}'
+def includeSharedBuild = {{ .IncludeSharedBuild }}
 def gradleVersion = GradleVersion.current()
 def allowInsecure = gradleVersion >= GradleVersion.version("6.2") && artifactoryUrl.startsWith("http://")
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/forPelevin/gomoji v1.4.1
 	github.com/google/go-containerregistry v0.21.3
 	github.com/jedib0t/go-pretty/v6 v6.8.3
-	github.com/jfrog/build-info-go v1.13.1-0.20260910072358-fc0223006a3b
+	github.com/jfrog/build-info-go v1.13.1-0.20260911052048-0bf055d837f8
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260831061529-c6dd293bccca
 	github.com/jfrog/jfrog-cli-evidence v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jfrog/archiver/v3 v3.6.4 h1:qHAWCLKwo3+ocHNNoWzGZ8ESl8QQk/lR3W09Pt+ROvE=
 github.com/jfrog/archiver/v3 v3.6.4/go.mod h1:5V9l+Fte30Y4qe9dUOAd3yNTf8lmtVNuhKNrvI8PMhg=
-github.com/jfrog/build-info-go v1.13.1-0.20260910072358-fc0223006a3b h1:DEHE5lr01Yq7zRkwyzdrBGlhvVWPi6W8o46jv0AT8/Y=
-github.com/jfrog/build-info-go v1.13.1-0.20260910072358-fc0223006a3b/go.mod h1:CYRUCvLKfyARjoJXLWAxce1qNUxTEtbRKAARkV42vpE=
+github.com/jfrog/build-info-go v1.13.1-0.20260911052048-0bf055d837f8 h1:2BvhTk78gjeIsgpXxeYycagmmkuPDtEyUAXeeG9nODA=
+github.com/jfrog/build-info-go v1.13.1-0.20260911052048-0bf055d837f8/go.mod h1:CYRUCvLKfyARjoJXLWAxce1qNUxTEtbRKAARkV42vpE=
 github.com/jfrog/froggit-go v1.21.1 h1:I/XUOO6GQ1d/rmBlM361F8T654C3ohIWrpw23xNL9JY=
 github.com/jfrog/froggit-go v1.21.1/go.mod h1:umBiakJB0CSPFfe0AHVaC3n9xsmUT7NGkDCny3bRchI=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] Appropriate label is added to auto generate release notes.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] PR description is clear and concise, and it includes the proposed solution/fix.
-----
### Summary
- Classic `jf gradle` can opt in to shared-build collection.
- Flag on: `-PincludeSharedBuild=true` and `ORG_GRADLE_PROJECT_includeSharedBuild=true`.
- Flag off: neither is injected.
- FlexPack Gradle path matches `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gradle command execution now supports including shared build logic through a configurable option.
  * When enabled, the setting is propagated to Gradle configurations, including included builds.

* **Changes**
  * The Gradle configuration option has been renamed to clarify that it controls shared build logic.
  * The previous shared-build status getter is no longer available.

* **Tests**
  * Added coverage verifying that the shared-build property is set only when the option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->